### PR TITLE
Reduce fixed domain memory usage

### DIFF
--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1881,7 +1881,7 @@ void Optimize::SetImages(const std::vector<ImageType::Pointer> &images)
 {
   this->m_images = images;
   this->m_sampler->SetImages(images);
-  ImageType::Pointer first_image = images[i];
+  ImageType::Pointer first_image = images[0];
   this->m_sampler->SetInput(0, first_image);                // set the 0th input
   this->m_spacing = first_image->GetSpacing()[0];
   this->m_num_shapes = images.size();

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -181,6 +181,10 @@ void Optimize::SetParameters()
           m_sampler->GetParticleSystem()->GetDomain(m_domain_flags[i])->DeleteImages();
         }
       }
+      else
+      {
+        m_sampler->GetParticleSystem()->GetDomain(m_domain_flags[i])->DeleteImages();
+      }
     }
   }
 

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -301,7 +301,6 @@ void Optimize::SetUseXYZ(std::vector<bool> use_xyz)
 //---------------------------------------------------------------------------
 void Optimize::SetUseNormals(std::vector<bool> use_normals)
 {
-  std::cerr << "size = " << use_normals.size() << "\n";
   this->m_use_normals = use_normals;
 }
 

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1961,7 +1961,7 @@ void Optimize::SetDomainFlags(std::vector<int> flags)
 }
 
 //---------------------------------------------------------------------------
-std::vector<int> Optimize::GetDomainFlags()
+const std::vector<int> &Optimize::GetDomainFlags()
 {
   return this->m_domain_flags;
 }

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -297,6 +297,7 @@ void Optimize::SetUseXYZ(std::vector<bool> use_xyz)
 //---------------------------------------------------------------------------
 void Optimize::SetUseNormals(std::vector<bool> use_normals)
 {
+  std::cerr << "size = " << use_normals.size() << "\n";
   this->m_use_normals = use_normals;
 }
 

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1885,7 +1885,6 @@ void Optimize::SetImages(const std::vector<ImageType::Pointer> &images)
   this->m_sampler->SetInput(0, first_image);                // set the 0th input
   this->m_spacing = first_image->GetSpacing()[0];
   this->m_num_shapes = images.size();
-  break;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -174,7 +174,8 @@ void Optimize::SetParameters()
     for (int i = 0; i < m_domain_flags.size(); i++) {
       if (m_use_normals.size() > 0) {
         if (m_use_normals[i % m_domains_per_shape]) {
-          m_sampler->GetParticleSystem()->GetDomain(m_domain_flags[i])->DeletePartialDerivativeImages();
+          m_sampler->GetParticleSystem()->GetDomain(m_domain_flags[i])->
+          DeletePartialDerivativeImages();
         }
         else {
           m_sampler->GetParticleSystem()->GetDomain(m_domain_flags[i])->DeleteImages();
@@ -1392,8 +1393,10 @@ void Optimize::WritePointFilesWithFeatures(std::string iter_prefix)
     }
 
     // Only run the following code if we are dealing with ImplicitSurfaceDomains
-    const itk::ParticleImplicitSurfaceDomain < float, 3 > *domain
-          = dynamic_cast <const itk::ParticleImplicitSurfaceDomain < float, 3 >*> (m_sampler->GetParticleSystem()->GetDomain(i));
+    const itk::ParticleImplicitSurfaceDomain < float, 3 >* domain
+      = dynamic_cast <const itk::ParticleImplicitSurfaceDomain < float,
+                                                                 3 >*> (m_sampler->GetParticleSystem()
+                                                                        ->GetDomain(i));
     if (domain) {
       std::vector < float > fVals;
 
@@ -1406,13 +1409,15 @@ void Optimize::WritePointFilesWithFeatures(std::string iter_prefix)
         }
 
         if (m_use_normals[i % m_domains_per_shape]) {
-          typename itk::ParticleImageDomainWithGradients < float, 3 > ::VnlVectorType pG = domain->SampleNormalVnl(pos);
+          typename itk::ParticleImageDomainWithGradients < float,
+                                                           3 > ::VnlVectorType pG =
+            domain->SampleNormalVnl(pos);
           VectorType pN;
           pN[0] = pG[0]; pN[1] = pG[1]; pN[2] = pG[2];
           pN = m_sampler->GetParticleSystem()->TransformVector(pN,
-            m_sampler->GetParticleSystem()->GetTransform(
-              i) * m_sampler->GetParticleSystem()->GetPrefixTransform(
-                i));
+                                                               m_sampler->GetParticleSystem()->GetTransform(
+                                                                 i) * m_sampler->GetParticleSystem()->GetPrefixTransform(
+                                                                 i));
           outw << pN[0] << " " << pN[1] << " " << pN[2] << " ";
         }
 
@@ -1876,10 +1881,11 @@ void Optimize::SetImages(const std::vector<ImageType::Pointer> &images)
 {
   this->m_images = images;
   this->m_sampler->SetImages(images);
-  ImageType::Pointer first_image = images[0];
-  this->m_sampler->SetInput(0, first_image);            // set the 0th input
+  ImageType::Pointer first_image = images[i];
+  this->m_sampler->SetInput(0, first_image);                // set the 0th input
   this->m_spacing = first_image->GetSpacing()[0];
   this->m_num_shapes = images.size();
+  break;
 }
 
 //---------------------------------------------------------------------------
@@ -1946,6 +1952,12 @@ void Optimize::SetParticleFlags(std::vector<int> flags)
 void Optimize::SetDomainFlags(std::vector<int> flags)
 {
   this->m_domain_flags = flags;
+}
+
+//---------------------------------------------------------------------------
+std::vector<int> Optimize::GetDomainFlags()
+{
+  return this->m_domain_flags;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -392,6 +392,7 @@ void Optimize::InitializeSampler()
   float nbhd_to_sigma = 3.0;   // 3.0 -> 1.0
   float flat_cutoff = 0.3;   // 0.3 -> 0.85
 
+
   m_sampler->SetPairwisePotentialType(m_pairwise_potential_type);
 
   m_sampler->GetGradientFunction()->SetFlatCutoff(flat_cutoff);
@@ -438,15 +439,17 @@ void Optimize::InitializeSampler()
   m_sampler->GetEnsembleMixedEffectsEntropyFunction()
   ->SetRecomputeCovarianceInterval(m_recompute_regularization_interval);
 
+
+  // These flags must be set before Initialize, since Initialize need to know which domains are fixed ahead of time
+  for (unsigned int i = 0; i < this->m_domain_flags.size(); i++) {
+    this->GetSampler()->GetParticleSystem()->FlagDomain(this->m_domain_flags[i]);
+  }
+
   m_sampler->Initialize();
 
   m_sampler->GetOptimizer()->SetTolerance(0.0);
 
   // These flags have to be set after Initialize, since Initialize will set them all to zero
-  for (unsigned int i = 0; i < this->m_domain_flags.size(); i++) {
-    this->GetSampler()->GetParticleSystem()->FlagDomain(this->m_domain_flags[i]);
-  }
-
   for (unsigned int i = 0; i < this->m_particle_flags.size() / 2; i++) {
     this->GetSampler()->GetParticleSystem()
     ->SetFixedParticleFlag(this->m_particle_flags[2 * i], this->m_particle_flags[2 * i + 1]);

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -222,6 +222,8 @@ public:
   //! Set Domain Flags (TODO: details)
   void SetDomainFlags(std::vector<int> flags);
 
+  std::vector<int> GetDomainFlags();
+
   //! Set if file output is enabled
   void SetFileOutputEnabled(bool enabled);
 

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -222,7 +222,7 @@ public:
   //! Set Domain Flags (TODO: details)
   void SetDomainFlags(std::vector<int> flags);
 
-  std::vector<int> GetDomainFlags();
+  const std::vector<int>& GetDomainFlags();
 
   //! Set if file output is enabled
   void SetFileOutputEnabled(bool enabled);

--- a/Libs/Optimize/OptimizeParameterFile.cpp
+++ b/Libs/Optimize/OptimizeParameterFile.cpp
@@ -132,6 +132,7 @@ bool OptimizeParameterFile::set_io_parameters(TiXmlHandle* docHandle, Optimize* 
   bool use_mesh_based_attributes = false;
   std::vector<bool> use_xyz;
   std::vector<bool> use_normals;
+  std::cerr << "use_normals...\n";
 
   elem = docHandle->FirstChild("mesh_based_attributes").Element();
   if (elem) { use_mesh_based_attributes = (bool) atoi(elem->GetText());}
@@ -154,6 +155,7 @@ bool OptimizeParameterFile::set_io_parameters(TiXmlHandle* docHandle, Optimize* 
 
     elem = docHandle->FirstChild("use_normals").Element();
     if (elem) {
+      std::cerr << "use_normals...yes\n";
       std::istringstream inputsBuffer;
       std::string num;
       inputsBuffer.str(elem->GetText());
@@ -168,7 +170,12 @@ bool OptimizeParameterFile::set_io_parameters(TiXmlHandle* docHandle, Optimize* 
         return false;
       }
     }
+    else
+    {
+      std::cerr << "use_normals...no\n";
+    }
   }
+  std::cerr << "use_normals size = " << use_normals.size() << "\n";
 
   optimize->SetUseMeshBasedAttributes(use_mesh_based_attributes);
   optimize->SetUseXYZ(use_xyz);

--- a/Libs/Optimize/OptimizeParameterFile.cpp
+++ b/Libs/Optimize/OptimizeParameterFile.cpp
@@ -71,10 +71,6 @@ bool OptimizeParameterFile::load_parameter_file(std::string filename, Optimize* 
     return false;
   }
 
-  if (!this->read_inputs(&doc_handle, optimize)) {
-    return false;
-  }
-
   if (!this->read_mesh_inputs(&doc_handle, optimize)) {
     return false;
   }
@@ -92,6 +88,11 @@ bool OptimizeParameterFile::load_parameter_file(std::string filename, Optimize* 
   }
 
   if (!this->read_flag_domains(&doc_handle, optimize)) {
+    return false;
+  }
+
+  // read last so that we can skip loading any images from fixed domains
+  if (!this->read_inputs(&doc_handle, optimize)) {
     return false;
   }
 
@@ -302,6 +303,7 @@ bool OptimizeParameterFile::set_debug_parameters(TiXmlHandle* docHandle, Optimiz
 //---------------------------------------------------------------------------
 bool OptimizeParameterFile::read_inputs(TiXmlHandle* docHandle, Optimize* optimize)
 {
+  std::cerr << "read_inputs\n";
 
   TiXmlElement* elem = nullptr;
 
@@ -316,36 +318,68 @@ bool OptimizeParameterFile::read_inputs(TiXmlHandle* docHandle, Optimize* optimi
   int numShapes = 0;
 
   // load input shapes
-  std::vector < std::string > shapeFiles;
+  std::vector < std::string > shape_files;
   std::vector < Optimize::ImageType::Pointer > images;
 
   inputsBuffer.str(elem->GetText());
+
+  auto flags = optimize->GetDomainFlags();
+
+  int index = 0;
   while (inputsBuffer >> filename) {
 
-    if (this->verbosity_level_ > 1) {
-      std::cout << "Reading inputfile: " << filename << "...\n" << std::flush;
-    }
-    typename itk::ImageFileReader < Optimize::ImageType > ::Pointer reader = itk::ImageFileReader <
-      Optimize::ImageType > ::New();
-    reader->SetFileName(filename);
-    reader->UpdateLargestPossibleRegion();
-    images.push_back(reader->GetOutput());
+    shape_files.push_back(filename);
 
-    shapeFiles.push_back(filename);
+    bool fixed_domain = false;
+    for (int i = 0; i < flags.size(); i++) {
+      if (flags[i] == index) {
+        fixed_domain = true;
+      }
+    }
+
+    if (!fixed_domain) {
+      if (this->verbosity_level_ > 1) {
+        std::cout << "Reading inputfile: " << filename << "...\n" << std::flush;
+      }
+      typename itk::ImageFileReader < Optimize::ImageType > ::Pointer reader = itk::ImageFileReader <
+        Optimize::ImageType > ::New();
+      reader->SetFileName(filename);
+      reader->UpdateLargestPossibleRegion();
+      images.push_back(reader->GetOutput());
+    }
+    else {
+      images.push_back(nullptr);
+    }
+    index++;
   }
+
+  // now fill in null pointers with the first valid image
+  Optimize::ImageType::Pointer first_image;
+
+  for (int i = 0; i < images.size(); i++) {
+    if (images[i]) {
+      first_image = images[i];
+    }
+  }
+  for (int i = 0; i < images.size(); i++) {
+    if (!images[i]) {
+      images[i] = first_image;
+    }
+  }
+
 
   inputsBuffer.clear();
   inputsBuffer.str("");
 
-  numShapes = shapeFiles.size();
+  numShapes = shape_files.size();
 
   optimize->SetImages(images);
 
   std::vector < std::string > filenames;
 
   for (int i = 0; i < numShapes; i++) {
-    char* str = new char[shapeFiles[i].length() + 1];
-    strcpy(str, shapeFiles[i].c_str());
+    char* str = new char[shape_files[i].length() + 1];
+    strcpy(str, shape_files[i].c_str());
 
     char* fname;
     char* pch;

--- a/Libs/Optimize/OptimizeParameterFile.cpp
+++ b/Libs/Optimize/OptimizeParameterFile.cpp
@@ -132,7 +132,6 @@ bool OptimizeParameterFile::set_io_parameters(TiXmlHandle* docHandle, Optimize* 
   bool use_mesh_based_attributes = false;
   std::vector<bool> use_xyz;
   std::vector<bool> use_normals;
-  std::cerr << "use_normals...\n";
 
   elem = docHandle->FirstChild("mesh_based_attributes").Element();
   if (elem) { use_mesh_based_attributes = (bool) atoi(elem->GetText());}
@@ -170,12 +169,7 @@ bool OptimizeParameterFile::set_io_parameters(TiXmlHandle* docHandle, Optimize* 
         return false;
       }
     }
-    else
-    {
-      std::cerr << "use_normals...no\n";
-    }
   }
-  std::cerr << "use_normals size = " << use_normals.size() << "\n";
 
   optimize->SetUseMeshBasedAttributes(use_mesh_based_attributes);
   optimize->SetUseXYZ(use_xyz);

--- a/Libs/Optimize/OptimizeParameterFile.cpp
+++ b/Libs/Optimize/OptimizeParameterFile.cpp
@@ -303,8 +303,6 @@ bool OptimizeParameterFile::set_debug_parameters(TiXmlHandle* docHandle, Optimiz
 //---------------------------------------------------------------------------
 bool OptimizeParameterFile::read_inputs(TiXmlHandle* docHandle, Optimize* optimize)
 {
-  std::cerr << "read_inputs\n";
-
   TiXmlElement* elem = nullptr;
 
   elem = docHandle->FirstChild("inputs").Element();

--- a/Libs/Optimize/ParticleSystem/itkMaximumEntropySurfaceSampler.txx
+++ b/Libs/Optimize/ParticleSystem/itkMaximumEntropySurfaceSampler.txx
@@ -101,7 +101,9 @@ MaximumEntropySurfaceSampler<TImage>::AllocateDomainsAndNeighborhoods()
 
         m_DomainList[i]->SetSigma(img_temp->GetSpacing()[0] * 2.0);
 
-        m_DomainList[i]->SetImage(img_temp);
+
+        bool minimal_load = m_ParticleSystem->GetDomainFlag(i);
+        m_DomainList[i]->SetImage(img_temp, minimal_load);
 
         if (m_CuttingPlanes.size() > i)
         {

--- a/Libs/Optimize/ParticleSystem/itkMaximumEntropySurfaceSampler.txx
+++ b/Libs/Optimize/ParticleSystem/itkMaximumEntropySurfaceSampler.txx
@@ -103,6 +103,7 @@ MaximumEntropySurfaceSampler<TImage>::AllocateDomainsAndNeighborhoods()
 
 
         bool minimal_load = m_ParticleSystem->GetDomainFlag(i);
+
         m_DomainList[i]->SetImage(img_temp, minimal_load);
 
         if (m_CuttingPlanes.size() > i)

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomain.h
@@ -41,7 +41,7 @@ public:
 
   /** Set/Get the itk::Image specifying the particle domain.  The set method
       modifies the parent class LowerBound and UpperBound. */
-  void SetImage(ImageType *I)
+  void SetImage(ImageType *I, bool minimal)
   {
     this->Modified();
     m_Image = I;

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithCurvature.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithCurvature.h
@@ -41,10 +41,14 @@ public:
 
   /** Set/Get the itk::Image specifying the particle domain.  The set method
       modifies the parent class LowerBound and UpperBound. */
-  void SetImage(ImageType *I)
+  void SetImage(ImageType *I, bool minimal)
   {
     // Computes partial derivatives in parent class
-    Superclass::SetImage(I);
+    Superclass::SetImage(I, minimal);
+
+    if (minimal) {
+      return;
+    }
 
     typename DiscreteGaussianImageFilter<ImageType, ImageType>::Pointer f = DiscreteGaussianImageFilter<ImageType, ImageType>::New();
 
@@ -80,12 +84,18 @@ public:
     // Release the memory in the parent hessian images.
     //this->DeletePartialDerivativeImages();
     
+    m_CurvatureInterpolator = ScalarInterpolatorType::New();
     m_CurvatureInterpolator->SetInputImage(m_CurvatureImage);
   } // end setimage
   
   double GetCurvature(const PointType &pos) const
   {
-    return m_CurvatureInterpolator->Evaluate(pos);
+    if (m_CurvatureInterpolator) {
+      return m_CurvatureInterpolator->Evaluate(pos);
+    }
+    else {
+      return 0;
+    }
   }
   
   typename ImageType::Pointer* GetCurvatureImage() { return m_CurvatureImage; }
@@ -93,8 +103,6 @@ public:
 protected:
   ParticleImageDomainWithCurvature()
   {
-    m_CurvatureInterpolator = ScalarInterpolatorType::New();
-    m_CurvatureImage = ImageType::New();
   }
   virtual ~ParticleImageDomainWithCurvature() {};
 

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithGradients.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithGradients.h
@@ -47,9 +47,9 @@ public:
 
   /** Set/Get the itk::Image specifying the particle domain.  The set method
       modifies the parent class LowerBound and UpperBound. */
-  void SetImage(ImageType *I)
+  void SetImage(ImageType *I, bool minimal)
   {
-    ParticleImageDomain<T, VDimension>::SetImage(I);
+    ParticleImageDomain<T, VDimension>::SetImage(I, minimal);
  
     // Compute gradient image and set up gradient interpolation.
     typename GradientImageFilterType::Pointer filter = GradientImageFilterType::New();

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithGradients.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithGradients.h
@@ -51,6 +51,10 @@ public:
   {
     ParticleImageDomain<T, VDimension>::SetImage(I, minimal);
  
+    if (minimal) {
+      return;
+    }
+
     // Compute gradient image and set up gradient interpolation.
     typename GradientImageFilterType::Pointer filter = GradientImageFilterType::New();
     filter->SetInput(I);

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithHessians.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithHessians.h
@@ -52,8 +52,7 @@ public:
   {
     Superclass::SetImage(I, minimal);
 
-    if (minimal)
-    {
+    if (minimal) {
       return;
     }
     

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithHessians.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithHessians.h
@@ -48,9 +48,14 @@ public:
 
   /** Set/Get the itk::Image specifying the particle domain.  The set method
       modifies the parent class LowerBound and UpperBound. */
-  void SetImage(ImageType *I)
+  void SetImage(ImageType *I, bool minimal)
   {
-    Superclass::SetImage(I);
+    Superclass::SetImage(I, minimal);
+
+    if (minimal)
+    {
+      return;
+    }
     
     typename DiscreteGaussianImageFilter<ImageType, ImageType>::Pointer
       gaussian = DiscreteGaussianImageFilter<ImageType, ImageType>::New();

--- a/Libs/Optimize/ParticleSystem/itkParticleMeanCurvatureAttribute.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleMeanCurvatureAttribute.h
@@ -81,7 +81,10 @@ public:
     m_CurvatureStandardDeviationList.push_back(0.0);
     const ParticleDomainAddEvent &event = dynamic_cast<const ParticleDomainAddEvent &>(e);
     const ParticleSystemType *ps= dynamic_cast<const ParticleSystemType *>(o);
-    this->ComputeCurvatureStatistics(ps, event.GetDomainIndex());
+
+    if (!ps->GetDomainFlag(event.GetDomainIndex())) {
+      this->ComputeCurvatureStatistics(ps, event.GetDomainIndex());
+    }
   }
 
   /** */

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.h
@@ -373,7 +373,13 @@ public:
   void UnflagDomain(unsigned int i)
   { m_DomainFlags[i] = false; }
   bool GetDomainFlag(unsigned int i) const
-  { return m_DomainFlags[i]; }
+  {
+    if (i >= m_DomainFlags.size()) {
+      // not set
+      return false;
+    }
+    return m_DomainFlags[i];
+  }
   const std::vector<bool> &GetDomainFlags() const
   { return m_DomainFlags; }
   void SetDomainFlags()

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.h
@@ -361,7 +361,15 @@ public:
   /** Flag/Unflag a domain.  Flagging a domain has different meanings according
       to the application using this particle system. */
   void FlagDomain(unsigned int i)
-  { m_DomainFlags[i] = true; }
+  {
+    // ensure large enough
+    while (i >= this->m_DomainFlags.size()) {
+      m_DomainFlags.push_back(false);
+    }
+
+    // set the flag
+    m_DomainFlags[i] = true;
+  }
   void UnflagDomain(unsigned int i)
   { m_DomainFlags[i] = false; }
   bool GetDomainFlag(unsigned int i) const

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
@@ -228,7 +228,6 @@ ParticleSystem<VDimension>
 ::AddPositionList(const std::vector<PointType> &p,
                                             unsigned int d, int threadId )
 {
-  std::cerr << "AddPositionList\n";
   // Traverse the list and add each point to the domain.
   for (typename std::vector<PointType>::const_iterator it= p.begin();
        it != p.end(); it++)

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
@@ -44,7 +44,6 @@ ParticleSystem<VDimension>
   m_Positions.resize(num);
   m_IndexCounters.resize(num);
   m_Neighborhoods.resize(num);
-  //m_DomainFlags.resize(num);
   while(num >= this->m_DomainFlags.size()) {
     m_DomainFlags.push_back(false);
   }
@@ -77,7 +76,6 @@ void ParticleSystem<VDimension>
   m_InverseTransforms[static_cast<int>( m_Domains.size() -1)].set_identity();
   m_PrefixTransforms[static_cast<int>( m_Domains.size() -1)].set_identity();
   m_InversePrefixTransforms[static_cast<int>( m_Domains.size() -1)].set_identity();
-  //m_DomainFlags[static_cast<int>( m_Domains.size() -1)] = false;
   
   // Notify any observers.
   ParticleDomainAddEvent e;

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
@@ -44,7 +44,10 @@ ParticleSystem<VDimension>
   m_Positions.resize(num);
   m_IndexCounters.resize(num);
   m_Neighborhoods.resize(num);
-  m_DomainFlags.resize(num);
+  //m_DomainFlags.resize(num);
+  while(num >= this->m_DomainFlags.size()) {
+    m_DomainFlags.push_back(false);
+  }
   this->Modified();
 }
 
@@ -74,7 +77,7 @@ void ParticleSystem<VDimension>
   m_InverseTransforms[static_cast<int>( m_Domains.size() -1)].set_identity();
   m_PrefixTransforms[static_cast<int>( m_Domains.size() -1)].set_identity();
   m_InversePrefixTransforms[static_cast<int>( m_Domains.size() -1)].set_identity();
-  m_DomainFlags[static_cast<int>( m_Domains.size() -1)] = false;
+  //m_DomainFlags[static_cast<int>( m_Domains.size() -1)] = false;
   
   // Notify any observers.
   ParticleDomainAddEvent e;
@@ -147,20 +150,17 @@ ParticleSystem<VDimension>
 {
   m_Positions[d]->operator[](m_IndexCounters[d]) = p;
 
-  // Potentially modifes position!
-  if (m_DomainFlags[d] == false)
-  {
-      m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](m_IndexCounters[d]));
-
-      m_Neighborhoods[d]->AddPosition( m_Positions[d]->operator[](m_IndexCounters[d]), m_IndexCounters[d], threadId);
+  // Potentially modifies position!
+  if (m_DomainFlags[d] == false) {
+    m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](m_IndexCounters[d]));
+    m_Neighborhoods[d]->AddPosition( m_Positions[d]->operator[](m_IndexCounters[d]), m_IndexCounters[d], threadId);
   }
 
   // Increase the FixedParticleFlag list size if necessary.
   if (m_IndexCounters[d] >= m_FixedParticleFlags[d % m_DomainsPerShape].size())
-    {
-        m_FixedParticleFlags[d % m_DomainsPerShape].push_back(false);
-    }
-
+  {
+    m_FixedParticleFlags[d % m_DomainsPerShape].push_back(false);
+  }
 
   // Notify any observers.
   ParticlePositionAddEvent e;
@@ -180,19 +180,17 @@ ParticleSystem<VDimension>
                                         unsigned int d,  int threadId)
 {
   if (m_FixedParticleFlags[d % m_DomainsPerShape][k] == false)
-    {
-  
-    m_Positions[d]->operator[](k) = p;
-    
-    // Potentially modifes position!
-    if (m_DomainFlags[d] == false)
-    {
-        m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](k));
-    
-        m_Neighborhoods[d]->SetPosition( m_Positions[d]->operator[](k), k, threadId);
-     }
+  {
+    // Potentially modifies position!
+    if (m_DomainFlags[d] == false) {
+      m_Positions[d]->operator[](k) = p;
 
-     }
+      m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](k));
+
+      m_Neighborhoods[d]->SetPosition( m_Positions[d]->operator[](k), k, threadId);
+    }
+
+  }
 
   // Notify any observers.
   ParticlePositionSetEvent e;
@@ -230,6 +228,7 @@ ParticleSystem<VDimension>
 ::AddPositionList(const std::vector<PointType> &p,
                                             unsigned int d, int threadId )
 {
+  std::cerr << "AddPositionList\n";
   // Traverse the list and add each point to the domain.
   for (typename std::vector<PointType>::const_iterator it= p.begin();
        it != p.end(); it++)


### PR DESCRIPTION
This PR reduces memory usages for fixed domains.  It eliminates the loading of distance transforms for fixed domains (though they must still be specified in the xml file), and eliminates the computation of gradients, curvature and hessians for fixed domains.