### PR TITLE
vnl bug for big matrices

### DIFF
--- a/Run/source/ITKParticleSystem/itkParticleEnsembleEntropyFunction.txx
+++ b/Run/source/ITKParticleSystem/itkParticleEnsembleEntropyFunction.txx
@@ -109,7 +109,7 @@ ParticleEnsembleEntropyFunction<VDimension>
     if (this->m_UseMeanEnergy)
     {
         pinvMat.set_identity();
-        m_InverseCovMatrix->set_identity();
+        m_InverseCovMatrix->clear(); //set_identity();
     }
     else
     {
@@ -206,7 +206,12 @@ ParticleEnsembleEntropyFunction<VDimension>
     Xi(2,0) = m_ShapeMatrix->operator()(k+2, d/DomainsPerShape) - m_points_mean->get(k+2, 0);
 
 
-    vnl_matrix_type tmp1 = m_InverseCovMatrix->extract(3,3,k,k);
+    vnl_matrix_type tmp1(3, 3, 0.0);
+
+    if (this->m_UseMeanEnergy)
+        tmp1.set_identity();
+    else
+        tmp1 = m_InverseCovMatrix->extract(3,3,k,k);
 
     vnl_matrix_type tmp = Xi.transpose()*tmp1;
 

--- a/Run/source/ITKParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
+++ b/Run/source/ITKParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
@@ -64,7 +64,7 @@ ParticleMeshBasedGeneralEntropyGradientFunction<VDimension>
     if (this->m_UseMeanEnergy)
     {
         pinvMat.set_identity();
-        m_InverseCovMatrix->set_identity();
+        m_InverseCovMatrix->clear(); //set_identity();
     }
     else
     {
@@ -247,7 +247,12 @@ ParticleMeshBasedGeneralEntropyGradientFunction<VDimension>
         num += num1 * system->GetNumberOfParticles(i);
     }
 
-    vnl_matrix_type tmp1 = m_InverseCovMatrix->extract(sz_Yidx, sz_Yidx, num, num);
+    vnl_matrix_type tmp1(sz_Yidx, sz_Yidx, 0.0);
+    
+    if (this->m_UseMeanEnergy)
+        tmp1.set_identity();
+    else
+        tmp1 = m_InverseCovMatrix->extract(sz_Yidx, sz_Yidx, num, num);
 
     vnl_matrix_type Y_dom_idx(sz_Yidx, 1, 0.0);
 


### PR DESCRIPTION
removed the construction of inverse covariance matrix as a big identity matrix num_points*3 x num_points*3 for mean energy-based updates