### PR TITLE
Simplify build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ project(ShapeWorks)
 # OpenVDB only provides a module file (FindOpenVDB.cmake), so we use OpenVDB_DIR to find it
 if (NOT DEFINED OpenVDB_DIR)
   set(OpenVDB_DIR ${CMAKE_PREFIX_PATH}/lib/cmake/OpenVDB)
-  message(STATUS "OpenVDB_DIR set to ${OpenVDB_DIR}; if any problem finding OpenVDB, manually set it to path containing FindOpenVDB.cmake.")
 endif()
+message(STATUS "OpenVDB_DIR set to ${OpenVDB_DIR} (must contain FindOpenVDB.cmake)")
 file(TO_CMAKE_PATH ${OpenVDB_DIR} OpenVDB_DIR) # fixes path to use forward slashes on Windows
 list(APPEND CMAKE_MODULE_PATH ${OpenVDB_DIR})
 find_package(OpenVDB MODULE REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,11 +26,14 @@ include(DefaultBuildType)
 
 project(ShapeWorks)
 
-# OpenVDB doesn't provide a config file currently
-# https://www.openvdb.org/documentation/doxygen/build.html#buildUsingOpenVDB
-file(TO_CMAKE_PATH ${OpenVDB_DIR} OpenVDB_DIR) # use forward slashes on windows
+# OpenVDB only provides a module file (FindOpenVDB.cmake), so we use OpenVDB_DIR to find it
+if (NOT DEFINED OpenVDB_DIR)
+  set(OpenVDB_DIR ${CMAKE_PREFIX_PATH}/lib/cmake/OpenVDB)
+  message(STATUS "OpenVDB_DIR set to ${OpenVDB_DIR}; if any problem finding OpenVDB, manually set it to path containing FindOpenVDB.cmake.")
+endif()
+file(TO_CMAKE_PATH ${OpenVDB_DIR} OpenVDB_DIR) # fixes path to use forward slashes on Windows
 list(APPEND CMAKE_MODULE_PATH ${OpenVDB_DIR})
-find_package(OpenVDB REQUIRED)
+find_package(OpenVDB MODULE REQUIRED)
 
 # use ccache if available
 find_program(CCACHE_PROGRAM ccache)

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -277,7 +277,7 @@ show_shapeworks_build()
     OPENMP_FLAG="-DUSE_OPENMP=OFF"
   fi
 
-  echo "cmake -DCMAKE_PREFIX_PATH=${INSTALL_DIR} ${OPENMP_FLAG} -DBuild_Studio={BUILD_GUI} -Wno-dev -Wno-deprecated -DCMAKE_BUILD_TYPE=Release ${SRC}"
+  echo "cmake -DCMAKE_PREFIX_PATH=${INSTALL_DIR} ${OPENMP_FLAG} -DBuild_Studio=${BUILD_GUI} -Wno-dev -Wno-deprecated -DCMAKE_BUILD_TYPE=Release ${SRC}"
 }
 
 # determine if we can build using specified or discovered version of Qt


### PR DESCRIPTION
Make it so path to FindOpenVDB.cmake isn't needed when using build_dependencies. 
*NOTE*: this also corrects a typo in the config string printed by build_dependencies.sh, which means it will rebuild everything. So maybe merge it after everyone has gone to bed. :)