### PR TITLE
Disable ITK5 dynamic multithreading for MapFilter and ReduceFilter.

### DIFF
--- a/ExternalLibs/trimesh2/include/MapFilter.h
+++ b/ExternalLibs/trimesh2/include/MapFilter.h
@@ -29,7 +29,8 @@ public:
   typedef TFunctor FType;
 
   itkNewMacro(Self);
-  itkTypeMacro(MeanFilter,  ImageToImageFilter);
+  itkTypeMacro(MapFilter, ImageToImageFilter);
+
 
   void SetFunctor(FType * f) { m_functor = f; }
   const FType * GetFunctor() const { return m_functor; }
@@ -37,6 +38,7 @@ public:
   void SetRequestedRegion( const OutRegion & outRegion ){ m_region = outRegion; }
 
 protected:
+  MapFilter();
   virtual void AllocateOutputs();
   virtual void ThreadedGenerateData(const OutRegion & outputRegionForThread,
                                     itk::ThreadIdType threadId);

--- a/ExternalLibs/trimesh2/include/MapFilter.hxx
+++ b/ExternalLibs/trimesh2/include/MapFilter.hxx
@@ -5,6 +5,15 @@
 #ifndef __MapFilter_HXX
 #define __MapFilter_HXX
 
+// constructor
+template<class TFunctor,class TInput,class TOutput>
+MapFilter<TFunctor,TInput,TOutput>::MapFilter()
+{
+  // disable dynamic multithreading (ITKv5)
+  this->DynamicMultiThreadingOff();
+}
+
+
 template< class TFunctor,
           class TInput,
           class TOutput

--- a/ExternalLibs/trimesh2/include/ReduceFilter.h
+++ b/ExternalLibs/trimesh2/include/ReduceFilter.h
@@ -28,7 +28,7 @@ public:
   typedef TFunctor FType;
 
   itkNewMacro(Self);
-  itkTypeMacro(MeanFilter,  ImageToImageFilter);
+  itkTypeMacro(ReduceFilter, ImageToImageFilter);
 
   void SetFunctor(FType * f) { m_functor = f; }
   const FType * GetFunctor() const { return m_functor; }
@@ -38,6 +38,8 @@ public:
   OutType & GetResult() { return m_result; }
 
 protected:
+  ReduceFilter();
+
   virtual void BeforeThreadedGenerateData();
   virtual void AllocateOutputs();
   virtual void ThreadedGenerateData(const InRegion & outputRegionForThread,

--- a/ExternalLibs/trimesh2/include/ReduceFilter.hxx
+++ b/ExternalLibs/trimesh2/include/ReduceFilter.hxx
@@ -5,6 +5,15 @@
 #ifndef __ReduceFilter_HXX
 #define __ReduceFilter_HXX
 
+// constructor
+template<class TFunctor,class TInput,class TOutput>
+ReduceFilter<TFunctor,TInput,TOutput>::ReduceFilter()
+{
+  // disable dynamic multithreading (ITKv5)
+  this->DynamicMultiThreadingOff();
+}
+
+
 template< class TFunctor,
           class TInput,
           class TOutput


### PR DESCRIPTION
Also fix ITK names.

This should fix the crash in GenerateFidsFilesFromMeshes (issue #243)