### PR TITLE
Studio: Add export of current mesh as VTK and also scalars as CSV.

### DIFF
--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cc
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cc
@@ -997,6 +997,88 @@ void ShapeWorksStudioApp::on_action_preferences_triggered()
 }
 
 //---------------------------------------------------------------------------
+void ShapeWorksStudioApp::on_action_export_current_mesh_triggered()
+{
+  QString direct = preferences_.get_preference("Main/last_directory", QString());
+  auto dir = direct.toStdString();
+  dir = dir.substr(0, dir.find_last_of("/") + 1);
+  QString filename = QFileDialog::getSaveFileName(this, tr("Save Project As..."),
+                                                  QString::fromStdString(dir) + "newMesh",
+                                                  tr("VTK files (*.vtk)"));
+  if (filename.isEmpty()) {
+    return;
+  }
+  this->preferences_.set_preference("Main/last_directory", QDir().absoluteFilePath(filename));
+
+  auto poly_data = this->visualizer_->get_current_mesh();
+  vtkPolyDataWriter* writer = vtkPolyDataWriter::New();
+  writer->SetFileName(filename.toStdString().c_str());
+  writer->SetInputData(poly_data);
+  writer->Write();
+}
+
+//---------------------------------------------------------------------------
+void ShapeWorksStudioApp::on_action_export_mesh_scalars_triggered()
+{
+  QString direct = preferences_.get_preference("Main/last_directory", QString());
+  auto dir = direct.toStdString();
+  dir = dir.substr(0, dir.find_last_of("/") + 1);
+  QString filename = QFileDialog::getSaveFileName(this, tr("Save Project As..."),
+                                                  QString::fromStdString(dir) + "scalars",
+                                                  tr("CSV files (*.csv)"));
+  if (filename.isEmpty()) {
+    return;
+  }
+  this->preferences_.set_preference("Main/last_directory", QDir().absoluteFilePath(filename));
+
+  auto poly_data = this->visualizer_->get_current_mesh();
+
+  std::ofstream output;
+  output.open(filename.toStdString().c_str());
+  output << "point,x,y,z";
+
+  auto scalars = poly_data->GetPointData()->GetScalars();
+  scalars->SetName("scalar_values");
+
+  //poly_data->GetPointData()->AddArray(scalars);
+  int num_arrays = poly_data->GetPointData()->GetNumberOfArrays();
+
+  for (int i = 0; i < num_arrays; i++) {
+    if (!poly_data->GetPointData()->GetArrayName(i))
+    {
+      output << "," << "scalars";
+    }
+    else
+    {
+      output << "," << poly_data->GetPointData()->GetArrayName(i);
+      std::cout << "array: " << poly_data->GetPointData()->GetArrayName(i) << "\n";
+    }
+  }
+
+  output << "\n";
+
+  // iterate over vertices
+  vtkPoints* points = poly_data->GetPoints();
+  int num_points = points->GetNumberOfPoints();
+
+  for (int i = 0; i < num_points; i++) {
+    output << i;
+    output << "," << poly_data->GetPoint(i)[0];
+    output << "," << poly_data->GetPoint(i)[1];
+    output << "," << poly_data->GetPoint(i)[2];
+
+    for (int j = 0; j < num_arrays; j++) {
+      output << "," << poly_data->GetPointData()->GetArray(j)->GetTuple(i)[0];
+      //std::cout << "array: " << poly_data->GetPointData()->GetArrayName(i) << "\n";
+    }
+
+    output << "\n";
+  }
+
+  output.close();
+}
+
+//---------------------------------------------------------------------------
 void ShapeWorksStudioApp::closeEvent(QCloseEvent* event)
 {
   // close the preferences window in case it is open

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.h
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.h
@@ -69,6 +69,8 @@ public Q_SLOTS:
   void on_actionExport_PCA_Mode_Points_triggered();
   void on_actionExport_Variance_Graph_triggered();
   void on_action_preferences_triggered();
+  void on_action_export_current_mesh_triggered();
+  void on_action_export_mesh_scalars_triggered();
 
   void on_center_checkbox_stateChanged();
   void on_thumbnail_size_slider_valueChanged();

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.ui
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.ui
@@ -243,6 +243,8 @@
     <addaction name="actionSet_Data_Directory"/>
     <addaction name="separator"/>
     <addaction name="action_import"/>
+    <addaction name="action_export_current_mesh"/>
+    <addaction name="action_export_mesh_scalars"/>
     <addaction name="actionExport_PCA_Mesh"/>
     <addaction name="actionExport_Eigenvalues"/>
     <addaction name="actionExport_Variance_Graph"/>
@@ -625,6 +627,16 @@
   <action name="actionExport_Variance_Graph">
    <property name="text">
     <string>Export Variance Graph</string>
+   </property>
+  </action>
+  <action name="action_export_current_mesh">
+   <property name="text">
+    <string>Export Current Mesh...</string>
+   </property>
+  </action>
+  <action name="action_export_mesh_scalars">
+   <property name="text">
+    <string>Export Mesh Scalars...</string>
    </property>
   </action>
  </widget>

--- a/Studio/src/Application/Visualization/Visualizer.cc
+++ b/Studio/src/Application/Visualization/Visualizer.cc
@@ -152,6 +152,7 @@ void Visualizer::display_shape(const vnl_vector<double> &points, const std::vect
 {
   QVector<DisplayObjectHandle> objects;
   objects.push_back(this->create_display_object(points, vectors));
+  this->display_objects_ = objects;
   this->lightbox_->set_display_objects(objects);
   this->update_viewer_properties();
   //this->reset_camera();
@@ -162,6 +163,16 @@ void Visualizer::display_shape(const vnl_vector<double> &points, const std::vect
 vnl_vector<double> Visualizer::getCurrentShape()
 {
   return this->currentShape_;
+}
+
+//-----------------------------------------------------------------------------
+vtkSmartPointer<vtkPolyData> Visualizer::get_current_mesh()
+{
+  std::cerr << "number of objects: " << this->display_objects_.size() << "\n";
+  if (this->display_objects_.size() > 0) {
+    return this->display_objects_[0]->get_mesh()->get_poly_data();
+  }
+  return nullptr;
 }
 
 //-----------------------------------------------------------------------------

--- a/Studio/src/Application/Visualization/Visualizer.h
+++ b/Studio/src/Application/Visualization/Visualizer.h
@@ -68,6 +68,8 @@ public:
 
   vnl_vector<double> getCurrentShape();
 
+  vtkSmartPointer<vtkPolyData> get_current_mesh();
+
 public Q_SLOTS:
 
   /// update viewer properties (e.g. glyph size, quality, etc)


### PR DESCRIPTION
This PR adds two menu options to Studio.  There is a current mesh export and also current mesh scalars output.

To use with group differences, make sure you have the group differences displayed, then choose "Export Mesh Scalars"

The CSV file written will have a column "scalar_values".