### PR TITLE
Enable ITK writer compression on itk::ImageFileWriters

### DIFF
--- a/ExternalLibs/trimesh2/include/TriMesh.h
+++ b/ExternalLibs/trimesh2/include/TriMesh.h
@@ -1370,6 +1370,7 @@ public:
             std::string f = debug_prefix + ".faceInd.nrrd";
             writer->SetFileName( f.c_str() );
             writer->SetInput( OutputImage );
+            writer->SetUseCompression(true);
             writer->Update();
 
             saveFidsViaKDtreeDistanceMap(OutputImage, debug_prefix);
@@ -1673,6 +1674,7 @@ public:
                 std::string f = debug_prefix + ".faceInd" + debug_suffix + ".nrrd";
                 writer->SetFileName( f.c_str() );
                 writer->SetInput( OutputImage );
+                writer->SetUseCompression(true);
                 writer->Update();
 
                 //saveFidsViaSuperVoxelDistanceMap(OutputImage, debug_prefix, radiusFactor); // using the subvoxel resolution not the original one
@@ -1996,6 +1998,7 @@ public:
             std::string f = debug_prefix + ".faceInd_r" + ss.str() +  "_sp" + sp.str() + ".nrrd";
             writer->SetFileName( f.c_str() );
             writer->SetInput( OutputImage );
+            writer->SetUseCompression(true);
             writer->Update();
         }
         // Collect values in faceIndexMap
@@ -3112,6 +3115,7 @@ public:
         std::string f = prefix + ".DistMap_r" + ss.str() + ".nrrd";
         w->SetFileName( f.c_str() );
         w->SetInput( origDistMap );
+        w->SetUseCompression(true);
         w->Update();
     }
 
@@ -3258,6 +3262,7 @@ public:
         std::string f = prefix + ".SignedDistMap" + suffix + ".nrrd";
         w->SetFileName( f.c_str() );
         w->SetInput( origDistMap );
+        w->SetUseCompression(true);
         w->Update();
     }
 
@@ -3355,6 +3360,7 @@ public:
         std::string f = prefix + ".fidsSV_distMap_r" + ss.str() + ".nrrd";
         w->SetFileName( f.c_str() );
         w->SetInput( distMap );
+        w->SetUseCompression(true);
         w->Update();
     }
 
@@ -3416,6 +3422,7 @@ public:
         std::string f = prefix + ".fidsKD_distMap" + ".nrrd";
         w->SetFileName( f.c_str() );
         w->SetInput( origDistMap );
+        w->SetUseCompression(true);
         w->Update();
     }
 

--- a/Libs/Alignment/ApplyRigid3DTransformationToImage.cxx
+++ b/Libs/Alignment/ApplyRigid3DTransformationToImage.cxx
@@ -265,6 +265,7 @@ int main(int argc, char * argv [] )
 
         itkImageWriter->SetInput( resampler->GetOutput() );
         itkImageWriter->SetFileName( solutionRaw );
+        itkImageWriter->SetUseCompression(true);
         itkImageWriter->Update();
 
 

--- a/Libs/Alignment/ICPRigid3DImageRegistration.cxx
+++ b/Libs/Alignment/ICPRigid3DImageRegistration.cxx
@@ -349,6 +349,7 @@ int main(int argc, char * argv [] )
 
         itkImageWriter->SetInput( resampler->GetOutput() );
         itkImageWriter->SetFileName( solutionSegmentation );
+        itkImageWriter->SetUseCompression(true);
         itkImageWriter->Update();
         //////////////////////////////////
         // Same transformation applied on the raw images
@@ -384,6 +385,7 @@ int main(int argc, char * argv [] )
 
             itkImageWriter->SetInput( resampler->GetOutput() );
             itkImageWriter->SetFileName( solutionRaw );
+            itkImageWriter->SetUseCompression(true);
             itkImageWriter->Update();
          }
 

--- a/Libs/Alignment/ResampleVolumeToIsotropic.cxx
+++ b/Libs/Alignment/ResampleVolumeToIsotropic.cxx
@@ -380,6 +380,7 @@ int main( int argc, char * argv[] )
   typedef itk::ImageFileWriter< OutputImageType >  WriterType;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( argv[2] );
+  writer->SetUseCompression(true);
   writer->SetInput( resampler->GetOutput() );
   try
     {

--- a/Libs/Alignment/ResizeOriginResampleVolumes.cxx
+++ b/Libs/Alignment/ResizeOriginResampleVolumes.cxx
@@ -210,6 +210,7 @@ int main( int argc, char * argv[] )
 
         writer->SetFileName( outFilenames[sh].c_str() );
         writer->SetInput( resampler->GetOutput() );
+        writer->SetUseCompression(true);
         try
         {
             writer->Update();

--- a/Libs/Alignment/TranslateImages.cxx
+++ b/Libs/Alignment/TranslateImages.cxx
@@ -133,6 +133,7 @@ int main( int argc, char * argv[] )
     WType::Pointer mriwriter = WType::New();
     mriwriter->SetFileName( MRIoutFilename);
     mriwriter->SetInput(mriresampler->GetOutput());
+    mriwriter->SetUseCompression(true);
     try
     {
         mriwriter->Update();

--- a/Libs/Alignment/TranslateShapeToImageOrigin.cxx
+++ b/Libs/Alignment/TranslateShapeToImageOrigin.cxx
@@ -296,6 +296,7 @@ int main( int argc, char * argv[] )
     WriterType::Pointer writer = WriterType::New();
     writer->SetFileName( outFilename);
     writer->SetInput(outputImage);
+    writer->SetUseCompression(true);
 
     try
     {
@@ -343,6 +344,7 @@ int main( int argc, char * argv[] )
         WType::Pointer mriwriter = WType::New();
         mriwriter->SetFileName( MRIoutFilename);
         mriwriter->SetInput(mriresampler->GetOutput());
+        mriwriter->SetUseCompression(true);
         try
         {
             mriwriter->Update();

--- a/Libs/Image/ClipVolume.cxx
+++ b/Libs/Image/ClipVolume.cxx
@@ -91,6 +91,7 @@ int dataslice(std::vector< std::string > inputpaths, std::vector< std::string > 
         WriterType::Pointer writer = WriterType::New();
         writer->SetInput( image );
         writer->SetFileName(outputname.c_str());
+        writer->SetUseCompression(true);
         writer->Update();
     }
     return EXIT_SUCCESS;

--- a/Libs/Image/CloseHoles.cxx
+++ b/Libs/Image/CloseHoles.cxx
@@ -57,6 +57,7 @@ int main(int argc, char * argv[] )
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outFilename );
   writer->SetInput( filter->GetOutput() );
+  writer->SetUseCompression(true);
   try
     {
     writer->Update();

--- a/Libs/Image/CropImages.cxx
+++ b/Libs/Image/CropImages.cxx
@@ -128,6 +128,7 @@ int main(int argc, char * argv[] )
         WriterType::Pointer writer = WriterType::New();
         writer->SetFileName( outFilename);
         writer->SetInput(output);
+        writer->SetUseCompression(true);
 
         try
         {
@@ -200,6 +201,7 @@ int main(int argc, char * argv[] )
         MRIWriterType::Pointer MRIwriter = MRIWriterType::New();
         MRIwriter->SetFileName( MRIoutFilename);
         MRIwriter->SetInput(MRIoutput);
+        MRIwriter->SetUseCompression(true);
 
         try
         {

--- a/Libs/Image/ExtractGivenLabelImage.cxx
+++ b/Libs/Image/ExtractGivenLabelImage.cxx
@@ -119,6 +119,7 @@ int main( int argc, char * argv[] )
     WriterType::Pointer writer = WriterType::New();
     writer->SetFileName( outFilename );
     writer->SetInput(outputImage);
+    writer->SetUseCompression(true);
 
     try
     {

--- a/Libs/Image/FastMarching.cxx
+++ b/Libs/Image/FastMarching.cxx
@@ -71,6 +71,7 @@ int main(int argc, char * argv[])
     WriterType::Pointer writer = WriterType::New();
     writer->SetFileName(outFilename.c_str());
     writer->SetInput( distanceMapImageFilter->GetOutput() );
+    writer->SetUseCompression(true);
     writer->Update();
     
     return EXIT_SUCCESS;

--- a/Libs/Image/ReflectVolumes.cxx
+++ b/Libs/Image/ReflectVolumes.cxx
@@ -160,6 +160,7 @@ int main( int argc, char * argv[] )
     WType::Pointer writer = WType::New();
     writer->SetFileName( outFilename);
     writer->SetInput(infoFilter_->GetOutput());
+    writer->SetUseCompression(true);
     try
     {
         writer->Update();

--- a/Libs/Image/ThresholdImages.cxx
+++ b/Libs/Image/ThresholdImages.cxx
@@ -43,6 +43,7 @@ int binarythreshold(std::string inputpath, std::string outputpath,
     WriterType::Pointer writer = WriterType::New();
     writer->SetInput( threshold->GetOutput() );
     writer->SetFileName(outputpath.c_str());
+    writer->SetUseCompression(true);
     writer->Update();
     
 	return EXIT_SUCCESS;

--- a/Libs/Image/TopologyPreservingSmoothing.cxx
+++ b/Libs/Image/TopologyPreservingSmoothing.cxx
@@ -178,6 +178,7 @@ int main( int argc, char *argv[])
         ImageWriterType::Pointer w = ImageWriterType::New();
         w->SetInput( smoothing->GetOutput() );
         w->SetFileName(distFilenames[dtNo].c_str());
+        w->SetUseCompression(true);
         w->Update();
         if(verbose) {
             std::cout << "Done\n";
@@ -245,7 +246,7 @@ int main( int argc, char *argv[])
         size_t ind = outFilenames[dtNo].find('.');
         std::string filename = outFilenames[dtNo];
         writer->SetFileName( filename.c_str() );
-        writer->SetFileName( filename.c_str() );
+        writer->SetUseCompression(true);
 
         try {
             writer->Update();

--- a/Libs/Mesh/GenerateBinaryAndDTImagesFromMeshes.cxx
+++ b/Libs/Mesh/GenerateBinaryAndDTImagesFromMeshes.cxx
@@ -535,6 +535,7 @@ int main(int argc, char *argv[])
         ImageWriterType::Pointer w2 = ImageWriterType::New();
         w2->SetFileName( f2.c_str() );
         w2->SetInput( binaryImage );
+        w2->SetUseCompression(true);
         w2->Update();
 
         std::string f3 = prefix + ".DT" + suffix + ".nrrd";
@@ -546,6 +547,7 @@ int main(int argc, char *argv[])
         ImageWriterType::Pointer w3 = ImageWriterType::New();
         w3->SetFileName( f3.c_str() );
         w3->SetInput( dtImage );
+        w3->SetUseCompression(true);
         w3->Update();
 
     }

--- a/Libs/Mesh/GenerateFidsFilesFromMeshes.cxx
+++ b/Libs/Mesh/GenerateFidsFilesFromMeshes.cxx
@@ -688,6 +688,7 @@ int main(int argc, char *argv[])
 //        std::string f2 = prefix + ".rasterized" + suffix + ".nrrd";
         w2->SetFileName( f2.c_str() );
         w2->SetInput( binaryImage );
+        w2->SetUseCompression(true);
         w2->Update();
 //#endif
         }
@@ -714,6 +715,7 @@ int main(int argc, char *argv[])
 //        std::string f3 = prefix + ".DT" + suffix + ".nrrd";
         w3->SetFileName( f3.c_str() );
         w3->SetInput( dtImage );
+        w3->SetUseCompression(true);
         w3->Update();
 //#endif
         }

--- a/Libs/Mesh/GetFeatureVolume.cxx
+++ b/Libs/Mesh/GetFeatureVolume.cxx
@@ -318,6 +318,7 @@ int main(int argc, char *argv[])
             WriterType::Pointer writer = WriterType::New();
             writer->SetInput( narrowbandVolume );
             writer->SetFileName( featureFileName );
+            writer->SetUseCompression(true);
             writer->Update();
 
         }

--- a/Libs/Mesh/RemoveFidsDTLeakage.cxx
+++ b/Libs/Mesh/RemoveFidsDTLeakage.cxx
@@ -163,6 +163,7 @@ int main(int argc, char *argv[])
         WriterType::Pointer writer = WriterType::New();
         writer->SetInput( outDist );
         writer->SetFileName( outDistFilename[shCount].c_str() );
+        writer->SetUseCompression(true);
         writer->Update();
     }
 

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -41,6 +41,7 @@ static void prep_distance_transform(std::string input, std::string output)
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName(output.c_str());
   writer->SetInput(dt_filter->GetOutput());
+  writer->SetUseCompression(true);
   writer->Update();
 }
 


### PR DESCRIPTION
Enabled compression on ITK image writers wherever I could find them in the code.  This should save time and space.