### PR TITLE
Fix errors in ellipsoid example

### DIFF
--- a/Examples/Python/OptimizeUtils.py
+++ b/Examples/Python/OptimizeUtils.py
@@ -161,7 +161,8 @@ def runShapeWorksOptimize_SingleScale(parentDir, inDataFiles, parameterDictionar
     outPointsWorld = []
     outPointsLocal = []
     for i in range(len(inDataFiles)):
-        inpath = os.path.dirname(inDataFiles[j]) + '/'
+        inname = inDataFiles[i].replace('\\','/')
+        inpath = os.path.dirname(inDataFiles[i]) + '/'
         outname = inname.replace(inpath, outDir)
         wrdname = outname.replace('.nrrd', '_world.particles')
         lclname = outname.replace('.nrrd', '_local.particles')
@@ -199,7 +200,7 @@ def runShapeWorksOptimize_MultiScale(parentDir, inDataFiles, parameterDictionary
     outPointsLocal = []
     for i in range(len(inDataFiles)):
         inname = inDataFiles[i].replace('\\','/')
-        inpath = os.path.dirname(inDataFiles[j]) + '/'
+        inpath = os.path.dirname(inDataFiles[i]) + '/'
         outname = inname.replace(inpath, outDir)
         wrdname = outname.replace('.nrrd', '_world.particles')
         lclname = outname.replace('.nrrd', '_local.particles')

--- a/Examples/Python/README.md
+++ b/Examples/Python/README.md
@@ -1,4 +1,4 @@
 How to run the tests in this folder:
 
-`python ellipsoidMain.py --use_single_scale 1`
+`python ellipsoidMain.py --use_single_scale 1 <path to ShapeWorks binaries>`
 


### PR DESCRIPTION
Small changes for missing variables in Python script.

Probably unrelated here, but the Python script crashed at a later step because ShapeWorks Studio was missing: the default option in CMake is to not build Studio.