### PR TITLE
Fix naming of assets for development releases

### DIFF
--- a/Support/package.sh
+++ b/Support/package.sh
@@ -20,6 +20,12 @@ if [[ "$VERSION" == "tag" ]]; then
     VERSION="ShapeWorks-$(git describe --tags)-$PLATFORM"
 fi
 
+# Special case for when we are on the master branch (dev releases)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" == "master" ]]; then
+    VERSION="ShapeWorks-dev-$PLATFORM"
+fi
+
 echo "Version: $VERSION"
 
 rm -rf "package/$VERSION"

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -12,6 +12,12 @@ if [[ "$VERSION" == "tag" ]]; then
     VERSION="ShapeWorks-$(git describe --tags)-windows"
 fi
 
+# Special case for when we are on the master branch (dev releases)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" == "master" ]]; then
+    VERSION="ShapeWorks-dev-windows"
+fi
+
 
 export SW_VERSION=$VERSION
 ROOT=`pwd`


### PR DESCRIPTION
Using the tag is problematic with the automatic release action.  The problem is that all three platforms will get the same tag that will be something like "dev-linux-31", even on mac/windows.  So I've changed the packaging scripts to just use "dev" for the master branch.