### PR TITLE
Separate centering resampling

### DIFF
--- a/Examples/Python/GroomUtils.py
+++ b/Examples/Python/GroomUtils.py
@@ -29,7 +29,7 @@ def rename(inname, outDir, extension_addition, extension_change=''):
     print("######################################\n")
     return outname
 
-def applyIsotropicResampling(outDir, inDataList, isoSpacing=1.0, recenter=True, isBinary=True):
+def applyIsotropicResampling(outDir, inDataList, isoSpacing=1.0, isBinary=True):
     """
     This function takes in a filelist and produces the resampled files in the appropriate directory.
     """
@@ -51,8 +51,6 @@ def applyIsotropicResampling(outDir, inDataList, isoSpacing=1.0, recenter=True, 
         
         if isBinary:
             cmd.extend(["binarize"])
-        if recenter:
-            cmd.extend(["recenter-image"])
 
         cmd.extend(["write-image", "--name", outname])
         print("Calling cmd:\n"+" ".join(cmd))

--- a/Examples/Python/GroomUtils.py
+++ b/Examples/Python/GroomUtils.py
@@ -47,7 +47,7 @@ def applyIsotropicResampling(outDir, inDataList, isoSpacing=1.0, isBinary=True):
             cmd.extend(["antialias"])
         cmd.extend(["isoresample", "--isospacing", str(isoSpacing)])  
         if isBinary:
-            cmd.extend(["threshold"])
+            cmd.extend(["binarize"])
         cmd.extend(["write-image", "--name", outname])
         subprocess.check_call(cmd)
     return outDataList

--- a/Examples/Python/GroomUtils.py
+++ b/Examples/Python/GroomUtils.py
@@ -33,27 +33,22 @@ def applyIsotropicResampling(outDir, inDataList, isoSpacing=1.0, isBinary=True):
     """
     This function takes in a filelist and produces the resampled files in the appropriate directory.
     """
+    print("\n########### Resampling ###############")
     if not os.path.exists(outDir):
         os.makedirs(outDir)
     outDataList = []
     for i in range(len(inDataList)):
         inname = inDataList[i]
-        print("\n########### Resampling ###############")
         outname = rename(inname, outDir, 'isores')
         outDataList.append(outname)
-
-        cmd = ["shapeworks", "read-image", "--name", inname]
-
+        cmd = ["shapeworks", 
+               "read-image", "--name", inname]
         if isBinary:
             cmd.extend(["antialias"])
-
         cmd.extend(["isoresample", "--isospacing", str(isoSpacing)])  
-        
         if isBinary:
-            cmd.extend(["binarize"])
-
+            cmd.extend(["threshold"])
         cmd.extend(["write-image", "--name", outname])
-        print("Calling cmd:\n"+" ".join(cmd))
         subprocess.check_call(cmd)
     return outDataList
 

--- a/Examples/Python/ellipsoid.py
+++ b/Examples/Python/ellipsoid.py
@@ -82,10 +82,12 @@ def Run_Pipeline(args):
     ## GROOM : Data Pre-processing 
     For the unprepped data the first few steps are 
     -- Isotropic resampling
+    -- Center
     -- Padding
     -- Center of Mass Alignment
     -- Rigid Alignment
     -- Largest Bounding Box and Cropping 
+    For a detailed explanation of grooming steps see: https://github.com/SCIInstitute/ShapeWorks/blob/master/Documentation/Groom.md
     """
 
     print("\nStep 2. Groom - Data Pre-processing\n")
@@ -98,35 +100,23 @@ def Run_Pipeline(args):
         os.makedirs(parentDir)
 
     if int(args.start_with_prepped_data) == 0:
-        """
-        Apply isotropic resampling
 
-        For detailed explainations of parameters for resampling volumes, go to
-        ... link
-        """
+        """ Apply isotropic resampling """
         resampledFiles = applyIsotropicResampling(parentDir + "resampled", fileList)
 
-        """
-        Apply padding
+        """ Center """
+        centeredFiles = center(parentDir + "centered", resampledFiles)
 
-        For detailed explainations of parameters for padding volumes, go to
-        ... link
-        """
+        """ Apply padding"""
+        paddedFiles = applyPadding(parentDir + "padded", centeredFiles, 10)
 
-        paddedFiles = applyPadding(parentDir + "padded", resampledFiles, 10)
-
-        """
-        Apply center of mass alignment
-
-        For detailed explainations of parameters for center of mass (COM) alignment of volumes, go to
-        ... link
-        """
+        """ Apply center of mass alignment """
         comFiles = applyCOMAlignment(parentDir + "com_aligned", paddedFiles)
-        """Apply rigid alignment"""
 
+        """ Apply rigid alignment """
         rigidFiles = applyRigidAlignment(parentDir, comFiles, None, comFiles[0])
 
-        """Compute largest bounding box and apply cropping"""
+        """ Compute largest bounding box and apply cropping """
         croppedFiles = applyCropping(parentDir, rigidFiles, None)
 
     """

--- a/Examples/Python/femur.py
+++ b/Examples/Python/femur.py
@@ -55,7 +55,7 @@ def Run_Pipeline(args):
         DatasetUtils.downloadDataset(datasetName)
 
     parentDir="TestFemur/"
-    inputDir = 'TestFemur/' + datasetName + '/'
+    inputDir = 'TestFemur/' + datasetName + 'data/'
 
     if not os.path.exists(parentDir):
         os.makedirs(parentDir)
@@ -151,8 +151,8 @@ def Run_Pipeline(args):
         """
         Apply isotropic resampling - The segmentation and images are resampled independently to have uniform spacing.
         """
-        resampledFiles_segmentations = applyIsotropicResampling(parentDir + "resampled/segmentations", fileList_seg, recenter=False, isBinary=True)
-        resampledFiles_images = applyIsotropicResampling(parentDir + "resampled/images", reflectedFile_img, recenter=False, isBinary=False)
+        resampledFiles_segmentations = applyIsotropicResampling(parentDir + "resampled/segmentations", fileList_seg, isBinary=True)
+        resampledFiles_images = applyIsotropicResampling(parentDir + "resampled/images", reflectedFile_img, isBinary=False)
         """
         Apply padding - Both the segmentation and raw images are padded in case the seg lies on the image boundary.
         """

--- a/Examples/Python/left_atrium.py
+++ b/Examples/Python/left_atrium.py
@@ -40,7 +40,9 @@ def Run_Pipeline(args):
     data and create necessary supporting files. The files will be Extracted in a
     newly created Directory TestEllipsoids.
     This data is LGE segmentation of left atrium.
+    For a detailed explanation of grooming steps see: https://github.com/SCIInstitute/ShapeWorks/blob/master/Documentation/Groom.md
     """
+
     """
     Extract the zipfile into proper directory and create necessary supporting
     files
@@ -82,6 +84,7 @@ def Run_Pipeline(args):
         ## GROOM : Data Pre-processing
         For the unprepped data the first few steps are
         -- Isotropic resampling
+        -- Center
         -- Padding
         -- Center of Mass Alignment
         -- Rigid Alignment
@@ -97,14 +100,16 @@ def Run_Pipeline(args):
 
         """
         Apply isotropic resampling
-
-        For detailed explainations of parameters for resampling volumes, go to
-        'https://github.com/SCIInstitute/ShapeWorks/blob/master/Prep/Documentation/ImagePrepTools.pdf'
-
         the segmentation and images are resampled independently and the result files are saved in two different directories.
         """
         resampledFiles_segmentations = applyIsotropicResampling(parentDir + "resampled/segmentations", fileList_seg, isBinary=True)
         resampledFiles_images = applyIsotropicResampling(parentDir + "resampled/images", fileList_img, isBinary=False)
+
+        """
+        Centering
+        """
+        centeredFiles_segmentations = center(parentDir + "centered/segmentations", resampledFiles_segmentations)
+        centeredFiles_images = center(parentDir + "centered/images", resampledFiles_images)
 
         """
         Apply padding
@@ -114,8 +119,8 @@ def Run_Pipeline(args):
 
         Both the segmentation and raw images are padded.
         """
-        paddedFiles_segmentations = applyPadding(parentDir + 'padded/segmentations', resampledFiles_segmentations, 10)
-        paddedFiles_images = applyPadding(parentDir+ 'padded/images', resampledFiles_images, 10)
+        paddedFiles_segmentations = applyPadding(parentDir + 'padded/segmentations', centeredFiles_segmentations, 10)
+        paddedFiles_images = applyPadding(parentDir+ 'padded/images', centeredFiles_images, 10)
 
         """
         Apply center of mass alignment
@@ -205,6 +210,11 @@ def Run_Pipeline(args):
             resampledFiles = applyIsotropicResampling(parentDir + "resampled", fileList_seg)
 
             """
+            Centering
+            """
+            centeredFiles = center(parentDir + "centered", resampledFiles)
+
+            """
             Apply padding
 
             For detailed explainations of parameters for padding volumes, go to
@@ -212,7 +222,7 @@ def Run_Pipeline(args):
 
             """
 
-            paddedFiles = applyPadding(parentDir + "padded", resampledFiles, 10)
+            paddedFiles = applyPadding(parentDir + "padded", centeredFiles, 10)
 
             """
             Apply center of mass alignment

--- a/Testing/PythonTests/PythonTests.cpp
+++ b/Testing/PythonTests/PythonTests.cpp
@@ -42,7 +42,7 @@ TEST(PythonTests, tiny_test) {
 
   // check that one of the resulting files exists
   std::string check_file = python_examples_location +
-                           "/TestEllipsoids/PointFiles/32/seg.ellipsoid_0.isores.pad.com.aligned.cropped.tpSmoothDT_local.particles";
+                           "/TestEllipsoids/PointFiles/32/seg.ellipsoid_0.isores.center.pad.com.aligned.cropped.tpSmoothDT_local.particles";
 
   // change to the python examples directory
   chdir(python_examples_location.c_str());


### PR DESCRIPTION
I removed the recenter call from applyIsotropicResampling in GroomUtils.py and had the use cases call the "center" function in GroomUtils if they needed it. I also fixed the girder naming issue Alan mentioned for the femur use case.
I tested this on all of the use cases and this change did not effect the results.
