### PR TITLE
Fix typos and layout of 'shapeworks' usage

### DIFF
--- a/Applications/shapeworks/Commands.cpp
+++ b/Applications/shapeworks/Commands.cpp
@@ -180,7 +180,7 @@ int ResampleImage::execute(const optparse::Values &options, SharedCommandData &s
 void RecenterImage::buildParser()
 {
   const std::string prog = "recenter-image";
-  const std::string desc = "recenters an image by changing its origin in the image header to the physcial coordinates of the center of the image";
+  const std::string desc = "recenters an image by changing its origin in the image\n\t\t\theader to the physical coordinates of the center of the image";
   parser.prog(prog).description(desc);
 
   Command::buildParser();

--- a/Applications/shapeworks/Executable.cpp
+++ b/Applications/shapeworks/Executable.cpp
@@ -44,6 +44,7 @@ void Executable::addCommand(Command &command)
   ss << "Available commands:\n---------------------\n";
   for (auto cmdtype: parser_epilog)
   {
+    ss << "\n";
     ss << cmdtype.first << "\n";
     for (auto cmd: cmdtype.second)
       ss << std::string(indent, ' ')

--- a/Libs/Image/Image.cpp
+++ b/Libs/Image/Image.cpp
@@ -164,7 +164,7 @@ bool Image::binarize(PixelType threshold, PixelType inside, PixelType outside)
 }
 
 /// recenter
-/// recenters by changing origin (in the image header) to the physcial coordinates of the center of the image
+/// recenters by changing origin (in the image header) to the physical coordinates of the center of the image
 bool Image::recenter()
 {
   if (!this->image)


### PR DESCRIPTION
Fixed typo, moved second line of long description to match indent, added newline between command groups.

Before:

<img width="696" alt="shapeworks-before" src="https://user-images.githubusercontent.com/1693349/75371129-6fed3c80-5883-11ea-87b8-b5a6586e19cc.png">

After:

<img width="666" alt="shapeworks-after" src="https://user-images.githubusercontent.com/1693349/75371141-754a8700-5883-11ea-826c-a868a22bd307.png">
