### PR TITLE
Refactor ImageDomain

### DIFF
--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -30,7 +30,6 @@
 // itk
 #include <itkImageFileReader.h>
 #include <itkMultiThreaderBase.h>
-#include <itkZeroCrossingImageFilter.h>
 #include <itkImageRegionIteratorWithIndex.h>
 #include <itkMacro.h>
 
@@ -490,16 +489,7 @@ double Optimize::GetMinNeighborhoodRadius()
                                                                  * > (m_sampler->GetParticleSystem()
                                                                       ->GetDomain(i));
 
-    itk2vtkConnector = itk::ImageToVTKImageFilter < ImageType > ::New();
-    itk2vtkConnector->SetInput(domain->GetImage());
-    vtkSmartPointer < vtkContourFilter > ls = vtkSmartPointer < vtkContourFilter > ::New();
-    ls->SetInputData(itk2vtkConnector->GetOutput());
-    ls->SetValue(0, 0.0);
-    ls->Update();
-    vtkSmartPointer < vtkMassProperties > mp = vtkSmartPointer < vtkMassProperties > ::New();
-    mp->SetInputData(ls->GetOutput());
-    mp->Update();
-    double area = mp->GetSurfaceArea();
+    double area = domain->GetSurfaceArea();
     double sigma =
       std::sqrt(area / (m_sampler->GetParticleSystem()->GetNumberOfParticles(i) * M_PI));
     if (rad < sigma) {
@@ -522,29 +512,10 @@ void Optimize::AddSinglePoint()
 
     bool done = false;
 
-    ImageType::Pointer img = dynamic_cast < itk::ParticleImageDomain < float, 3 >* > (
-      m_sampler->GetParticleSystem()->GetDomain(i))->GetImage();
-
-    itk::ZeroCrossingImageFilter < ImageType, ImageType > ::Pointer zc =
-      itk::ZeroCrossingImageFilter < ImageType, ImageType > ::New();
-    zc->SetInput(img);
-    zc->Update();
-    itk::ImageRegionConstIteratorWithIndex < ImageType > it(zc->GetOutput(),
-                                                            zc->GetOutput()->GetRequestedRegion());
-
-    for (it.GoToReverseBegin(); !it.IsAtReverseEnd() && done == false; --it) {
-      if (it.Get() == 1.0) {
-        PointType pos;
-        img->TransformIndexToPhysicalPoint(it.GetIndex(), pos);
-        done = true;
-        try
-        {
-          m_sampler->GetParticleSystem()->AddPosition(pos, i);
-        } catch (itk::ExceptionObject &) {
-          done = false;
-        }
-      }
-    }
+    const itk::ParticleImageDomain < float, 3 >* domain =
+            static_cast < const itk::ParticleImageDomain < float, 3 > * > (m_sampler->GetParticleSystem() ->GetDomain(i));
+    const auto zcPos = domain->GetZeroCrossingPoint();
+    m_sampler->GetParticleSystem()->AddPosition(zcPos, i);
   }
 }
 
@@ -1112,17 +1083,7 @@ void Optimize::SetCotanSigma()
     using DomainType = itk::ParticleImageDomain<float, 3>;
     const DomainType* domain =
       static_cast<const DomainType*> (m_sampler->GetParticleSystem()->GetDomain(i));
-
-    itk2vtkConnector = itk::ImageToVTKImageFilter<ImageType>::New();
-    itk2vtkConnector->SetInput(domain->GetImage());
-    vtkSmartPointer<vtkContourFilter> ls = vtkSmartPointer<vtkContourFilter>::New();
-    ls->SetInputData(itk2vtkConnector->GetOutput());
-    ls->SetValue(0, 0.0);
-    ls->Update();
-    vtkSmartPointer<vtkMassProperties> mp = vtkSmartPointer<vtkMassProperties>::New();
-    mp->SetInputData(ls->GetOutput());
-    mp->Update();
-    double area = mp->GetSurfaceArea();
+    double area = domain->GetSurfaceArea();
     double sigma = m_cotan_sigma_factor *
                    std::sqrt(area /
                              (m_sampler->GetParticleSystem()->GetNumberOfParticles(i) * M_PI));

--- a/Libs/Optimize/ParticleSystem/itkMaximumEntropySurfaceSampler.txx
+++ b/Libs/Optimize/ParticleSystem/itkMaximumEntropySurfaceSampler.txx
@@ -211,10 +211,10 @@ MaximumEntropySurfaceSampler<TImage>::InitializeOptimizationFunctions()
         const ParticleImageDomain<float, 3> * domain = static_cast<const ParticleImageDomain<float, 3> *> (this->GetParticleSystem()->GetDomain(d));
         for (unsigned int i = 0; i < TImage::ImageDimension; i++)
         {
-            if (domain->GetImage()->GetRequestedRegion().GetSize()[i] > maxdim)
+            if (domain->GetSize()[i] > maxdim)
             {
-                maxdim = domain->GetImage()->GetRequestedRegion().GetSize()[i];
-                tempMax = maxdim * domain->GetImage()->GetSpacing()[i];
+                maxdim = domain->GetSize()[i];
+                tempMax = maxdim * domain->GetSpacing()[i];
             }
         }
         maxradius = tempMax > maxradius ? tempMax : maxradius;

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomain.h
@@ -14,7 +14,7 @@
 #include <itkZeroCrossingImageFilter.h>
 #include <vtkContourFilter.h>
 #include <vtkMassProperties.h>
-#include <debug-install/include/ITK-5.0/itkImageRegionConstIteratorWithIndex.h>
+#include <itkImageRegionConstIteratorWithIndex.h>
 
 namespace itk
 {


### PR DESCRIPTION
This PR adds a few extra APIs to ParticleImageDomain so that the Optimizer and other classes don't do `domain->GetImage() ...`. This is a subset of the changes I've made for OpenVDB, and would be required to get the Optimizer to work with arbitrary domains(such as meshes).

(Note that the UpdateSurfaceArea function does not work currently. It is needed by ModifiedContangentGradientFunction, which hasn't been tested recently.)

@0leks does this cover everything you need?