### PR TITLE
Fix mac package

### DIFF
--- a/Studio/src/Application/CMakeLists.txt
+++ b/Studio/src/Application/CMakeLists.txt
@@ -81,6 +81,8 @@ INCLUDE_DIRECTORIES( ${CMAKE_CURRENT_SOURCE_DIR} )
 IF(APPLE)
   # set how it shows up in the Info.plist file
   SET(MACOSX_BUNDLE_ICON_FILE ShapeWorksStudio.icns)
+  # set the bundle identifier
+  SET(MACOSX_BUNDLE_GUI_IDENTIFIER edu.utah.sci.shapeworks.studio)
   # set where in the bundle to put the icns file
   SET_SOURCE_FILES_PROPERTIES(${CMAKE_CURRENT_SOURCE_DIR}/Resources/ShapeWorksStudio.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
   # include the icns file in the target

--- a/Studio/src/Application/Resources/Info.plist.in
+++ b/Studio/src/Application/Resources/Info.plist.in
@@ -36,5 +36,7 @@
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
+	<key>BundleIsRelocatable</key>
+	<string>False</string>
 </dict>
 </plist>


### PR DESCRIPTION
This fixes the Mac bundle for Studio in a couple of ways.  First, we were missing the bundle identifier, and second, this sets the bundle as non-relocatable.  More here:

https://scriptingosx.com/2017/05/relocatable-package-installers-and-quickpkg-update/

I believe this was causing the problem we were seeing on a Catalina system, but I don't think it had anything to do with Catalina after all.  What I believe happened is that it updated some other app bundles elsewhere on the system (possibly another copy of Studio) instead. 