### PR TITLE
fix conda_installs, disable (broken, time-consuming) make install by default, set default build type, and improve build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -9,6 +9,8 @@ _coming soon:_ instructions for user installation without needing to build Shape
 First, clone the ShapeWorks source, (see [GettingStarted.md](GettingStarted.md#source-and-branches) for more details).  
 `$ git clone https://github.com/SCIInstitute/ShapeWorks`  
 <br>If you want to build a branch other than master, check that branch out next:  
+`$ git checkout <branchname>`
+<br>If you want to create a new branch based off of the current branch:  
 `$ git checkout -b <branchname>`
 
 ### Install dependencies (OSX/Linux)

--- a/CMake/DefaultBuildType.cmake
+++ b/CMake/DefaultBuildType.cmake
@@ -1,0 +1,16 @@
+# Set a default build type if none was specified
+
+set(default_build_type "Release")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set(default_build_type "Debug")
+endif()
+ 
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build (Debug Release MinSizeRel RelWithDebInfo)." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@ endif()
 message(STATUS "SHAPEWORKS_GUI: ${SHAPEWORKS_GUI}")
 
 set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install" CACHE STRING "Install path prefix, prepended onto install directories.")
-set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the build type, options are: None Debug Release RelWithDebInfo MinSizeRel")
+
+include(DefaultBuildType)
 set(SHAPEWORKS_EXTERNALS_CMAKE_BUILD_TYPE Release CACHE STRING "Build type for external libraries (default Release)")
 mark_as_advanced(SHAPEWORKS_EXTERNALS_CMAKE_BUILD_TYPE)
 
@@ -53,6 +54,7 @@ if (SHAPEWORKS_SUPERBUILD)
     DEPENDS ${ShapeWorks_DEPENDENCIES}
     DOWNLOAD_COMMAND ""
     UPDATE_COMMAND ""
+    INSTALL_COMMAND ""
     SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}"
     PREFIX shapeworks
     BUILD_ALWAYS TRUE
@@ -201,6 +203,7 @@ else()
 
   add_subdirectory(ExternalLibs)    # TODO: cmake externalproject_add should be used for libs in this directory
   add_subdirectory(Libs)
+  #add_subdirectory(Applications)   # coming soon...
 
   include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/conda_installs.sh
+++ b/conda_installs.sh
@@ -36,8 +36,9 @@ eval "$(conda shell.bash hook)"
 conda activate shapeworks
 
 #install shapeworks deps
+conda install --yes -c anaconda pip # needed in sub-environments or the base env's pip will silently install to base
 conda install --yes -c anaconda geotiff libxrandr-devel-cos6-x86_64 libxinerama-devel-cos6-x86_64 libxcursor-devel-cos6-x86_64 libxi-devel-cos6-x86_64
-conda install --yes -c conda-forge cmake xorg-libx11 libuuid xorg-libsm 
+conda install --yes -c conda-forge ncurses cmake xorg-libx11 libuuid xorg-libsm 
 conda install --yes -c anaconda numpy
 conda install --yes -c conda-forge colorama
 conda install --yes -c https://conda.anaconda.org/simpleitk SimpleITK
@@ -45,8 +46,6 @@ conda install --yes -c conda-forge requests
 pip install --upgrade pip
 pip install termcolor
 pip install matplotlib
-
-# install the local GirderConnector code as a package
-pip install -e Python/DatasetUtilsPackage
+pip install -e Python/DatasetUtilsPackage # install the local GirderConnector code as a package
 
 conda info


### PR DESCRIPTION
… polluted by pip installs; install ncurses to ensure ccmake works in this environment (broken due to version associated with python 3.5); add default build type (Debug if using a git clone, Release otherwise, and neither when generator allows build type to be selected); don't make install since it is currently broken, takes forever to do it for Studio, and isn't needed for development; clarify branch checkout vs creation in BUILD.md instructions (fix issue #261)