### PR TITLE
Replace srand/rand with C++11 Mersenne Twister 19937

### DIFF
--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -573,9 +573,9 @@ void Optimize::Initialize()
 
   int n = m_sampler->GetParticleSystem()->GetNumberOfDomains();
   vnl_vector_fixed < double, 3 > random;
-  srand(1);
+
   for (int i = 0; i < 3; i++) {
-    random[i] = static_cast < double > (rand());
+    random[i] = static_cast < double > (this->m_rand());
   }
   double norm = random.magnitude();
   random /= norm;

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -18,6 +18,7 @@
 // std
 #include <vector>
 #include <string>
+#include <random>
 
 // itk
 #include <itkImage.h>
@@ -379,4 +380,6 @@ protected:
   itk::MemberCommand<Optimize>::Pointer m_iterate_command;
   int m_total_iterations = 0;
   size_t m_iteration_count = 0;
+
+  std::mt19937 m_rand{42};
 };


### PR DESCRIPTION
Currently seeded with 42.  This gives us a cross-platform reproducible PRNG.

