### PR TITLE
Fix la memory

### DIFF
--- a/Examples/Python/CommonUtils.py
+++ b/Examples/Python/CommonUtils.py
@@ -38,34 +38,8 @@ def create_cpp_xml(filename, outputfilename):
     file = open(outputfilename,"w")
     file.write(xml_text)
     file.close()
-    
+
 def sampledata(inDataList, num_sample):
-    IMG = []
-    DIM = []
-    for i in range(len(inDataList)):
-        image = itk.imread(inDataList[i], itk.F)
-        tmp = itk.GetArrayFromImage(image)
-        IMG.append(tmp)
-        DIM.append(tmp.shape)
-
-    ref_dim = np.max(DIM, axis=0)
-    for i in range(len(inDataList)):
-        IMG[i] = np.pad(IMG[i], ((0,ref_dim[0]-DIM[i][0]), (0,ref_dim[1]-DIM[i][1]), (0,ref_dim[2]-DIM[i][2])), mode ='constant' , constant_values = 0)
-        IMG[i] = np.ndarray.flatten(IMG[i], 'C')
-    IMG = np.asarray(IMG)
-    print("########## Sample subset of data #########")
-    cprint("Run K-means clustering!", 'cyan')
-    model = KMeans(n_clusters=num_sample)
-    clusters = model.fit_predict(IMG)
-    labels = list(model.labels_)
-    samples_idx = []
-    cprint("sample one data per cluster to have diverse samples", 'cyan')
-    for i in range(num_sample):
-        samples_idx.append(labels.index(i))
-    print("###########################################\n")
-    return samples_idx
-
-def sampledataSpectralClustring(inDataList, num_sample):
     D = np.zeros((len(inDataList), len(inDataList)))
     for i in range(len(inDataList)):
         image_1 = itk.GetArrayFromImage(itk.imread(inDataList[i], itk.F))

--- a/Examples/Python/GroomUtils.py
+++ b/Examples/Python/GroomUtils.py
@@ -210,7 +210,6 @@ def FindReferenceImage(inDataList):
             COM - np.pad(tmp, (((x - tmp.shape[0]) // 2, (x - tmp.shape[0]) - (x - tmp.shape[0]) // 2),
                                ((y - tmp.shape[1]) // 2, (y - tmp.shape[1]) - (y - tmp.shape[1]) // 2),
                                ((z - tmp.shape[2]) // 2, (z - tmp.shape[2]) - (z - tmp.shape[2]) // 2))))
-
         if tmp_dist < dist:
             idx = i
             dist = tmp_dist

--- a/Examples/Python/GroomUtils.py
+++ b/Examples/Python/GroomUtils.py
@@ -185,24 +185,39 @@ def FindReferenceImage(inDataList):
     """
         This find the median file between all the input files
     """
-    IMG = []
-    DIM = []
+    x = y = z = 0
+    for i in range(len(inDataList)):
+        dim = itk.GetArrayFromImage(itk.imread(inDataList[i])).shape
+        if dim[0] > x:
+            x = dim[0]
+        if dim[1] > y:
+            y = dim[1]
+        if dim[2] > z:
+            z = dim[2]
+
+    COM = np.zeros((x, y, z))
     for i in range(len(inDataList)):
         tmp = itk.GetArrayFromImage(itk.imread(inDataList[i]))
-        IMG.append(tmp)
-        DIM.append(tmp.shape)
-
-    ref_dim = np.max(DIM, axis =0)
-
+        COM += np.pad(tmp, (((x - tmp.shape[0]) // 2, (x - tmp.shape[0]) - (x - tmp.shape[0]) // 2),
+                            ((y - tmp.shape[1]) // 2, (y - tmp.shape[1]) - (y - tmp.shape[1]) // 2),
+                            ((z - tmp.shape[2]) // 2, (z - tmp.shape[2]) - (z - tmp.shape[2]) // 2)))
+    COM /= len(inDataList)
+    dist = np.inf
+    idx = 0
     for i in range(len(inDataList)):
-        IMG[i] = np.pad(IMG[i], ((0,ref_dim[0]-DIM[i][0]), (0,ref_dim[1]-DIM[i][1]), (0,ref_dim[2]-DIM[i][2])), mode ='constant' , constant_values = 0)
+        tmp = itk.GetArrayFromImage(itk.imread(inDataList[i]))
+        tmp_dist = np.linalg.norm(
+            COM - np.pad(tmp, (((x - tmp.shape[0]) // 2, (x - tmp.shape[0]) - (x - tmp.shape[0]) // 2),
+                               ((y - tmp.shape[1]) // 2, (y - tmp.shape[1]) - (y - tmp.shape[1]) // 2),
+                               ((z - tmp.shape[2]) // 2, (z - tmp.shape[2]) - (z - tmp.shape[2]) // 2))))
 
-    COM = np.sum(np.asarray(IMG), axis=0) / len(inDataList)
+        if tmp_dist < dist:
+            idx = i
+            dist = tmp_dist
 
-    idx = np.argmin(np.sqrt(np.sum((np.asarray(IMG) - COM) ** 2, axis=(1, 2, 3))))
     print(" ")
     print("############# Reference File #############")
-    cprint(("The reference file for rigid alignment is found"), 'green')
+    cprint(("The reference file for rigid alignment is found"), 'cyan')
     cprint(("Output Median Filename : ", inDataList[idx]), 'yellow')
     print("###########################################")
     print(" ")


### PR DESCRIPTION
I have edited the "FindReferenceImage" function to take care of different image sizes and prevent loading all the images into memory.  I have tested on LA data.
For sampling a subset of data the "sampledata" is changed to just read two images at a time and run spectral clustering based on the distance matrix of input images. 
@jadie1  Could you please test this two functions for the femur data as well.