### PR TITLE
Studio updates

### DIFF
--- a/Libs/Particles/itkParticleShapeStatistics.cpp
+++ b/Libs/Particles/itkParticleShapeStatistics.cpp
@@ -163,8 +163,8 @@ int ParticleShapeStatistics < VDimension > ::ImportPoints(
     }
   }
 
-  std::cerr << "m_numSamples1 = " << m_numSamples1 << "\n";
-  std::cerr << "m_numSamples2 = " << m_numSamples2 << "\n";
+  //std::cerr << "m_numSamples1 = " << m_numSamples1 << "\n";
+  //std::cerr << "m_numSamples2 = " << m_numSamples2 << "\n";
 
   m_pointsMinusMean.set_size(m_numDimensions, m_numSamples);
   m_shapes.set_size(m_numDimensions, m_numSamples);

--- a/Studio/src/Application/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Application/Analysis/AnalysisTool.cpp
@@ -308,11 +308,6 @@ void AnalysisTool::handle_analysis_options()
     this->ui_->pcaModeSpinBox->setEnabled(false);
   }
 
-  this->ui_->group1_button->setEnabled(this->session_->groups_available());
-  this->ui_->group2_button->setEnabled(this->session_->groups_available());
-  this->ui_->difference_button->setEnabled(this->session_->groups_available());
-  this->ui_->group_slider_widget->setEnabled(this->session_->groups_available());
-
   emit update_view();
 }
 
@@ -381,6 +376,7 @@ bool AnalysisTool::compute_stats()
 
   // set widget enable state for groups
   bool groups_available = this->session_->groups_available();
+
   this->ui_->group_slider->setEnabled(groups_available);
   this->ui_->group_animate_checkbox->setEnabled(groups_available);
   this->ui_->group_radio_button->setEnabled(groups_available);
@@ -613,6 +609,11 @@ void AnalysisTool::enable_actions()
 {
   this->ui_->reconstructionButton->setEnabled(
     this->session_->particles_present() && this->session_->get_groomed_present());
+
+  this->ui_->group1_button->setEnabled(this->session_->groups_available());
+  this->ui_->group2_button->setEnabled(this->session_->groups_available());
+  this->ui_->difference_button->setEnabled(this->session_->groups_available());
+  this->ui_->group_slider_widget->setEnabled(this->session_->groups_available());
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/src/Application/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Application/Analysis/AnalysisTool.cpp
@@ -220,7 +220,7 @@ void AnalysisTool::setLabels(QString which, QString value)
 }
 
 //---------------------------------------------------------------------------
-int AnalysisTool::getSampleNumber()
+int AnalysisTool::get_sample_number()
 {
   return this->ui_->sampleSpinBox->value();
 }

--- a/Studio/src/Application/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Application/Analysis/AnalysisTool.cpp
@@ -118,7 +118,6 @@ void AnalysisTool::handle_reconstruction_complete()
 {
   this->session_->handle_clear_cache();
 
-
   this->session_->calculate_reconstructed_samples();
   emit progress(100);
   emit message("Reconstruction Complete");
@@ -368,8 +367,9 @@ bool AnalysisTool::compute_stats()
   }
 
   this->stats_.ImportPoints(points, group_ids);
-
   this->stats_.ComputeModes();
+  this->stats_.PrincipalComponentProjections();
+
   this->stats_ready_ = true;
   std::vector<double> vals;
   for (int i = this->stats_.Eigenvalues().size() - 1; i > 0; i--) {

--- a/Studio/src/Application/Analysis/AnalysisTool.h
+++ b/Studio/src/Application/Analysis/AnalysisTool.h
@@ -113,8 +113,6 @@ public Q_SLOTS:
 
   void on_reconstructionButton_clicked();
 
-  void write_pca_scores(std::string filename);
-
 signals:
   void update_view();
   void pca_update();

--- a/Studio/src/Application/Analysis/AnalysisTool.h
+++ b/Studio/src/Application/Analysis/AnalysisTool.h
@@ -113,6 +113,8 @@ public Q_SLOTS:
 
   void on_reconstructionButton_clicked();
 
+  void write_pca_scores(std::string filename);
+
 signals:
   void update_view();
   void pca_update();

--- a/Studio/src/Application/Analysis/AnalysisTool.h
+++ b/Studio/src/Application/Analysis/AnalysisTool.h
@@ -56,7 +56,7 @@ public:
   bool pcaAnimate();
   bool groupAnimate();
 
-  int getSampleNumber();
+  int get_sample_number();
 
   bool compute_stats();
 

--- a/Studio/src/Application/Analysis/AnalysisTool.h
+++ b/Studio/src/Application/Analysis/AnalysisTool.h
@@ -114,6 +114,7 @@ public Q_SLOTS:
   void on_reconstructionButton_clicked();
 
 signals:
+
   void update_view();
   void pca_update();
   void progress(size_t);

--- a/Studio/src/Application/Analysis/AnalysisTool.ui
+++ b/Studio/src/Application/Analysis/AnalysisTool.ui
@@ -283,7 +283,7 @@ QToolButton:pressed{
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="mean_tab">
       <attribute name="title">

--- a/Studio/src/Application/Data/LegacyMeshGenerator.cpp
+++ b/Studio/src/Application/Data/LegacyMeshGenerator.cpp
@@ -19,7 +19,7 @@
 #include <Data/vtkPolyDataToImageData.h>
 
 #include <vtkMetaImageWriter.h>
-#include <vtkPolyDataWriter.h>
+
 
 #include "CustomSurfaceReconstructionFilter.h"
 

--- a/Studio/src/Application/Data/Mesh.cpp
+++ b/Studio/src/Application/Data/Mesh.cpp
@@ -11,7 +11,6 @@
 #include <vtkMarchingCubes.h>
 #include <vtkTriangleFilter.h>
 #include <vtkPolyDataNormals.h>
-#include <vtkPolyDataWriter.h>
 
 #include <Data/Mesh.h>
 #include <Data/ItkToVtk.h>

--- a/Studio/src/Application/Data/Session.cpp
+++ b/Studio/src/Application/Data/Session.cpp
@@ -242,7 +242,7 @@ bool Session::load_project(QString filename)
 //---------------------------------------------------------------------------
 bool Session::load_light_project(QString filename)
 {
-  std::cerr << "Loading light project...\n";
+  std::cerr << "Loading old XML parameter file...\n";
   this->is_light_project_ = true;
 
   // open and parse XML
@@ -365,7 +365,7 @@ bool Session::load_light_project(QString filename)
 
   this->project_->store_subjects();
 
-  std::cerr << "light project loaded\n";
+  std::cerr << "Old XML parameter file loaded\n";
   return true;
 }
 

--- a/Studio/src/Application/Data/Session.cpp
+++ b/Studio/src/Application/Data/Session.cpp
@@ -80,7 +80,7 @@ void Session::handle_clear_cache()
 //---------------------------------------------------------------------------
 void Session::calculate_reconstructed_samples()
 {
-  if (!this->particles_present_) {
+  if (!this->project_->get_particles_present()) {
     return;
   }
   //this->preferences_.set_preference("Studio/cache_enabled", false);
@@ -233,7 +233,8 @@ bool Session::load_project(QString filename)
     return this->load_light_project(filename);
   }
 
-  QString message = "Error: This version of ShapeWorksStudio only reads XLSX and legacy XML files: " + filename;
+  QString message =
+    "Error: This version of ShapeWorksStudio only reads XLSX and legacy XML files: " + filename;
   QMessageBox::critical(NULL, "ShapeWorksStudio", message, QMessageBox::Ok);
   return false;
 }
@@ -352,9 +353,6 @@ bool Session::load_light_project(QString filename)
     }
   }
 
-  this->particles_present_ = local_point_files.size() == global_point_files.size() &&
-                             global_point_files.size() > 1;
-
   //this->calculate_reconstructed_samples();
 
   this->settings().set("view_state", Visualizer::MODE_RECONSTRUCTION_C);
@@ -410,8 +408,6 @@ bool Session::load_xl_project(QString filename)
                                                                  goodPtsFile);
      }
    */
-  this->particles_present_ = local_point_files.size() == global_point_files.size() &&
-                             global_point_files.size() > 1;
 
   this->params_ = this->project_->get_parameters(Parameters::STUDIO_PARAMS);
 
@@ -507,8 +503,8 @@ void Session::load_original_files(std::vector<std::string> filenames)
   }
 
   this->renumber_shapes();
+  this->project_->store_subjects();
   if (filenames.size() > 0) {
-    this->original_present_ = true;
     emit data_changed();
   }
 }
@@ -539,7 +535,6 @@ void Session::load_groomed_images(std::vector<ImageType::Pointer> images, double
   this->project_->store_subjects();
   if (images.size() > 0) {
     this->unsaved_groomed_files_ = true;
-    this->groomed_present_ = true;
     emit data_changed();
   }
 }
@@ -565,9 +560,9 @@ void Session::load_groomed_files(std::vector<std::string> file_names, double iso
     this->shapes_[i]->get_subject()->set_groomed_filenames(groomed_filenames);
   }
 
+  this->project_->store_subjects();
   if (file_names.size() > 0) {
-    this->groomed_present_ = true;
-    //emit data_changed();
+    emit data_changed();
   }
 }
 
@@ -619,12 +614,6 @@ bool Session::update_points(std::vector<std::vector<itk::Point<double>>> points,
     emit points_changed();
   }
   return true;
-}
-
-//---------------------------------------------------------------------------
-void Session::set_reconstructed_present(bool value)
-{
-  this->particles_present_ = value;
 }
 
 //---------------------------------------------------------------------------
@@ -725,10 +714,6 @@ void Session::reset()
   this->filename_ = "";
 
   this->shapes_.clear();
-
-  this->original_present_ = false;
-  this->groomed_present_ = false;
-  this->particles_present_ = false;
 
   this->mesh_manager_ = QSharedPointer<MeshManager>(new MeshManager(preferences_));
 

--- a/Studio/src/Application/Data/Session.cpp
+++ b/Studio/src/Application/Data/Session.cpp
@@ -18,9 +18,6 @@
 
 #include <tinyxml.h>
 
-#include <vtkPolyDataWriter.h>
-#include <vtkPolyDataReader.h>
-
 #include <Libs/Project/Project.h>
 
 #include <Data/Session.h>

--- a/Studio/src/Application/Data/Session.h
+++ b/Studio/src/Application/Data/Session.h
@@ -65,8 +65,6 @@ public:
   bool load_point_files(std::vector<std::string> file_names, bool local);
   bool update_points(std::vector<std::vector<itk::Point<double>>> points, bool local);
 
-  void set_reconstructed_present(bool b);
-
   bool is_light_project();
 
   bool get_groomed_present();
@@ -135,10 +133,6 @@ private:
   QVector<QSharedPointer<Shape>> shapes_;
 
   QSharedPointer<MeshManager> mesh_manager_;
-
-  bool original_present_{false};
-  bool groomed_present_{false};
-  bool particles_present_{false};
 
   bool groups_available_{false};
   bool is_light_project_{false};

--- a/Studio/src/Application/Optimize/OptimizeTool.cpp
+++ b/Studio/src/Application/Optimize/OptimizeTool.cpp
@@ -63,8 +63,8 @@ void OptimizeTool::handle_optimize_complete()
   auto global = this->optimize_->GetGlobalPoints();
   this->session_->update_points(local, true);
   this->session_->update_points(global, false);
-  this->session_->set_reconstructed_present(
-    local.size() == global.size() && global.size() > 1);
+  //this->session_->set_reconstructed_present(
+//    local.size() == global.size() && global.size() > 1);
   this->session_->calculate_reconstructed_samples();
   this->session_->get_project()->store_subjects();
   emit progress(100);

--- a/Studio/src/Application/Optimize/OptimizeTool.cpp
+++ b/Studio/src/Application/Optimize/OptimizeTool.cpp
@@ -200,7 +200,7 @@ void OptimizeTool::disable_actions()
 //---------------------------------------------------------------------------
 void OptimizeTool::shutdown_threads()
 {
-  std::cerr << "Shut Down Optimization Threads";
+  std::cerr << "Shut Down Optimization Threads\n";
   if (!this->optimize_) {
     return;
   }

--- a/Studio/src/Application/Visualization/Lightbox.cpp
+++ b/Studio/src/Application/Visualization/Lightbox.cpp
@@ -288,6 +288,12 @@ void Lightbox::set_shapes(QVector<QSharedPointer<Shape>> shapes)
 }
 
 //-----------------------------------------------------------------------------
+QVector<ShapeHandle> Lightbox::get_shapes()
+{
+  return this->shapes_;
+}
+
+//-----------------------------------------------------------------------------
 void Lightbox::redraw()
 {
   if (this->render_window_) {

--- a/Studio/src/Application/Visualization/Lightbox.h
+++ b/Studio/src/Application/Visualization/Lightbox.h
@@ -32,6 +32,7 @@ public:
   ~Lightbox();
 
   void set_shapes(QVector<QSharedPointer<Shape>> shapes);
+  QVector<ShapeHandle> get_shapes();
 
   void set_interactor(vtkRenderWindowInteractor* interactor);
 

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
@@ -813,7 +813,7 @@ void ShapeWorksStudioApp::handle_optimize_start()
 void ShapeWorksStudioApp::handle_display_setting_changed()
 {
   if (this->analysis_tool_->pcaAnimate()) {return;}
-  this->update_display();
+  this->update_display(true);
 }
 
 //---------------------------------------------------------------------------
@@ -944,7 +944,7 @@ void ShapeWorksStudioApp::update_display(bool force)
       this->set_view_combo_item_enabled(VIEW_MODE::RECONSTRUCTED,
                                         this->session_->particles_present() &&
                                         reconstruct_ready);
-      this->visualizer_->display_sample(this->analysis_tool_->getSampleNumber());
+      this->visualizer_->display_sample(this->analysis_tool_->get_sample_number());
       this->visualizer_->reset_camera();
     }
     else { //?
@@ -1048,10 +1048,9 @@ void ShapeWorksStudioApp::on_action_preferences_triggered()
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::on_action_export_current_mesh_triggered()
 {
-  auto dir = preferences_.get_last_directory().toStdString();
-  dir = dir.substr(0, dir.find_last_of("/") + 1);
+  auto dir = preferences_.get_last_directory() + "/";
   QString filename = QFileDialog::getSaveFileName(this, tr("Save Project As..."),
-                                                  QString::fromStdString(dir) + "newMesh",
+                                                  dir + "mesh",
                                                   tr("VTK files (*.vtk)"));
   if (filename.isEmpty()) {
     return;

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
@@ -324,6 +324,7 @@ bool ShapeWorksStudioApp::on_action_save_project_as_triggered()
 
   this->save_project(filename.toStdString());
 
+  this->enable_possible_actions();
   return false;
 }
 

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
@@ -299,20 +299,9 @@ bool ShapeWorksStudioApp::on_action_save_project_triggered()
 //---------------------------------------------------------------------------
 bool ShapeWorksStudioApp::on_action_save_project_as_triggered()
 {
-  QString fname("Untitled.xlsx");
-  if (this->session_->get_shapes().size() > 0) {
-    QString original_filename = this->session_->get_shapes()[0]->get_original_filename();
-    if (original_filename != "") {
-      std::string tmp = original_filename.toStdString();
-      tmp = tmp.substr(0, tmp.size() - 5);
-      fname = QString::fromStdString(tmp);
-    }
-  }
   QString last_directory = this->preferences_.get_last_directory();
-  auto dir = last_directory.toStdString();
-  dir = dir.substr(0, dir.find_last_of("/") + 1);
   QString filename = QFileDialog::getSaveFileName(this, tr("Save Project As..."),
-                                                  QString::fromStdString(dir) + fname,
+                                                  last_directory,
                                                   tr("XLSX files (*.xlsx)"));
   if (filename.isEmpty()) {
     return false;

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
@@ -328,7 +328,7 @@ void ShapeWorksStudioApp::on_action_import_triggered()
 {
   QStringList filenames;
   std::cerr << "getOpenFileNames, last_dir = " <<
-  this->preferences_.get_last_directory().toStdString() << "\n";
+    this->preferences_.get_last_directory().toStdString() << "\n";
   filenames = QFileDialog::getOpenFileNames(this, tr("Import Files..."),
                                             this->preferences_.get_last_directory(),
                                             tr("NRRD files (*.nrrd);;MHA files (*.mha)"));
@@ -1067,8 +1067,7 @@ void ShapeWorksStudioApp::on_action_export_current_mesh_triggered()
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::on_action_export_mesh_scalars_triggered()
 {
-  auto dir = preferences_.get_last_directory().toStdString();
-  dir = dir.substr(0, dir.find_last_of("/") + 1);
+  auto dir = preferences_.get_last_directory().toStdString() + "/";
   QString filename = QFileDialog::getSaveFileName(this, tr("Save Project As..."),
                                                   QString::fromStdString(dir) + "scalars",
                                                   tr("CSV files (*.csv)"));
@@ -1120,6 +1119,22 @@ void ShapeWorksStudioApp::on_action_export_mesh_scalars_triggered()
   }
 
   output.close();
+}
+
+//---------------------------------------------------------------------------
+void ShapeWorksStudioApp::on_action_export_pca_scores_triggered()
+{
+  auto dir = preferences_.get_last_directory().toStdString() + "/";
+  QString filename = QFileDialog::getSaveFileName(this, tr("Save Project As..."),
+                                                  QString::fromStdString(dir) + "scores",
+                                                  tr("CSV files (*.csv)"));
+  if (filename.isEmpty()) {
+    return;
+  }
+  this->preferences_.set_last_directory(QFileInfo(filename).absolutePath());
+
+  auto stats = this->analysis_tool_->get_stats();
+  stats.WriteCSVFile2(filename.toStdString());
 }
 
 //---------------------------------------------------------------------------
@@ -1308,8 +1323,7 @@ void ShapeWorksStudioApp::on_actionExport_Eigenvalues_triggered()
   auto values = stats.Eigenvalues();
   QString fname("Untitled.eval");
 
-  auto dir = this->preferences_.get_last_directory().toStdString();
-  dir = dir.substr(0, dir.find_last_of("/") + 1);
+  auto dir = this->preferences_.get_last_directory().toStdString() + "/";
   QString filename = QFileDialog::getSaveFileName(this, tr("Save Eigenvalue EVAL file..."),
                                                   QString::fromStdString(dir) + fname,
                                                   tr("EVAL files (*.eval)"));
@@ -1331,8 +1345,7 @@ void ShapeWorksStudioApp::on_actionExport_Eigenvectors_triggered()
   auto stats = this->analysis_tool_->get_stats();
   auto values = stats.Eigenvectors();
   QString fname("Untitled.eval");
-  auto dir = this->preferences_.get_last_directory().toStdString();
-  dir = dir.substr(0, dir.find_last_of("/") + 1);
+  auto dir = this->preferences_.get_last_directory().toStdString() + "/";
   QString filename = QFileDialog::getSaveFileName(this, tr("Save Eigenvector EVAL files..."),
                                                   QString::fromStdString(dir) + fname,
                                                   tr("EVAL files (*.eval)"));
@@ -1359,8 +1372,7 @@ void ShapeWorksStudioApp::on_actionExport_Eigenvectors_triggered()
 void ShapeWorksStudioApp::on_actionExport_PCA_Mode_Points_triggered()
 {
   QString fname("Untitled.pts");
-  auto dir = this->preferences_.get_last_directory().toStdString();
-  dir = dir.substr(0, dir.find_last_of("/") + 1);
+  auto dir = this->preferences_.get_last_directory().toStdString() + "/";
   QString filename = QFileDialog::getSaveFileName(this, tr("Save PCA Mode PCA files..."),
                                                   QString::fromStdString(dir) + fname,
                                                   tr("PTS files (*.pts)"));

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
@@ -1061,6 +1061,7 @@ void ShapeWorksStudioApp::on_action_export_current_mesh_triggered()
   vtkPolyDataWriter* writer = vtkPolyDataWriter::New();
   writer->SetFileName(filename.toStdString().c_str());
   writer->SetInputData(poly_data);
+  writer->WriteArrayMetaDataOff();
   writer->Write();
 }
 
@@ -1299,6 +1300,7 @@ void ShapeWorksStudioApp::on_actionExport_PCA_Mesh_triggered()
       name = name.substr(0, name.find_last_of(".")) + std::to_string(i) + ".vtk";
       writer->SetFileName(name.c_str());
       writer->SetInputData(msh);
+      writer->WriteArrayMetaDataOff();
       writer->Write();
     }
     this->handle_message("Successfully exported PCA Mesh files: " + filename.toStdString());
@@ -1312,6 +1314,7 @@ void ShapeWorksStudioApp::on_actionExport_PCA_Mesh_triggered()
   writer->SetFileName(filename.toStdString().c_str());
   /// TODO: fix
   //writer->SetInputData(msh);
+  writer->WriteArrayMetaDataOff();
   writer->Write();
   this->handle_message("Successfully exported PCA Mesh file: " + filename.toStdString());
 }

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
@@ -385,8 +385,6 @@ void ShapeWorksStudioApp::on_zoom_slider_valueChanged()
 
   int value = this->ui_->zoom_slider->value();
 
-  std::cerr << "zoom value set to: " << value << "\n";
-
   this->lightbox_->set_tile_layout(value, value);
   this->visualizer_->update_viewer_properties();
 
@@ -1030,7 +1028,6 @@ void ShapeWorksStudioApp::open_project(QString filename)
   this->analysis_tool_->set_analysis_mode(analysis_mode);
 
   int zoom_value = this->session_->settings().get(ShapeWorksStudioApp::SETTING_ZOOM_C, "4");
-  std::cerr << "setting zoom value to :" << zoom_value << "\n";
   this->ui_->zoom_slider->setValue(zoom_value);
 
   this->block_update_ = false;

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.h
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.h
@@ -68,6 +68,7 @@ public Q_SLOTS:
   void on_action_preferences_triggered();
   void on_action_export_current_mesh_triggered();
   void on_action_export_mesh_scalars_triggered();
+  void on_action_export_pca_scores_triggered();
 
   void on_center_checkbox_stateChanged();
   void on_zoom_slider_valueChanged();

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.ui
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.ui
@@ -244,10 +244,10 @@
     <addaction name="action_import"/>
     <addaction name="action_export_current_mesh"/>
     <addaction name="action_export_mesh_scalars"/>
-    <addaction name="actionExport_PCA_Mesh"/>
+    <addaction name="actionExport_Eigenvectors"/>
     <addaction name="actionExport_Eigenvalues"/>
     <addaction name="actionExport_Variance_Graph"/>
-    <addaction name="actionExport_Eigenvectors"/>
+    <addaction name="action_export_pca_scores"/>
     <addaction name="actionExport_PCA_Mode_Points"/>
     <addaction name="separator"/>
     <addaction name="action_recent1"/>
@@ -627,6 +627,11 @@
   <action name="action_export_mesh_scalars">
    <property name="text">
     <string>Export Mesh Scalars...</string>
+   </property>
+  </action>
+  <action name="action_export_pca_scores">
+   <property name="text">
+    <string>Export PCA Component Scores...</string>
    </property>
   </action>
  </widget>

--- a/Studio/src/Application/Visualization/Viewer.cpp
+++ b/Studio/src/Application/Visualization/Viewer.cpp
@@ -165,13 +165,13 @@ Viewer::Viewer()
   this->scalar_bar_actor_->GetPositionCoordinate()->SetCoordinateSystemToNormalizedViewport();
   this->scalar_bar_actor_->GetPositionCoordinate()->SetValue(.2, .05);
   this->scalar_bar_actor_->SetWidth(0.8);
-  this->scalar_bar_actor_->SetHeight(0.1);
+  this->scalar_bar_actor_->SetHeight(0.05);
   this->scalar_bar_actor_->SetPosition(0.1, 0.01);
   this->scalar_bar_actor_->SetLabelFormat("%.0f");
   this->scalar_bar_actor_->GetTitleTextProperty()->SetFontFamilyToArial();
-  this->scalar_bar_actor_->GetTitleTextProperty()->SetFontSize(12);
+  this->scalar_bar_actor_->GetTitleTextProperty()->SetFontSize(4);
   this->scalar_bar_actor_->GetLabelTextProperty()->SetFontFamilyToArial();
-  this->scalar_bar_actor_->GetLabelTextProperty()->SetFontSize(10);
+  this->scalar_bar_actor_->GetLabelTextProperty()->SetFontSize(4);
   this->scalar_bar_actor_->GetLabelTextProperty()->SetJustificationToCentered();
   this->scalar_bar_actor_->GetLabelTextProperty()->SetColor(1, 1, 1);
 

--- a/Studio/src/Application/Visualization/Visualizer.cpp
+++ b/Studio/src/Application/Visualization/Visualizer.cpp
@@ -49,7 +49,6 @@ void Visualizer::set_session(SessionHandle session)
 //-----------------------------------------------------------------------------
 void Visualizer::set_display_mode(std::string mode)
 {
-  std::cerr << "Visualizer::set_display_mode(" << mode << ")\n";
   this->display_mode_ = mode;
 }
 

--- a/Studio/src/Application/Visualization/Visualizer.cpp
+++ b/Studio/src/Application/Visualization/Visualizer.cpp
@@ -68,68 +68,8 @@ void Visualizer::set_center(bool center)
 //-----------------------------------------------------------------------------
 void Visualizer::display_samples()
 {
-
   this->update_viewer_properties();
   QVector<QSharedPointer<Shape>> shapes = this->session_->get_shapes();
-  /*
-
-     QVector<QSharedPointer<DisplayObject>> display_objects;
-
-     for (int i = 0; i < shapes.size(); i++) {
-     QSharedPointer<DisplayObject> object = QSharedPointer<DisplayObject>(new DisplayObject());
-
-     QSharedPointer<Mesh> mesh;
-     QString filename;
-     object->set_correspondence_points(shapes[i]->get_local_correspondence_points());
-     //load respective mesh
-     if (this->display_mode_ == Visualizer::MODE_ORIGINAL_C) {
-      mesh = shapes[i]->get_original_mesh();
-      filename = shapes[i]->get_original_filename();
-     }
-     else if (this->display_mode_ == Visualizer::MODE_GROOMED_C) {
-      mesh = shapes[i]->get_groomed_mesh();
-      filename = shapes[i]->get_groomed_filename();
-     }
-     else if (this->display_mode_ == Visualizer::MODE_RECONSTRUCTION_C) {
-      mesh = shapes[i]->get_reconstructed_mesh();
-      if (shapes[i]->get_original_filename() == "") {
-        filename = shapes[i]->get_global_point_filename();
-      }
-      else {
-        filename = shapes[i]->get_original_filename() + "-RE";
-      }
-     }
-     if (this->display_mode_ != Visualizer::MODE_RECONSTRUCTION_C) {
-      object->set_exclusion_sphere_centers(shapes[i]->get_exclusion_sphere_centers());
-      object->set_exclusion_sphere_radii(shapes[i]->get_exclusion_sphere_radii());
-     }
-     if (!mesh) {
-      mesh = shapes[i]->get_original_mesh();
-      filename = shapes[i]->get_original_filename();
-     }
-
-     if (!mesh) {
-      mesh = shapes[i]->get_reconstructed_mesh();
-      filename = shapes[i]->get_global_point_filename();
-     }
-
-     object->set_mesh(mesh);
-     QStringList annotations;
-     annotations << filename;
-     annotations << "";
-     annotations << QString::number(shapes[i]->get_id());
-     annotations << "";
-     object->set_annotations(annotations);
-
-     if (this->center_ && mesh && this->display_mode_ == Visualizer::MODE_ORIGINAL_C) {
-      object->set_transform(mesh->get_center_transform());
-     }
-
-     display_objects << object;
-     }
-
-     this->display_objects_ = display_objects;
-   */
   this->lightbox_->set_shapes(shapes);
   this->lightbox_->redraw();
   this->update_viewer_properties();
@@ -139,12 +79,6 @@ void Visualizer::display_samples()
 void Visualizer::update_samples()
 {
   QVector < QSharedPointer < Shape >> shapes = this->session_->get_shapes();
-/*
-   for (int i = 0; i < shapes.size(); i++) {
-    this->display_objects_[i]->set_correspondence_points(
-      shapes[i]->get_local_correspondence_points());
-   }
- */
   foreach(ViewerHandle viewer, this->lightbox_->get_viewers()) {
     viewer->update_points();
   }
@@ -184,9 +118,10 @@ void Visualizer::handle_new_mesh()
 //-----------------------------------------------------------------------------
 vtkSmartPointer<vtkPolyData> Visualizer::get_current_mesh()
 {
-  std::cerr << "number of objects: " << this->display_objects_.size() << "\n";
-  if (this->display_objects_.size() > 0) {
-    return this->display_objects_[0]->get_mesh(this->display_mode_)->get_poly_data();
+  std::cerr << "number of objects: " << this->shapes_.size() << "\n";
+  if (this->shapes_.size() > 0) {
+    std::cerr << "returning something nice\n";
+    return this->shapes_[0]->get_mesh(this->display_mode_)->get_poly_data();
   }
   return nullptr;
 }
@@ -194,6 +129,18 @@ vtkSmartPointer<vtkPolyData> Visualizer::get_current_mesh()
 //-----------------------------------------------------------------------------
 void Visualizer::display_sample(int i)
 {
+  this->update_viewer_properties();
+  QVector<ShapeHandle> display_shapes;
+  QVector<ShapeHandle> shapes = this->session_->get_shapes();
+  if (i < shapes.size())
+  {
+    display_shapes.push_back(shapes[i]);
+  }
+
+  this->lightbox_->set_shapes(display_shapes);
+  this->lightbox_->redraw();
+  this->update_viewer_properties();
+
   /*
      int sample_count = this->project_->get_shapes().size();
      if (sample_count == 0) { return; }

--- a/Studio/src/Application/Visualization/Visualizer.cpp
+++ b/Studio/src/Application/Visualization/Visualizer.cpp
@@ -118,10 +118,10 @@ void Visualizer::handle_new_mesh()
 //-----------------------------------------------------------------------------
 vtkSmartPointer<vtkPolyData> Visualizer::get_current_mesh()
 {
-  std::cerr << "number of objects: " << this->shapes_.size() << "\n";
-  if (this->shapes_.size() > 0) {
+  auto shapes = this->lightbox_->get_shapes();
+  if (shapes.size() > 0) {
     std::cerr << "returning something nice\n";
-    return this->shapes_[0]->get_mesh(this->display_mode_)->get_poly_data();
+    return shapes[0]->get_mesh(this->display_mode_)->get_poly_data();
   }
   return nullptr;
 }
@@ -132,72 +132,13 @@ void Visualizer::display_sample(int i)
   this->update_viewer_properties();
   QVector<ShapeHandle> display_shapes;
   QVector<ShapeHandle> shapes = this->session_->get_shapes();
-  if (i < shapes.size())
-  {
+  if (i < shapes.size()) {
     display_shapes.push_back(shapes[i]);
   }
 
   this->lightbox_->set_shapes(display_shapes);
   this->lightbox_->redraw();
   this->update_viewer_properties();
-
-  /*
-     int sample_count = this->project_->get_shapes().size();
-     if (sample_count == 0) { return; }
-     i = std::min(sample_count - 1, i);
-
-     this->update_viewer_properties();
-
-     QVector<QSharedPointer<DisplayObject>> list_ptr;
-
-     QSharedPointer < Shape > shape = this->project_->get_shapes().at(i);
-
-     QSharedPointer<Mesh> mesh;
-     QString filename;
-
-     //load based on preference, but always load something
-
-     mesh = shape->get_original_mesh();
-     filename = shape->get_original_filename();
-     QSharedPointer<DisplayObject> object = QSharedPointer<DisplayObject>(new DisplayObject());
-     object->set_correspondence_points(shape->get_local_correspondence_points());
-
-     if (!mesh || this->display_mode_ == Visualizer::MODE_GROOMED_C) {
-     mesh = shape->get_groomed_mesh();
-     filename = shape->get_groomed_filename();
-     }
-
-     if (!mesh || this->display_mode_ == Visualizer::MODE_RECONSTRUCTION_C) {
-     mesh = shape->get_reconstructed_mesh();
-     filename = shape->get_original_filename() + "(RE)";
-
-     // use local correspondence points for reconstructed mesh
-     object->set_correspondence_points(shape->get_local_correspondence_points());
-     }
-     object->set_mesh(mesh);
-
-     if (this->display_mode_ != Visualizer::MODE_RECONSTRUCTION_C) {
-     object->set_exclusion_sphere_centers(shape->get_exclusion_sphere_centers());
-     object->set_exclusion_sphere_radii(shape->get_exclusion_sphere_radii());
-     }
-
-     QStringList annotations;
-     annotations << filename;
-     annotations << "";
-     annotations << QString::number(shape->get_id());
-     annotations << "";
-     object->set_annotations(annotations);
-
-     if (this->center_) {
-     object->set_transform(mesh->get_center_transform());
-     }
-     list_ptr << object;
-
-     this->update_viewer_properties();
-     this->lightbox_->set_display_objects(list_ptr);
-     this->lightbox_->redraw();
-     this->currentShape_ = shape->get_local_correspondence_points();
-   */
 }
 
 //-----------------------------------------------------------------------------

--- a/Studio/src/Application/Visualization/Visualizer.h
+++ b/Studio/src/Application/Visualization/Visualizer.h
@@ -100,5 +100,4 @@ private:
   vnl_vector<double> cached_mean_;
   vnl_vector<double> current_shape_;
 
-  ShapeList shapes_;
 };

--- a/Studio/src/Application/Visualization/Visualizer.h
+++ b/Studio/src/Application/Visualization/Visualizer.h
@@ -100,5 +100,5 @@ private:
   vnl_vector<double> cached_mean_;
   vnl_vector<double> current_shape_;
 
-  ShapeList display_objects_;
+  ShapeList shapes_;
 };


### PR DESCRIPTION
This PR makes the following changes:

* Enable save after save-as from a new/unsaved project
* Fix save-as default location
* Fix "display sample" mode when in analysis
* Fix "export current mesh" (was not working with updated data structures)
* Added PCA raw component score export to Studio (was only in View2 previously)