### PR TITLE
Fix studio crash 340

### DIFF
--- a/Studio/src/Application/Data/Project.cc
+++ b/Studio/src/Application/Data/Project.cc
@@ -235,7 +235,7 @@ bool Project::load_project(QString filename, std::string& planesFile)
   TiXmlDocument doc(filename.toStdString().c_str());
   bool loadOkay = doc.LoadFile();
   if (!loadOkay) {
-    QString message = "Error: Invalid parameter file" + filename;
+    QString message = "Error: Invalid parameter file: " + filename;
     QMessageBox::critical(NULL, "ShapeWorksStudio", message, QMessageBox::Ok);
     return false;
   }
@@ -259,6 +259,12 @@ bool Project::load_project(QString filename, std::string& planesFile)
   for (TiXmlElement* e = shapes_node->FirstChildElement("shape"); e != NULL;
        e = e->NextSiblingElement("shape")) {
     TiXmlElement* initial_mesh_element = e->FirstChildElement("initial_mesh");
+    if (!initial_mesh_element)
+    {
+      QString message = "Error: Invalid parameter file: " + filename;
+      QMessageBox::critical(NULL, "ShapeWorksStudio", message, QMessageBox::Ok);
+      return false;
+    }
     import_files.push_back(initial_mesh_element->GetText());
     TiXmlElement* groomed_mesh_element = e->FirstChildElement("groomed_mesh");
     if (groomed_mesh_element) {

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cc
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cc
@@ -230,7 +230,7 @@ void ShapeWorksStudioApp::initialize_vtk()
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::on_action_new_project_triggered()
 {
-  if (this->preferences_.not_saved()) {
+  if (this->preferences_.not_saved() && this->ui_->action_save_project->isEnabled()) {
     // save the size of the window to preferences
     QMessageBox msgBox;
     msgBox.setText("Do you want to save your changes as a project file?");
@@ -991,7 +991,7 @@ void ShapeWorksStudioApp::closeEvent(QCloseEvent* event)
 {
   // close the preferences window in case it is open
   this->preferences_window_->close();
-  if (this->preferences_.not_saved()) {
+  if (this->preferences_.not_saved() && this->ui_->action_save_project->isEnabled()) {
     // save the size of the window to preferences
     QMessageBox msgBox;
     msgBox.setText("Do you want to save your changes as a project file?");


### PR DESCRIPTION
Fixes #340 by:

1. Detect the invalid XML file and print a warning rather than crash.
2. Disable writing of these XML files if the save action is disabled.