### PR TITLE
Reduce memory usage in inverse covariance matrix

### DIFF
--- a/Libs/Optimize/CMakeLists.txt
+++ b/Libs/Optimize/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(Optimize
   trimesh2
   Mesh
   tinyxml
+  Utils
   Particles)
 
 target_include_directories(Optimize PUBLIC

--- a/Libs/Optimize/ParticleSystem/itkParticleEnsembleEntropyFunction.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleEnsembleEntropyFunction.h
@@ -191,9 +191,9 @@ protected:
     m_RecomputeCovarianceInterval = 1;
     m_Counter = 0;
     m_UseMeanEnergy = true;
-    m_PointsUpdate = new vnl_matrix_type(10,10);
-    m_InverseCovMatrix = new vnl_matrix_type(10,10);
-    m_points_mean = new vnl_matrix_type(10,10);
+    m_PointsUpdate = std::make_shared<vnl_matrix_type>(10, 10);
+    m_InverseCovMatrix = std::make_shared<vnl_matrix_type>(10, 10);
+    m_points_mean = std::make_shared<vnl_matrix_type>(10, 10);
   }
   virtual ~ParticleEnsembleEntropyFunction() {}
   void operator=(const ParticleEnsembleEntropyFunction &);
@@ -201,7 +201,7 @@ protected:
   typename ShapeMatrixType::Pointer m_ShapeMatrix;
 
   virtual void ComputeCovarianceMatrix();
-  vnl_matrix_type * m_PointsUpdate;
+  std::shared_ptr<vnl_matrix_type> m_PointsUpdate;
   double m_MinimumVariance;
   double m_MinimumEigenValue;
   double m_CurrentEnergy;
@@ -211,8 +211,8 @@ protected:
   int m_Counter;
   bool m_UseMeanEnergy;
 
-  vnl_matrix_type * m_InverseCovMatrix; // 3Nx3N - used for energy computation
-  vnl_matrix_type * m_points_mean; //3NxM - used for energy computation
+  std::shared_ptr<vnl_matrix_type> m_points_mean; // 3Nx3N - used for energy computation
+  std::shared_ptr<vnl_matrix_type> m_InverseCovMatrix; //3NxM - used for energy computation
 
 };
 

--- a/Libs/Optimize/ParticleSystem/itkParticleEnsembleEntropyFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleEnsembleEntropyFunction.txx
@@ -18,7 +18,7 @@
 #include "itkParticleImageDomainWithGradients.h"
 #include "vnl/algo/vnl_symmetric_eigensystem.h"
 #include "itkParticleGaussianModeWriter.h"
-#include "Utils.h"
+#include "Libs/Utils/Utils.h"
 #include <string>
 
 namespace itk

--- a/Libs/Optimize/ParticleSystem/itkParticleEnsembleEntropyFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleEnsembleEntropyFunction.txx
@@ -143,7 +143,7 @@ ParticleEnsembleEntropyFunction<VDimension>
 
         vnl_matrix_type projMat = points_minus_mean * UG;
         const auto lhs = projMat * invLambda;
-        const auto rhs = invLambda * projMat.transpose();
+        const auto rhs = invLambda * projMat.transpose(); // invLambda doesn't need to be transposed since its a diagonal matrix
         m_InverseCovMatrix->set_size(num_dims, num_dims);
         Utils::multiply_into(*m_InverseCovMatrix, lhs, rhs);
     }

--- a/Libs/Optimize/ParticleSystem/itkParticleEnsembleEntropyFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleEnsembleEntropyFunction.txx
@@ -147,7 +147,7 @@ ParticleEnsembleEntropyFunction<VDimension>
         m_InverseCovMatrix->set_size(num_dims, num_dims);
         Utils::multiply_into(*m_InverseCovMatrix, lhs, rhs);
     }
-  m_PointsUpdate->update(points_minus_mean * pinvMat);
+    m_PointsUpdate->update(points_minus_mean * pinvMat);
 
 //     std::cout << m_PointsUpdate.extract(num_dims, num_samples,0,0) << std::endl;
 

--- a/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
@@ -97,7 +97,7 @@ ParticleMeshBasedGeneralEntropyGradientFunction<VDimension>
 
         vnl_matrix_type projMat = points_minus_mean * UG;
         const auto lhs = projMat * invLambda;
-        const auto rhs = invLambda * projMat.transpose();
+        const auto rhs = invLambda * projMat.transpose(); // invLambda doesn't need to be transposed since its a diagonal matrix
         m_InverseCovMatrix->set_size(num_dims, num_dims);
         Utils::multiply_into(*m_InverseCovMatrix, lhs, rhs);
     }

--- a/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
@@ -56,7 +56,6 @@ ParticleMeshBasedGeneralEntropyGradientFunction<VDimension>
 
     vnl_diag_matrix<double> W;
 
-    m_InverseCovMatrix->set_size(num_dims, num_dims);
     m_InverseCovMatrix->fill(0.0);
     vnl_matrix_type gramMat(num_samples, num_samples, 0.0);
     vnl_matrix_type pinvMat(num_samples, num_samples, 0.0); //gramMat inverse
@@ -64,7 +63,8 @@ ParticleMeshBasedGeneralEntropyGradientFunction<VDimension>
     if (this->m_UseMeanEnergy)
     {
         pinvMat.set_identity();
-        m_InverseCovMatrix->clear(); //set_identity();
+        m_InverseCovMatrix->set_size(num_dims, num_dims);
+        m_InverseCovMatrix->clear(); //set_identity(); //TODO: this line might be unnecessary
     }
     else
     {
@@ -98,9 +98,7 @@ ParticleMeshBasedGeneralEntropyGradientFunction<VDimension>
         pinvMat = (UG * invLambda) * UG.transpose();
 
         vnl_matrix_type projMat = points_minus_mean * UG;
-        vnl_matrix_type projMat2 = projMat * invLambda;
-        projMat2 = projMat2 * projMat2.transpose();
-        m_InverseCovMatrix->update(projMat2);
+        *m_InverseCovMatrix = (projMat * invLambda) * (invLambda * projMat.transpose());
     }
 
     vnl_matrix_type Q = points_minus_mean * pinvMat;

--- a/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
@@ -15,7 +15,7 @@
 #include <time.h>
 #include "itkParticleImageDomainWithGradients.h"
 #include "itkParticleImageDomainWithHessians.h"
-#include "Utils.h"
+#include "Libs/Utils/Utils.h"
 
 namespace itk
 {

--- a/Libs/Utils/CMakeLists.txt
+++ b/Libs/Utils/CMakeLists.txt
@@ -11,6 +11,9 @@ add_library(Utils STATIC
 target_include_directories(Utils PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:include>)
+target_link_libraries(Utils PUBLIC
+  Eigen3::Eigen)
+
 
 # Install
 set_target_properties(Utils PROPERTIES PUBLIC_HEADER

--- a/Libs/Utils/Utils.cpp
+++ b/Libs/Utils/Utils.cpp
@@ -440,7 +440,7 @@ std::string Utils::int2str(int n, int number_of_zeros)
 // is slightly faster.
 template<typename T>
 void Utils::multiply_into(vnl_matrix<T> &out, const vnl_matrix<T> &lhs, const vnl_matrix<T> &rhs) {
-  typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> RowMajorMatrix;
+  typedef Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> RowMajorMatrix;
   Eigen::Map<RowMajorMatrix> eig_out(out.data_block(), out.rows(), out.cols());
   Eigen::Map<const RowMajorMatrix> eig_lhs(lhs.data_block(), lhs.rows(), lhs.cols());
   Eigen::Map<const RowMajorMatrix> eig_rhs(rhs.data_block(), rhs.rows(), rhs.cols());

--- a/Libs/Utils/Utils.cpp
+++ b/Libs/Utils/Utils.cpp
@@ -438,9 +438,9 @@ std::string Utils::int2str(int n, int number_of_zeros)
 template<typename T>
 void Utils::multiply_into(vnl_matrix<T> &out, const vnl_matrix<T> &lhs, const vnl_matrix<T> &rhs) {
 #ifndef NDEBUG
-  if (lhs.num_cols != rhs.num_rows)
-      vnl_error_matrix_dimension("vnl_matrix<T>::operator*", lhs.num_rows, lhs.num_cols,
-                                 rhs.num_rows, rhs.num_cols);
+  if (lhs.cols() != rhs.rows())
+      vnl_error_matrix_dimension("Utils::multiply_into", lhs.rows(), lhs.cols(),
+                                 rhs.rows(), rhs.cols());
 #endif
 
   const unsigned int l = lhs.rows();

--- a/Libs/Utils/Utils.cpp
+++ b/Libs/Utils/Utils.cpp
@@ -431,6 +431,36 @@ std::string Utils::int2str(int n, int number_of_zeros)
     return s;
 }
 
+//--------------- linear algebra -------------------------------------------
+// Copied version of https://github.com/vxl/vxl/blob/5df3b4a335d921bb4f25031e31b08d8f3c557641/core/vnl/vnl_matrix.h#L376
+// but avoids allocating a new buffer for the output. Assumes `out` has sufficient size.
+// Tracked by issue: https://github.com/vxl/vxl/issues/778
+template<typename T>
+void Utils::multiply_into(vnl_matrix<T> &out, const vnl_matrix<T> &lhs, const vnl_matrix<T> &rhs) {
+#ifndef NDEBUG
+  if (lhs.num_cols != rhs.num_rows)
+      vnl_error_matrix_dimension("vnl_matrix<T>::operator*", lhs.num_rows, lhs.num_cols,
+                                 rhs.num_rows, rhs.num_cols);
+#endif
+
+  const unsigned int l = lhs.rows();
+  const unsigned int m = lhs.cols();
+  const unsigned int n = rhs.cols();
+
+  for (unsigned int i = 0; i < l; ++i) {
+    for (unsigned int k = 0; k < n; ++k) {
+      T sum{0};
+      for (unsigned int j = 0; j < m; ++j)
+        sum += T(lhs[i][j] * rhs[j][k]);
+      out[i][k] = sum;
+    }
+  }
+}
+
+// Explicitly instantiate this function templatized over double
+template void
+Utils::multiply_into(vnl_matrix<double> &, const vnl_matrix<double> &, const vnl_matrix<double> &);
+
 
 //--------------- average normal directions --------------------------------
 

--- a/Libs/Utils/Utils.h
+++ b/Libs/Utils/Utils.h
@@ -33,6 +33,7 @@
 #include <vtkPoints.h>
 #include <itkImage.h>
 #include <itkPoint.h>
+#include <vnl/vnl_matrix.h>
 
 namespace utils
 {

--- a/Libs/Utils/Utils.h
+++ b/Libs/Utils/Utils.h
@@ -114,7 +114,13 @@ public:
     static std::vector<double> linspace(double a, double b, size_t N);
     static std::string int2str(int n, int number_of_zeros);
 
-    //--------------- average normal directions --------------------------------
+    //--------------- linear algebra -------------------------------------------
+
+    // matrix multiplication without an allocation for the output
+    template<typename T>
+    static void multiply_into(vnl_matrix<T> &out, const vnl_matrix<T> &lhs, const vnl_matrix<T> &rhs);
+
+  //--------------- average normal directions --------------------------------
     /**
      * Given a set of theta measurements, pick the "average" (approximately).
      *

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -111,9 +111,10 @@ build_vxl()
   git clone https://github.com/vxl/vxl.git
   cd vxl
   # They fixed the VS compilation problem the day after the v2.0.2 release.
+  # Also, move constructors were added in 2019,
   # There hasn't been a release since
   # git checkout -f tags/${VXL_VER}
-  git checkout -f c3fd27959f51e0469a7a6075e975f245ac306f3d
+  git checkout -f 5df3b4a335d921bb4f25031e31b08d8f3c557641
 
   if [[ $BUILD_CLEAN = 1 ]]; then rm -rf build; fi
   mkdir -p build && cd build

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -111,10 +111,9 @@ build_vxl()
   git clone https://github.com/vxl/vxl.git
   cd vxl
   # They fixed the VS compilation problem the day after the v2.0.2 release.
-  # Also, move constructors were added in 2019,
   # There hasn't been a release since
   # git checkout -f tags/${VXL_VER}
-  git checkout -f 5df3b4a335d921bb4f25031e31b08d8f3c557641
+  git checkout -f c3fd27959f51e0469a7a6075e975f245ac306f3d
 
   if [[ $BUILD_CLEAN = 1 ]]; then rm -rf build; fi
   mkdir -p build && cd build


### PR DESCRIPTION
This reduces memory usage in itkParticleGeneralMeshBasedGeneralEntropyGradientFunction when mesh_attributes is enabled. Avoids some copies, some allocations, and reordered/expanded matrix operations to run faster. In the pelvis case, memory requirement for the particle system has reduced from ~14GB to ~5GB. Iteration time seems to have reduced by about 50% in the same use case.

Same fixes implemented in itkParticleEnsembleEntropyFunction.