### PR TITLE
make the build quieter by silencing some warnings which otherwise mak…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,10 @@ endif(LINUX)
 SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 SET(CMAKE_BUNDLE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-# GUI
+# make it easier to see more important compiler warnings and errors (# TODO: fix the actual cause of the warnings)
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
 
+# GUI
 if (SHAPEWORKS_GUI)
     
   find_package(Qt5 COMPONENTS Core Widgets OpenGL Gui Sql ${SHAPEWORKS_QT_REQUIRED})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,9 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 SET(CMAKE_BUNDLE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # make it easier to see more important compiler warnings and errors (# TODO: fix the actual cause of the warnings)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
+if (NOT MSVC)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-inconsistent-missing-override")
+endif()
 
 # GUI
 if (SHAPEWORKS_GUI)

--- a/ExternalLibs/trimesh2/CMakeLists.txt
+++ b/ExternalLibs/trimesh2/CMakeLists.txt
@@ -5,3 +5,8 @@ add_library(trimesh2 STATIC
 target_include_directories(trimesh2 PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
+
+# make it easier to see more important compiler warnings and errors (# TODO: fix the actual cause of the warnings)
+if (UNIX)
+  target_compile_options(trimesh2 PRIVATE -Wno-deprecated-declarations)
+endif()

--- a/ExternalLibs/trimesh2/include/map.h
+++ b/ExternalLibs/trimesh2/include/map.h
@@ -48,8 +48,8 @@ public:
         typedef MapFilter<FType,InType,OutType> MF;
         typename MF::Pointer mf = MF::New();
         mf->SetFunctor(&functor); // handles output
-        if(numThreads>0)
-            mf->SetNumberOfThreads(numThreads);
+        // if(numThreads>0)
+        //     mf->SetNumberOfThreads(numThreads);
         mf->SetInput(in);
         if(outRegion.GetSize()[0] > 0)
         {
@@ -96,8 +96,8 @@ public:
     typedef ReduceFilter<FType,InType,OutType> RF;
     typename RF::Pointer rf = RF::New();
     rf->SetFunctor(&functor);
-    if(numThreads>0)
-      rf->SetNumberOfThreads(numThreads);
+    // if(numThreads>0)
+    //   rf->SetNumberOfThreads(numThreads);
     rf->SetInput(in);
 
     rf->Update(); // throws

--- a/ExternalLibs/trimesh2/include/map.h
+++ b/ExternalLibs/trimesh2/include/map.h
@@ -2,6 +2,9 @@
  * Copyright (c) 2013 University of Utah
  */
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 #ifndef __map_H
 #define __map_H
 
@@ -48,8 +51,8 @@ public:
         typedef MapFilter<FType,InType,OutType> MF;
         typename MF::Pointer mf = MF::New();
         mf->SetFunctor(&functor); // handles output
-        // if(numThreads>0)
-        //     mf->SetNumberOfThreads(numThreads);
+	if(numThreads>0)
+            mf->SetNumberOfThreads(numThreads);
         mf->SetInput(in);
         if(outRegion.GetSize()[0] > 0)
         {
@@ -96,8 +99,8 @@ public:
     typedef ReduceFilter<FType,InType,OutType> RF;
     typename RF::Pointer rf = RF::New();
     rf->SetFunctor(&functor);
-    // if(numThreads>0)
-    //   rf->SetNumberOfThreads(numThreads);
+    if(numThreads>0)
+      rf->SetNumberOfThreads(numThreads);
     rf->SetInput(in);
 
     rf->Update(); // throws
@@ -110,3 +113,5 @@ public:
 
 
 #endif
+
+#pragma clang diagnostic pop

--- a/Libs/Alignment/Transforms/itkCompactlySupportedRBFSparseKernelTransform.h
+++ b/Libs/Alignment/Transforms/itkCompactlySupportedRBFSparseKernelTransform.h
@@ -79,12 +79,12 @@ protected:
    * are not inherited. */
     typedef typename Superclass::GMatrixType GMatrixType;
 
-    const GMatrixType & ComputeG(const InputVectorType & x) const;
+    const GMatrixType & ComputeG(const InputVectorType & x) const override;
 
     /** Compute the contribution of the landmarks weighted by the kernel funcion
       to the global deformation of the space  */
     virtual void ComputeDeformationContribution( const InputPointType & inputPoint,
-                                                 OutputPointType & result ) const;
+                                                 OutputPointType & result ) const override;
 
 private:
     CompactlySupportedRBFSparseKernelTransform(const Self&); //purposely not implemented

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -40,17 +40,17 @@
 #include <vtkPolyData.h>
 #include <vtkMassProperties.h>
 
-// particle system
+// shapeworks particle system
 #include "TriMesh.h"
 #include "itkImageToVTKImageFilter.h"
-#include "itkParticleImageDomain.h"
-#include "itkParticleImageDomainWithGradients.h"
-#include "itkParticleImplicitSurfaceDomain.h"
-#include "itkParticleImageDomainWithHessians.h"
-#include "object_reader.h"
-#include "object_writer.h"
+#include "ParticleSystem/itkParticleImageDomain.h"
+#include "ParticleSystem/itkParticleImageDomainWithGradients.h"
+#include "ParticleSystem/itkParticleImplicitSurfaceDomain.h"
+#include "ParticleSystem/itkParticleImageDomainWithHessians.h"
+#include "ParticleSystem/object_reader.h"
+#include "ParticleSystem/object_writer.h"
 
-#include <Optimize.h>
+#include "Optimize.h"
 
 //---------------------------------------------------------------------------
 Optimize::Optimize()

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -21,14 +21,14 @@
 
 // itk
 #include <itkImage.h>
-#include <itkMaximumEntropyCorrespondenceSampler.h>
 #include <itkCommand.h>
-#include <itkParticleProcrustesRegistration.h>
-#include <itkParticleGoodBadAssessment.h>
-#include <itkParticleVectorFunction.h>
 
 // shapeworks particle system
-#include <itkParticleSystem.h>
+#include "ParticleSystem/itkParticleSystem.h"
+#include "ParticleSystem/itkMaximumEntropyCorrespondenceSampler.h"
+#include "ParticleSystem/itkParticleProcrustesRegistration.h"
+#include "ParticleSystem/itkParticleGoodBadAssessment.h"
+#include "ParticleSystem/itkParticleVectorFunction.h"
 
 /**
  * \class Optimize

--- a/Libs/Optimize/OptimizeParameterFile.cpp
+++ b/Libs/Optimize/OptimizeParameterFile.cpp
@@ -1,5 +1,5 @@
-#include <OptimizeParameterFile.h>
-#include <Optimize.h>
+#include "OptimizeParameterFile.h"
+#include "Optimize.h"
 
 #include <itkImageFileReader.h>
 


### PR DESCRIPTION
…e it almost impossible to notice more important warnings or errors

One modified file here also demonstrates how to silence the warnings that say a function lacks `override` in its declaration.

The modified trimesh CMakeLists.txt also shows how to set a compiler flag for only a single target rather than modifying CMAKE_CXX_FLAGS for the entire project. But the warning came up every time the file was included and so this change also simply removes the offending line of code, the argument for which is that the default value of that parameter is already 1.