### PR TITLE
Fix LPI (and other) oriented volumes in Studio

### DIFF
--- a/Studio/src/Application/Data/Mesh.cc
+++ b/Studio/src/Application/Data/Mesh.cc
@@ -10,6 +10,7 @@
 
 #include <itkImageRegionIteratorWithIndex.h>
 #include <itkVTKImageExport.h>
+#include <itkOrientImageFilter.h>
 
 #include <Data/Mesh.h>
 #include <Data/ItkToVtk.h>
@@ -61,6 +62,16 @@ ImageType::Pointer Mesh::create_from_file(std::string filename, double iso_value
   reader->SetFileName(filename);
   reader->Update();
   ImageType::Pointer image = reader->GetOutput();
+
+  // set orientation to RAI
+  itk::OrientImageFilter<ImageType,ImageType>::Pointer orienter =
+    itk::OrientImageFilter<ImageType,ImageType>::New();
+  orienter->UseImageDirectionOn();
+  orienter->SetDesiredCoordinateOrientation(itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI);
+  orienter->SetInput(image);
+  orienter->Update();
+  image = orienter->GetOutput();
+
   this->create_from_image(image, iso_value);
   return image;
 }


### PR DESCRIPTION
The fix is very easy for Studio since we have a single point of import we can just convert to RAI.