### PR TITLE
use conda for gtest rather than downloading it every time cmake is run

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -47,6 +47,18 @@ jobs:
         version: "5.9.9"
         cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
+    - name: Setup Conda
+      uses: goanpeca/setup-miniconda@v1
+      with:
+          miniconda-version: 'latest'
+          
+    - name: Conda info
+      run: conda info
+
+    - name: conda installs
+      shell: bash -l {0}
+      run: source ./conda_installs.sh
+
     - name: Cache dependencies
       id: cache-dependencies
       uses: actions/cache@v1
@@ -72,33 +84,17 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSHAPEWORKS_SUPERBUILD=OFF -DVXL_DIR="${{runner.workspace}}\deps\vxl\build" -DITK_DIR="${{runner.workspace}}\deps\lib\cmake\ITK-5.0" -DVTK_DIR="${{runner.workspace}}\deps\lib\cmake\vtk-8.2" -DEigen3_DIR="${{runner.workspace}}\deps\share\eigen3\cmake" -DBuild_Studio=ON -DBuild_View2=ON
+      run: conda activate shapeworks && cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSHAPEWORKS_SUPERBUILD=OFF -DVXL_DIR="${{runner.workspace}}\deps\vxl\build" -DITK_DIR="${{runner.workspace}}\deps\lib\cmake\ITK-5.0" -DVTK_DIR="${{runner.workspace}}\deps\lib\cmake\vtk-8.2" -DEigen3_DIR="${{runner.workspace}}\deps\share\eigen3\cmake" -DBuild_Studio=ON -DBuild_View2=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE -j 4
+      run: conda activate shapeworks && cmake --build . --config $BUILD_TYPE -j 4
 
     - name: Copy Libraries
       working-directory: ${{runner.workspace}}/build
       run: xcopy /f ${{runner.workspace}}\deps\bin\*.dll ${{runner.workspace}}\build\bin\Release
-    
-    - name: Setup Conda
-      uses: goanpeca/setup-miniconda@v1
-      with:
-          miniconda-version: 'latest'
-          
-    - name: Conda info
-      run: conda info
-
-    - name: conda installs
-      shell: bash -l {0}
-      run: source ./conda_installs.sh
-
-    - name: activate shapeworks
-      shell: bash -l {0}
-      run: conda activate shapeworks
     
     - name: Build Binary Package
       shell: bash

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
-      shell: bash
+      shell: bash -l {0}
       working-directory: ${{runner.workspace}}/build
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
@@ -88,7 +88,7 @@ jobs:
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      shell: bash
+      shell: bash -l {0}
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: conda activate shapeworks && cmake --build . --config $BUILD_TYPE -j 4
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,26 +24,6 @@ set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install" CACHE STRING "Ins
 
 include(DefaultBuildType)
 
-# Google Test
-if (BUILD_TESTS)
-  message(STATUS "Building Google Test")
-  set( gtest_force_shared_crt ON CACHE BOOL "Always use msvcrt.dll" FORCE)
-  enable_testing()
-  include(FetchContent)
-  
-  FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        release-1.10.0
-    )
-  
-  FetchContent_GetProperties(googletest)
-  if(NOT googletest_POPULATED)
-    FetchContent_Populate(googletest)
-    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
-  endif()
-endif(BUILD_TESTS)
-
 project(ShapeWorks)
 
 # use ccache if available

--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -1,3 +1,6 @@
+enable_testing()
+find_package(GTest REQUIRED)
+
 # Set the test data location
 set(TEST_DATA_DIR "${CMAKE_SOURCE_DIR}/Testing/data")
 

--- a/Testing/ImageTests/CMakeLists.txt
+++ b/Testing/ImageTests/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(ImageTests
 
 target_link_libraries(ImageTests
   tinyxml Mesh vgl vgl_algo Image Optimize Utils trimesh2
-  gtest_main ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  ${ITK_LIBRARIES} ${VTK_LIBRARIES}
+  GTest::Main
+  )
 
 add_test(NAME ImageTests COMMAND ImageTests)

--- a/Testing/MeshTests/CMakeLists.txt
+++ b/Testing/MeshTests/CMakeLists.txt
@@ -10,6 +10,9 @@ add_executable(MeshTests
 
 target_link_libraries(MeshTests
   tinyxml Mesh vgl vgl_algo Mesh Optimize Utils trimesh2
-  gtest_main ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  ${ITK_LIBRARIES} ${VTK_LIBRARIES}
+  GTest::Main
+  )
+
 
 add_test(NAME MeshTests COMMAND MeshTests)

--- a/Testing/OptimizeTests/CMakeLists.txt
+++ b/Testing/OptimizeTests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(OptimizeTests
 target_link_libraries(OptimizeTests
   ${ITK_LIBRARIES} ${VTK_LIBRARIES}
   tinyxml Mesh vgl vgl_algo Optimize Utils trimesh2 Particles
-  gtest_main)
+  GTest::Main
+  )
 
 add_test(NAME OptimizeTests COMMAND OptimizeTests)

--- a/Testing/ParticlesTests/CMakeLists.txt
+++ b/Testing/ParticlesTests/CMakeLists.txt
@@ -8,6 +8,8 @@ add_executable(ParticlesTests
 
 target_link_libraries(ParticlesTests
   ${ITK_LIBRARIES} ${VTK_LIBRARIES}
-  Particles gtest_main)
+  Particles
+  GTest::Main
+  )
 
 add_test(NAME ParticlesTests COMMAND ParticlesTests)

--- a/Testing/PythonTests/CMakeLists.txt
+++ b/Testing/PythonTests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(PythonTests
   )
 
 target_link_libraries(PythonTests
-  gtest_main )
+  GTest::Main
+  )
 
 add_test(NAME PythonTests COMMAND PythonTests)

--- a/conda_installs.sh
+++ b/conda_installs.sh
@@ -49,6 +49,7 @@ function install_conda() {
   #install shapeworks deps
   if ! conda install --yes \
        cmake=3.15.5 \
+       gtest=1.10.0 \
        colorama=0.4.3 \
        requests=2.22.0 \
        geotiff=1.5.1 \


### PR DESCRIPTION
You don't have to re-run conda_installs (but it's in there), just run:
`conda install gtest`
It's very fast and dependency-free.

This will break the GitHub actions since I don't think they use conda_installs.sh.