### PR TITLE
Update build instructions

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -32,7 +32,7 @@ First, clone the ShapeWorks source, (see [GettingStarted.md](GettingStarted.md#s
 <br>If you want to create a new branch based off of the current branch:  
 `$ git checkout -b <branchname>`
 
-### Install dependencies (OSX/Linux)
+### Install dependencies
 
 We recommend using anaconda to create a sandbox environment. While optional, using a conda environment allows multiple builds with different dependencies. You can install Anaconda and the [ShapeWorks dependencies](deps.txt) using:  
 `source ./conda_installs.sh`  
@@ -45,18 +45,25 @@ Download and install the latest version for your OS, selecting the LGPL (free) l
 [[OSX]](https://download.qt.io/archive/qt/5.13/5.13.0/qt-opensource-mac-x64-5.13.0.dmg) [[Linux]](https://download.qt.io/archive/qt/5.13/5.13.0/qt-opensource-linux-x64-5.13.0.run) [[Windows]](https://download.qt.io/archive/qt/5.13/5.13.0/qt-opensource-windows-x86-5.13.0.exe)  
 <br>Ensure the bin directory for this Qt is in your path:  
 **OSX/Linux:** `$ export PATH=<path to your installation>/bin:$PATH`  
-**Windows:** `c:\shapeworks> set PATH=<path to your installation>\bin:%PATH%`     #todo: double check this
+On Windows, ensure the bin directory which contains the file "qmake.exe" is in your path:  
+**Windows:** `c:\shapeworks> set PATH=<path to your installation>\bin:%PATH%`     #todo: double check this  
+**Windows git bash:** `export PATH=$PATH:"<path to your installation>/winrt_x64_msvc2017/bin"`  
 
-### Install dependencies (Windows)
-
-Install anaconda and Qt5 as above.
 
 ### Superbuild
 
 After the above dependencies installed via conda, ShapeWorks uses VXL, ITK, and VTK.  You can either provide your own (note: ITK must be built with VTK support), or use the provided superbuild.sh script to build all three (and optionally ShapeWorks itself).  On windows, please use an msys shell (e.g. git bash) and run the same superbuild.sh to build VXL, VTK, and ITK.
 
 The **superbuild.sh** script accepts various options, such as specifying the locations of dependencies and whether or not to build the GUI. It can be used to build everything, or just the dependencies.  
-Use `./superbuild.sh --help` for more details.
+Use `./superbuild.sh --help` for more details.  
+
+If you get an error that looks like this:
+```
+which: no qmake in (...)
+## For GUI applications, please make sure at least version $QT_MIN_VER of Qt5 is installed and that its qmake is in the path.
+## Download Qt5 from: https://download.qt.io/archive/qt/
+```
+Make sure you added Qt to your path as explained in the **Install dependencies** step.
 
 ### Configuration
 The following instructions describe how to configure and build ShapeWorks independently if the superbuild.sh script was only used to build dependencies.  

--- a/BUILD.md
+++ b/BUILD.md
@@ -39,7 +39,7 @@ We recommend using anaconda to create a sandbox environment. Using a conda envir
 `source ./conda_installs.sh`  
 <br>Accept the cryptography license terms and default installation path.  
 <br>These dependencies can be manually installed if preferred. [Here is the list](deps.txt).  
-Note that conda may install a different version of Qt that is too old to use with ShapeWorks. Be sure to set the `CMAKE_PREFIX_PATH` as described below in [Configuration](#Configuration).
+Note that conda may install a different version of Qt that is too old to use with ShapeWorks. Be sure to set the `CMAKE_PREFIX_PATH` as described below in [Configuration Options](#Options).
 
 Install **Qt5**, required by ShapeWorks gui applications (at least version 5.10).  
 Download and install the latest version for your OS, selecting the LGPL (free) license.  
@@ -52,16 +52,15 @@ Download and install the latest version for your OS, selecting the LGPL (free) l
 
 #### CMake
 Download and install [[CMake]](https://cmake.org/)  
-
-#### Compiler
 Download and install [[Visual Studio]](https://visualstudio.microsoft.com/) or another CMake-compatible compiler  
 
 #### Anaconda
 Download and install [[Anaconda]](https://www.anaconda.com/)  
 It is recommended **not** to add Anaconda to your PATH and **not** to register Anaconda as your default Python.  
+Using the *Anaconda Prompt*, run `conda_installs.sh` on OSX or Linux and run `conda_installs.bat` on Windows
 
 #### Qt5
-Download and install the latest version of [[Qt5]](https://download.qt.io/archive/qt/)  
+Download and install the latest version of [[Qt5]](https://download.qt.io/archive/qt/) (at least version 5.10 required)  
 After installing Qt5, add the directory containing `qmake.exe` to your PATH  
 Example qmake directory: `D:\Qt\5.14.0\winrt_x64_msvc2017\bin`  
 
@@ -97,7 +96,7 @@ CMake GUI to see and change any of the options:
 Required:  
 ```
   -G<generator> (For example: -GXCode or -G"Visual Studio 16 2019" -Ax64)
-  -DCMAKE_PREFIX_PATH=<qt cmake path>  (This is different from qmake path in the [Install dependencies/Qt5])#Qt5) step
+  -DCMAKE_PREFIX_PATH=<qt cmake path>  (This is different from qmake path in the Install Qt5 step
   -DVXL_DIR=<vxl cmake path>  (contains VXLConfig.cmake)
   -DVTK_DIR=<vtk cmake path>  (contains VTKConfig.cmake)
   -DITK_DIR=<itk cmake path>  (contains ITKConfig.cmake)
@@ -117,6 +116,11 @@ Optional:
     - (maybe need to build using `cmake --build . -j 16` in order to pass parallel flags to dependent projects (e.g., vtk))  
 - XCode project: `open ShapeWorks.xcodeproj` and build from there  
 - Microsoft Visual Studio: Open ShapeWorks.sln and build from there  
+
+#### Before running Example Python scripts
+Add the ShapeWorks and dependency binaries to the path:  
+- *OSX/Linux:* `$ export PATH=/path/to/shapeworks/build/bin;/path/to/dependencies/bin:$PATH`  
+- *Windows*: `> set PATH=\path\to\shapeworks\build\bin;\path\to\dependency\bin;%PATH%`  
 
 #### Examples
 *OSX* example that builds dependencies separately, then generates an XCode project for ShapeWorks:  

--- a/BUILD.md
+++ b/BUILD.md
@@ -14,22 +14,8 @@ To clone the ShapeWorks source:
 `$ git clone https://github.com/SCIInstitute/ShapeWorks`  
 See [GettingStarted.md](GettingStarted.md#source-and-branches) for more details on git commands.  
 
-## Install dependencies (OSX/Linux)  
 
-We recommend using anaconda to create a sandbox environment. Using a conda environment allows multiple builds with different dependencies. You can install Anaconda and the [ShapeWorks dependencies](deps.txt) using:  
-`source ./conda_installs.sh`  
-<br>Accept the cryptography license terms and default installation path.  
-<br>These dependencies can be manually installed if preferred. [Here is the list](deps.txt).  
-Note that conda may install a different version of Qt that is too old to use with ShapeWorks. Be sure to set the `CMAKE_PREFIX_PATH` as described below in [Configuration Options](#Options).
-
-Install **Qt5**, required by ShapeWorks gui applications (at least version 5.10).  
-Download and install the latest version for your OS, selecting the LGPL (free) license.  
-[[OSX]](https://download.qt.io/archive/qt/5.13/5.13.0/qt-opensource-mac-x64-5.13.0.dmg) [[Linux]](https://download.qt.io/archive/qt/5.13/5.13.0/qt-opensource-linux-x64-5.13.0.run) [[Windows]](https://download.qt.io/archive/qt/5.13/5.13.0/qt-opensource-windows-x86-5.13.0.exe)  
-<br>Ensure the bin directory for this Qt is in your path:  
-**OSX/Linux:** `$ export PATH=<path to your installation>/bin:$PATH`  
-
-
-## Install dependencies (Windows)
+## Install dependencies
 
 ### CMake
 Download and install [[CMake]](https://cmake.org/)  
@@ -38,11 +24,13 @@ Download and install [[Visual Studio]](https://visualstudio.microsoft.com/) or a
 ### Anaconda
 Download and install [[Anaconda]](https://www.anaconda.com/)  
 It is recommended **not** to add Anaconda to your PATH and **not** to register Anaconda as your default Python.  
-Using the *Anaconda Prompt*, run `conda_installs.sh` on OSX or Linux and run `conda_installs.bat` on Windows
+Using the *Anaconda Prompt*, run `conda_installs.sh` on OSX or Linux and run `conda_installs.bat` on Windows  
+
+You can also install these [dependencies](deps.txt) manually if you prefer not to use Anaconda  
 
 ### Qt5  
 Download and install the latest version of [[Qt5]](https://download.qt.io/archive/qt/), selecting the LGPL (free) license. (at least version 5.10 required)  
-After installing Qt5, add the directory containing `qmake.exe` to your PATH  
+After installing Qt5, add the directory containing `qmake.exe` to your PATH. (See [Adding to PATH](GettingStarted.md#PATH-environment-variable) for help with this)  
 Example qmake directory: `D:\Qt\5.14.0\winrt_x64_msvc2017\bin`  
 
 ### VXL, VTK, and ITK
@@ -52,7 +40,7 @@ It is recommended to use `$ ./superbuild.sh --dependencies-only` to build VXL, V
 
 Use `$ ./superbuild.sh --help` for more details on the available superbuild options.  
 
-If you get an error that looks like this:  
+**If you get an error** that looks like this:  
 ```
 which: no qmake in (...)
 ## For GUI applications, please make sure at least version $QT_MIN_VER of Qt5 is installed and that its qmake is in the path.
@@ -61,6 +49,7 @@ which: no qmake in (...)
 Make sure you added Qt to your path as explained in the [Install dependencies/Qt5](#Qt5) step.  
 
 If you decide to build ITK yourself and you would like to use the ShapeWorks GUI applications, make sure you build it with VTK  
+
 
 ## Configure and Build  
 Make a build directory and use cmake to configure your build:  

--- a/BUILD.md
+++ b/BUILD.md
@@ -32,9 +32,10 @@ First, clone the ShapeWorks source, (see [GettingStarted.md](GettingStarted.md#s
 <br>If you want to create a new branch based off of the current branch:  
 `$ git checkout -b <branchname>`
 
-### Install dependencies
 
-We recommend using anaconda to create a sandbox environment. While optional, using a conda environment allows multiple builds with different dependencies. You can install Anaconda and the [ShapeWorks dependencies](deps.txt) using:  
+### Install dependencies (OSX/Linux)  
+
+We recommend using anaconda to create a sandbox environment. Using a conda environment allows multiple builds with different dependencies. You can install Anaconda and the [ShapeWorks dependencies](deps.txt) using:  
 `source ./conda_installs.sh`  
 <br>Accept the cryptography license terms and default installation path.  
 <br>These dependencies can be manually installed if preferred. [Here is the list](deps.txt).  
@@ -45,39 +46,53 @@ Download and install the latest version for your OS, selecting the LGPL (free) l
 [[OSX]](https://download.qt.io/archive/qt/5.13/5.13.0/qt-opensource-mac-x64-5.13.0.dmg) [[Linux]](https://download.qt.io/archive/qt/5.13/5.13.0/qt-opensource-linux-x64-5.13.0.run) [[Windows]](https://download.qt.io/archive/qt/5.13/5.13.0/qt-opensource-windows-x86-5.13.0.exe)  
 <br>Ensure the bin directory for this Qt is in your path:  
 **OSX/Linux:** `$ export PATH=<path to your installation>/bin:$PATH`  
-On Windows, ensure the bin directory which contains the file "qmake.exe" is in your path:  
-**Windows:** `c:\shapeworks> set PATH=<path to your installation>\bin:%PATH%`     #todo: double check this  
-**Windows git bash:** `export PATH=$PATH:"<path to your installation>/winrt_x64_msvc2017/bin"`  
 
 
-### Superbuild
+### Install dependencies (Windows)
 
-After the above dependencies installed via conda, ShapeWorks uses VXL, ITK, and VTK.  You can either provide your own (note: ITK must be built with VTK support), or use the provided superbuild.sh script to build all three (and optionally ShapeWorks itself).  On windows, please use an msys shell (e.g. git bash) and run the same superbuild.sh to build VXL, VTK, and ITK.
+#### CMake
+Download and install [[CMake]](https://cmake.org/)  
 
-The **superbuild.sh** script accepts various options, such as specifying the locations of dependencies and whether or not to build the GUI. It can be used to build everything, or just the dependencies.  
-Use `./superbuild.sh --help` for more details.  
+#### Compiler
+Download and install [[Visual Studio]](https://visualstudio.microsoft.com/) or another CMake-compatible compiler  
 
-If you get an error that looks like this:
+#### Anaconda
+Download and install [[Anaconda]](https://www.anaconda.com/) 
+
+#### Qt5
+Download and install the latest version of [[Qt5]](https://download.qt.io/archive/qt/)  
+After installing Qt5, add the directory containing 'qmake.exe' to your PATH  
+Example qmake directory: 'D:\Qt\5.14.0\winrt_x64_msvc2017\bin'
+
+#### VXL, VTK, and ITK
+These three dependencies can be installed using the **superbuild.sh** script.
+On Windows, use an msys shell (e.g. git bash) to run **superbuild.sh**.
+
+The **superbuild.sh** script accepts various options; use `./superbuild.sh --help` for more details.  
+
+If you get an error that looks like this:  
 ```
 which: no qmake in (...)
 ## For GUI applications, please make sure at least version $QT_MIN_VER of Qt5 is installed and that its qmake is in the path.
 ## Download Qt5 from: https://download.qt.io/archive/qt/
 ```
-Make sure you added Qt to your path as explained in the **Install dependencies** step.
+Make sure you added Qt to your path as explained in the [Install dependencies/Qt5](#Qt5) step.  
 
-### Configuration
-The following instructions describe how to configure and build ShapeWorks independently if the superbuild.sh script was only used to build dependencies.  
-Make a build directory and use cmake (or ccmake for a gui version) to configure your build:  
+
+### Configuration (OSX/Linux)  
+Make a build directory and use cmake to configure your build:  
 ```
 mkdir build
 cd build
-cmake <options> ..
+cmake <options> <base-shapeworks-directory>
 ```
-Note: using `ccmake` will present the user with a GUI that makes it easy to see and change any of the options.
+CMake GUI to see and change any of the options:
+- On OSX/Linux, you can use a GUI by running `ccmake` instead of `cmake`.  
+- On Windows, you can use the CMake application.
 
 Options include the following:
 ```
-  -G <generator> (e.g., -GXCode)
+  -G <generator> (For example: -GXCode or -G "Visual Studio 16 2019" -A x64)
   -DCMAKE_PREFIX_PATH=<lib Path(s)>   default: a ;-separated list of paths to Qt, vtk, ITK, etc.
                                                For Qt: it finds qmake in the system PATH; A prefix path must contain the lib/cmake directory.
   -DBuild_Studio=[OFF|ON]             default: OFF
@@ -93,12 +108,13 @@ Options include the following:
   -DVXL_DIR=<path to your own vxl>
 ```
 
+
 ### Build
 Execute build using your generated project file:  
 **Makefiles:** `make -j<num_procs>` where num_procs is the number of parallel processes, say 8.
 - maybe need to build using `cmake --build . -j 16` in order to pass parallel flags to dependent projects (e.g., vtk)
 **XCode project:** `open ShapeWorks.xcodeproj` and build from there  
-**Windows Visual Studio:** open it and build.  
+**Microsoft Visual Studio:** `open ShapeWorks.sln` and build  
 
 
 **Example (using OSX) that builds dependencies separately, then generates an XCode project for ShapeWorks:**  

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,14 +1,6 @@
-# ShapeWorks build and installation instructions
+# Instructions for building ShapeWorks from source
 
-## Downloadable installation
-
-Pre-built binary downloads are provided here:
-
-https://github.com/SCIInstitute/ShapeWorks/releases
-
-## Build from source
-
-### Clone source
+## Clone source
 
 ShapeWorks uses git-lfs to store image data for testing.  Please install and setup git lfs before cloning:
 
@@ -33,7 +25,7 @@ First, clone the ShapeWorks source, (see [GettingStarted.md](GettingStarted.md#s
 `$ git checkout -b <branchname>`
 
 
-### Install dependencies (OSX/Linux)  
+## Install dependencies (OSX/Linux)  
 
 We recommend using anaconda to create a sandbox environment. Using a conda environment allows multiple builds with different dependencies. You can install Anaconda and the [ShapeWorks dependencies](deps.txt) using:  
 `source ./conda_installs.sh`  
@@ -48,23 +40,23 @@ Download and install the latest version for your OS, selecting the LGPL (free) l
 **OSX/Linux:** `$ export PATH=<path to your installation>/bin:$PATH`  
 
 
-### Install dependencies (Windows)
+## Install dependencies (Windows)
 
-#### CMake
+### CMake
 Download and install [[CMake]](https://cmake.org/)  
 Download and install [[Visual Studio]](https://visualstudio.microsoft.com/) or another CMake-compatible compiler  
 
-#### Anaconda
+### Anaconda
 Download and install [[Anaconda]](https://www.anaconda.com/)  
 It is recommended **not** to add Anaconda to your PATH and **not** to register Anaconda as your default Python.  
 Using the *Anaconda Prompt*, run `conda_installs.sh` on OSX or Linux and run `conda_installs.bat` on Windows
 
-#### Qt5
+### Qt5
 Download and install the latest version of [[Qt5]](https://download.qt.io/archive/qt/) (at least version 5.10 required)  
 After installing Qt5, add the directory containing `qmake.exe` to your PATH  
 Example qmake directory: `D:\Qt\5.14.0\winrt_x64_msvc2017\bin`  
 
-#### VXL, VTK, and ITK
+### VXL, VTK, and ITK
 These three dependencies can be installed using the **superbuild.sh** script.  
 On Windows, use an msys shell (e.g. git bash) to do this.  
 It is recommended to use `$ ./superbuild.sh --dependencies-only` to build VXL, VTK, and ITK.  
@@ -81,7 +73,7 @@ Make sure you added Qt to your path as explained in the [Install dependencies/Qt
 
 If you decide to build ITK yourself and you would like to use the ShapeWorks GUI applications, make sure you build it with VTK  
 
-### Configure and Build  
+## Configure and Build  
 Make a build directory and use cmake to configure your build:  
 ```
 mkdir build
@@ -92,7 +84,7 @@ CMake GUI to see and change any of the options:
 - On OSX/Linux, you can use a GUI by running `ccmake` instead of `cmake`.  
 - On Windows, you can use the CMake application.  
 
-#### Options
+### Options
 Required:  
 ```
   -G<generator> (For example: -GXCode or -G"Visual Studio 16 2019" -Ax64)
@@ -111,18 +103,18 @@ Optional:
 ```
 **See [examples](#Examples) below for common values of the variables**  
 
-#### Building
+### Building
 - Makefiles: `make -j<num_procs>` where num_procs is the number of parallel processes, say 8.  
     - (maybe need to build using `cmake --build . -j 16` in order to pass parallel flags to dependent projects (e.g., vtk))  
 - XCode project: `open ShapeWorks.xcodeproj` and build from there  
 - Microsoft Visual Studio: Open ShapeWorks.sln and build from there  
 
-#### Before running Example Python scripts
+### Before running Example Python scripts
 Add the ShapeWorks and dependency binaries to the path:  
 - *OSX/Linux:* `$ export PATH=/path/to/shapeworks/build/bin;/path/to/dependencies/bin:$PATH`  
 - *Windows*: `> set PATH=\path\to\shapeworks\build\bin;\path\to\dependency\bin;%PATH%`  
 
-#### Examples
+### Examples
 *OSX* example that builds dependencies separately, then generates an XCode project for ShapeWorks:  
 ```
 $ ./superbuild.sh  --dependencies_only --build-dir=../dependencies --install-dir=../dependencies

--- a/BUILD.md
+++ b/BUILD.md
@@ -2,18 +2,13 @@
 
 ## Clone source
 
-ShapeWorks uses git-lfs to store image data for testing.  Please install and setup git lfs before cloning:
-
-git lfs install
-
-If this command fails, you probably need to install git-lfs:
-
-https://github.com/git-lfs/git-lfs/wiki/Installation
-
-If you have already cloned ShapeWorks before installing git-lfs, you can get the test image data using:
-
-git lfs fetch
-git lfs checkout
+ShapeWorks uses *git-lfs* to store image data for testing.  
+Please install and setup **[git-lfs](https://github.com/git-lfs/git-lfs/wiki/Installation)** before cloning.  
+If you have already cloned ShapeWorks before installing *git-lfs*, you can get the test image data using:  
+```
+$ git lfs fetch
+$ git lfs checkout
+```
 
 First, clone the ShapeWorks source, (see [GettingStarted.md](GettingStarted.md#source-and-branches) for more details).  
 `$ git clone https://github.com/SCIInstitute/ShapeWorks`  
@@ -23,7 +18,6 @@ First, clone the ShapeWorks source, (see [GettingStarted.md](GettingStarted.md#s
 `$ git branch -a`
 <br>If you want to create a new branch based off of the current branch:  
 `$ git checkout -b <branchname>`
-
 
 ## Install dependencies (OSX/Linux)  
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,4 +1,4 @@
-# Instructions for building ShapeWorks from source
+# Building ShapeWorks from source
 
 ## Clone source
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -10,14 +10,9 @@ $ git lfs fetch
 $ git lfs checkout
 ```
 
-First, clone the ShapeWorks source, (see [GettingStarted.md](GettingStarted.md#source-and-branches) for more details).  
+To clone the ShapeWorks source:  
 `$ git clone https://github.com/SCIInstitute/ShapeWorks`  
-<br>If you want to build a branch other than master, check that branch out next:  
-`$ git checkout <branchname>`
-<br>Available branches can be listed using:  
-`$ git branch -a`
-<br>If you want to create a new branch based off of the current branch:  
-`$ git checkout -b <branchname>`
+See [GettingStarted.md](GettingStarted.md#source-and-branches) for more details on git commands.  
 
 ## Install dependencies (OSX/Linux)  
 
@@ -45,8 +40,8 @@ Download and install [[Anaconda]](https://www.anaconda.com/)
 It is recommended **not** to add Anaconda to your PATH and **not** to register Anaconda as your default Python.  
 Using the *Anaconda Prompt*, run `conda_installs.sh` on OSX or Linux and run `conda_installs.bat` on Windows
 
-### Qt5
-Download and install the latest version of [[Qt5]](https://download.qt.io/archive/qt/) (at least version 5.10 required)  
+### Qt5  
+Download and install the latest version of [[Qt5]](https://download.qt.io/archive/qt/), selecting the LGPL (free) license. (at least version 5.10 required)  
 After installing Qt5, add the directory containing `qmake.exe` to your PATH  
 Example qmake directory: `D:\Qt\5.14.0\winrt_x64_msvc2017\bin`  
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -31,7 +31,8 @@ You can also install these [dependencies](deps.txt) manually if you prefer not t
 ### Qt5  
 Download and install the latest version of [[Qt5]](https://download.qt.io/archive/qt/), selecting the LGPL (free) license. (at least version 5.10 required)  
 After installing Qt5, add the directory containing `qmake.exe` to your PATH. (See [Adding to PATH](GettingStarted.md#PATH-environment-variable) for help with this)  
-Example qmake directory: `D:\Qt\5.14.0\winrt_x64_msvc2017\bin`  
+Example qmake directory Linux: `/opt/Qt5.14.0/5.14.0/gcc_64/bin`  
+Example qmake directory Windows: `D:\Qt\5.14.0\winrt_x64_msvc2017\bin`  
 
 ### VXL, VTK, and ITK
 These three dependencies can be installed using the **superbuild.sh** script.  
@@ -67,9 +68,9 @@ Required:
 ```
   -G<generator> (For example: -GXCode or -G"Visual Studio 16 2019" -Ax64)
   -DCMAKE_PREFIX_PATH=<qt cmake path>  (This is different from qmake path in the Install Qt5 step
-  -DVXL_DIR=<vxl cmake path>  (contains VXLConfig.cmake)
-  -DVTK_DIR=<vtk cmake path>  (contains VTKConfig.cmake)
-  -DITK_DIR=<itk cmake path>  (contains ITKConfig.cmake)
+  -DVXL_DIR=<vxl cmake path>           (contains VXLConfig.cmake)
+  -DVTK_DIR=<vtk cmake path>           (contains VTKConfig.cmake)
+  -DITK_DIR=<itk cmake path>           (contains ITKConfig.cmake)
 ```
 Optional:
 ```
@@ -107,5 +108,5 @@ open ShapeWorks.xcodeproj
 $ ./superbuild.sh  --dependencies_only --build-dir=../dependencies --install-dir=../dependencies
 mkdir build
 cd build
-cmake -G"Visual Studio 16 2019" -Ax64 -DCMAKE_PREFIX_PATH=D:/ProgramFiles/Qt5.14.0/5.14.0/msvc2017_64/lib/cmake -DVXL_DIR=dependencies/vxl/build -DVTK_DIR=dependencies/lib/cmake/vtk-8.2 -DITK_DIR=dependencies/lib/cmake/ITK-5.0 -DBuild_Post:BOOL=ON -DBuild_View2:BOOL=ON -DBuild_Studio:BOOL=ON ..
+cmake -G"Visual Studio 16 2019" -Ax64 -DCMAKE_PREFIX_PATH=D:/ProgramFiles/Qt5.14.0/5.14.0/msvc2017_64/lib/cmake -DVXL_DIR=../dependencies/vxl/build -DVTK_DIR=../dependencies/lib/cmake/vtk-8.2 -DITK_DIR=../dependencies/lib/cmake/ITK-5.0 -DBuild_Post:BOOL=ON -DBuild_View2:BOOL=ON -DBuild_Studio:BOOL=ON ..
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -57,18 +57,20 @@ Download and install [[CMake]](https://cmake.org/)
 Download and install [[Visual Studio]](https://visualstudio.microsoft.com/) or another CMake-compatible compiler  
 
 #### Anaconda
-Download and install [[Anaconda]](https://www.anaconda.com/) 
+Download and install [[Anaconda]](https://www.anaconda.com/)  
+It is recommended **not** to add Anaconda to your PATH and **not** to register Anaconda as your default Python.  
 
 #### Qt5
 Download and install the latest version of [[Qt5]](https://download.qt.io/archive/qt/)  
-After installing Qt5, add the directory containing 'qmake.exe' to your PATH  
-Example qmake directory: 'D:\Qt\5.14.0\winrt_x64_msvc2017\bin'
+After installing Qt5, add the directory containing `qmake.exe` to your PATH  
+Example qmake directory: `D:\Qt\5.14.0\winrt_x64_msvc2017\bin`  
 
 #### VXL, VTK, and ITK
-These three dependencies can be installed using the **superbuild.sh** script.
-On Windows, use an msys shell (e.g. git bash) to run **superbuild.sh**.
+These three dependencies can be installed using the **superbuild.sh** script.  
+On Windows, use an msys shell (e.g. git bash) to do this.  
+It is recommended to use `$ ./superbuild.sh --dependencies-only` to build VXL, VTK, and ITK.  
 
-The **superbuild.sh** script accepts various options; use `./superbuild.sh --help` for more details.  
+Use `$ ./superbuild.sh --help` for more details on the available superbuild options.  
 
 If you get an error that looks like this:  
 ```
@@ -78,50 +80,58 @@ which: no qmake in (...)
 ```
 Make sure you added Qt to your path as explained in the [Install dependencies/Qt5](#Qt5) step.  
 
+If you decide to build ITK yourself and you would like to use the ShapeWorks GUI applications, make sure you build it with VTK  
 
-### Configuration (OSX/Linux)  
+### Configure and Build  
 Make a build directory and use cmake to configure your build:  
 ```
 mkdir build
 cd build
-cmake <options> <base-shapeworks-directory>
+cmake <options> ..
 ```
 CMake GUI to see and change any of the options:
 - On OSX/Linux, you can use a GUI by running `ccmake` instead of `cmake`.  
-- On Windows, you can use the CMake application.
+- On Windows, you can use the CMake application.  
 
-Options include the following:
+#### Options
+Required:  
 ```
-  -G <generator> (For example: -GXCode or -G "Visual Studio 16 2019" -A x64)
-  -DCMAKE_PREFIX_PATH=<lib Path(s)>   default: a ;-separated list of paths to Qt, vtk, ITK, etc.
-                                               For Qt: it finds qmake in the system PATH; A prefix path must contain the lib/cmake directory.
+  -G<generator> (For example: -GXCode or -G"Visual Studio 16 2019" -Ax64)
+  -DCMAKE_PREFIX_PATH=<qt cmake path>  (This is different from qmake path in the [Install dependencies/Qt5])#Qt5) step
+  -DVXL_DIR=<vxl cmake path>  (contains VXLConfig.cmake)
+  -DVTK_DIR=<vtk cmake path>  (contains VTKConfig.cmake)
+  -DITK_DIR=<itk cmake path>  (contains ITKConfig.cmake)
+```
+Optional:
+```
   -DBuild_Studio=[OFF|ON]             default: OFF
   -DBuild_View2=[OFF|ON]              default: OFF
   -DBuild_Post=[OFF|ON]               default: ON
   -DCMAKE_INSTALL_PREFIX=<path>       default: ./install
-  -DCMAKE_BUILD_TYPE=[Debug|Release]  default: Release
+  -DCMAKE_BUILD_TYPE=[Debug|Release]  
 ```
-  Paths to dependencies can be set explicitly. Otherwise they will be downloaded and built automatically.
-```
-  -DVTK_DIR=<path to your own vtk>
-  -DITK_DIR=<path to your own ITK> # Note that ITK must be build with VTK for GUI applications
-  -DVXL_DIR=<path to your own vxl>
-```
+**See [examples](#Examples) below for common values of the variables**  
 
+#### Building
+- Makefiles: `make -j<num_procs>` where num_procs is the number of parallel processes, say 8.  
+    - (maybe need to build using `cmake --build . -j 16` in order to pass parallel flags to dependent projects (e.g., vtk))  
+- XCode project: `open ShapeWorks.xcodeproj` and build from there  
+- Microsoft Visual Studio: Open ShapeWorks.sln and build from there  
 
-### Build
-Execute build using your generated project file:  
-**Makefiles:** `make -j<num_procs>` where num_procs is the number of parallel processes, say 8.
-- maybe need to build using `cmake --build . -j 16` in order to pass parallel flags to dependent projects (e.g., vtk)
-**XCode project:** `open ShapeWorks.xcodeproj` and build from there  
-**Microsoft Visual Studio:** `open ShapeWorks.sln` and build  
-
-
-**Example (using OSX) that builds dependencies separately, then generates an XCode project for ShapeWorks:**  
+#### Examples
+*OSX* example that builds dependencies separately, then generates an XCode project for ShapeWorks:  
 ```
 $ ./superbuild.sh  --dependencies_only --build-dir=../dependencies --install-dir=../dependencies
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=./install  -DCMAKE_PREFIX_PATH="${PWD}/../../dependencies" -DBuild_Post:BOOL=ON -DBuild_View2:BOOL=ON -DBuild_Studio:BOOL=ON -DUSE_OPENMP=OFF -Wno-dev -Wno-deprecated -GXcode ..
 open ShapeWorks.xcodeproj
+```
+
+*Windows* example that builds dependencies separately, then generates a Visual Studio project for ShapeWorks:  
+```
+$ ./superbuild.sh  --dependencies_only --build-dir=../dependencies --install-dir=../dependencies
+mkdir build
+cd build
+cmake -G"Visual Studio 16 2019" -Ax64 -DCMAKE_PREFIX_PATH=D:/ProgramFiles/Qt5.14.0/5.14.0/msvc2017_64/lib/cmake -DVXL_DIR=dependencies/vxl/build -DVTK_DIR=dependencies/lib/cmake/vtk-8.2 -DITK_DIR=dependencies/lib/cmake/ITK-5.0 -DBuild_Post:BOOL=ON -DBuild_View2:BOOL=ON -DBuild_Studio:BOOL=ON ..
 ```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 ### vtk
 find_package(VTK ${SHAPEWORKS_VTK_VERSION_MIN})
 if (NOT VTK_FOUND)
-  message(FATAL_ERROR "** VTK not found. By default cmake will download it (see BUILD.md)")
+  message(FATAL_ERROR "VTK is required, but could not be found! Make sure path to VTKConfig.cmake is included in CMAKE_PREFIX_PATH")
 endif()
 include(${VTK_USE_FILE})
 
@@ -111,7 +111,7 @@ IF(VXL_FOUND)
   # this adds deprecated VXL variables to the cmake namespace (TODO: use the new ones)
   INCLUDE (${VXL_CMAKE_DIR}/UseVXL.cmake)
 ELSE(VXL_FOUND)
-  MESSAGE(SEND_ERROR "VXL is required, but could not be found.")
+  MESSAGE(SEND_ERROR "VXL is required, but could not be found! Make sure path to VXLConfig.cmake is included in CMAKE_PREFIX_PATH")
 ENDIF(VXL_FOUND)
 
 ### ITK
@@ -119,7 +119,7 @@ FIND_PACKAGE(ITK ${SHAPEWORKS_ITK_VERSION_MIN} REQUIRED)
 IF (ITK_FOUND)
   INCLUDE(${ITK_USE_FILE})
 ELSE()
-  MESSAGE(SEND_ERROR "ITK (The Insight Toolkit) is required, but could not be found.")
+  MESSAGE(SEND_ERROR "ITK (The Insight Toolkit) is required, but could not be found! Make sure path to ITKConfig.cmake is included in CMAKE_PREFIX_PATH")
 ENDIF()
 
 if(USE_OPENMP)

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -305,7 +305,7 @@ You can also add tables, quoted text like you'd see in an email, bulleted items,
    
 ## PATH environment variable
 
-Be careful doing this! You are responsible for messing up your own PATH.  
+**Be careful** doing this! You are responsible for messing up your own PATH.  
 
 ### Adding to the PATH on OSX/Linux
 `$ export PATH=path/to/add:$PATH`  

--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -302,3 +302,22 @@ You can also add tables, quoted text like you'd see in an email, bulleted items,
    [github]: <https://github.com/>
    [Gitter community]: <https://gitter.im/ShapeWorks>
    [Trello boards]: <https://trello.com/shapeworksteam>
+   
+## PATH environment variable
+
+Be careful doing this! You are responsible for messing up your own PATH.  
+
+### Adding to the PATH on OSX/Linux
+`$ export PATH=path/to/add:$PATH`  
+
+Verify the results with the command: `$ echo $PATH`  
+
+### Adding to the PATH on Windows
+`$ set PATH=path/to/add;%PATH%`  
+This only modifies the path for the current command prompt.  
+To permanently add to the path:  
+- Go to *Settings/Edit the system environment variables/Environment Variables*  
+- Choose the *Path* variable and press *Edit...*  
+- Add your path entry to the list  
+
+Verify the results with the command: `$ echo %PATH%`  

--- a/README.md
+++ b/README.md
@@ -47,21 +47,16 @@ Table of Contents
 Installation
 =====================
 
-Download
+Users
 ---------------------
 
 The latest shapeworks release can be downloaded here:
 
 https://github.com/SCIInstitute/ShapeWorks/releases/tag/v5.1
 
-To build shapeworks from source, please see **[Development](#development)**.
-
-Development
+Developers
 ---------------------
 Please see **[BUILD.md](BUILD.md)** for the current build instructions.  
-<!--
-Please see **[GettingStarted.md](GettingStarted.md)** for help using `git` to clone code and `MarkDown` for documentation.
--->
 
 <!-- the below is not updated with dead linkes
 Documentation is generated from [the gh-pages branch in GitHub.](https://github.com/SCIInstitute/ShapeWorks/tree/gh-pages)

--- a/superbuild.sh
+++ b/superbuild.sh
@@ -161,20 +161,11 @@ build_vtk()
       cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_TESTING:BOOL=OFF -DVTK_Group_Qt:BOOL=${BUILD_GUI} -DVTK_QT_VERSION=5 -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release -DVTK_PYTHON_VERSION=3 -Wno-dev ..
       cmake --build . --config Release || exit 1
       cmake --build . --config Release --target install
-
-      VTK_DIR=${INSTALL_DIR}/lib/cmake/vtk-${VTK_VER_STR}
   else
       cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_TESTING:BOOL=OFF -DVTK_Group_Qt:BOOL=${BUILD_GUI} -DVTK_QT_VERSION=5 -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release -DVTK_PYTHON_VERSION=3 -Wno-dev ..
       make -j${NUM_PROCS} install || exit 1
   fi
-
-  # TODO: this could be lib (not lib64) on the Windows linux subsystem (or even other linuxes), so need to verify
-  if [ "$(uname)" == "Darwin" ]; then
-      VTK_LIB_DIR="lib"
-  else
-      VTK_LIB_DIR="lib64"
-  fi  
-  VTK_DIR=${INSTALL_DIR}/${VTK_LIB_DIR}/cmake/vtk-${VTK_VER_STR}
+  VTK_DIR=${INSTALL_DIR}/lib/cmake/vtk-${VTK_VER_STR}
 }
 
 build_itk()


### PR DESCRIPTION
Changed Build.md to be more straight-forward and detailed.
Move PATH instructions to GettingStarted.md
Improve CMake error messages.
superbuild.sh: Always set VTK_DIR to the path with lib instead of lib64: VTK_DIR=${INSTALL_DIR}/lib/cmake/vtk-${VTK_VER_STR}