### PR TITLE
Attempting to fix eigen build on windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ if (BUILD_TESTS)
   endif()
 endif(BUILD_TESTS)
 
-
 project(ShapeWorks)
 
 # use ccache if available

--- a/superbuild.sh
+++ b/superbuild.sh
@@ -209,8 +209,14 @@ build_eigen()
   if [[ $BUILD_CLEAN = 1 ]]; then rm -rf build; fi
   mkdir -p build && cd build
 
-  cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ..
-  make -j${NUM_PROCS} install || exit 1
+  if [[ $OSTYPE == "msys" ]]; then
+      cmake -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" ..
+      cmake --build . --config Release || exit 1
+      cmake --build . --config Release --target install
+  else
+      cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ..
+      make -j${NUM_PROCS} install || exit 1
+  fi
 
   EIGEN_DIR=${INSTALL_DIR}/share/eigen3/cmake/
 }


### PR DESCRIPTION
We're having a problem that the eigen build is wrong for windows:

2020-02-19T18:58:26.9726289Z -- Configuring done
2020-02-19T18:58:31.6609916Z -- Generating done
2020-02-19T18:58:31.7035254Z -- Build files have been written to: D:/a/bdeps/eigen/build
2020-02-19T18:58:31.9449568Z mingw32-make: *** No rule to make target 'install'.  Stop.

However, for some reason this isn't aborting the github action and furthermore, the compile of shapeworks actually works.  But it does not cache correctly, so subsequent builds using the cache will fail.