### PR TITLE
Scale/Rotate command/function fixes, new resize command/function

### DIFF
--- a/Applications/shapeworks/Commands.cpp
+++ b/Applications/shapeworks/Commands.cpp
@@ -1066,7 +1066,7 @@ void Compare::buildParser()
   parser.add_option("--name").action("store").type("string").set_default("").help("Compare this image with another");
   parser.add_option("--verifyall").action("store").type("bool").set_default(true).help("Also verify origin, spacing, and direction matches [default: true]");
   parser.add_option("--tolerance").action("store").type("double").set_default(0.0).help("Allowed percentage of pixel differences [default: 0.0]");
-  parser.add_option("--precision").action("store").type("double").set_default(1e-12).help("Allowed difference between two pixels for them to still be considered equal [default: 0.0]");
+  parser.add_option("--precision").action("store").type("double").set_default(1e-12).help("Allowed difference between two pixels for them to still be considered equal [default: 1e-12]");
 
   Command::buildParser();
 }

--- a/Applications/shapeworks/Commands.cpp
+++ b/Applications/shapeworks/Commands.cpp
@@ -152,15 +152,15 @@ bool ImageInfo::execute(const optparse::Values &options, SharedCommandData &shar
     std::cout << "size (spacing * dims): " << sharedData.image.size() << std::endl;
   if (origin)
     std::cout << "physical origin:       " << sharedData.image.origin() << std::endl;
-  if (direction)
-    std::cout << "direction (coordsys):  " << std::endl
-              << sharedData.image.coordsys() << std::endl;
   if (center)
     std::cout << "center:                " << sharedData.image.center() << std::endl;
   if (centerofmass)
     std::cout << "center of mass (0,1]:  " << sharedData.image.centerOfMass() << std::endl;
   if (boundingbox)
     std::cout << "bounding box:          " << sharedData.image.boundingBox() << std::endl;
+  if (direction)
+    std::cout << "direction (coordsys):  " << std::endl
+              << sharedData.image.coordsys() << std::endl;
   
   return true;
 }
@@ -868,13 +868,13 @@ bool CropImage::execute(const optparse::Values &options, SharedCommandData &shar
 
   if (xmin == 0 && ymin == 0 && zmin == 0 &&
       xmax == 0 && ymax == 0 && zmax == 0)
-    sharedData.image.crop(sharedData.region);
+    sharedData.image.crop(sharedData.region); // use the previous region (maybe set by boundingbox cmd)
   else
   {
     Image::Region region(sharedData.image.dims());
     if (xmin < xmax) { region.min[0] = xmin; region.max[0] = xmax; }
-    if (ymin < ymax) { region.min[0] = ymin; region.max[0] = ymax; }
-    if (zmin < zmax) { region.min[0] = zmin; region.max[0] = zmax; }
+    if (ymin < ymax) { region.min[1] = ymin; region.max[1] = ymax; }
+    if (zmin < zmax) { region.min[2] = zmin; region.max[2] = zmax; }
     sharedData.image.crop(region);
   }
   return true;

--- a/Applications/shapeworks/Commands.cpp
+++ b/Applications/shapeworks/Commands.cpp
@@ -111,14 +111,14 @@ void ImageInfo::buildParser()
   const std::string desc = "prints requested image dimensions, spacing, size, origin, direction (coordinate system), center, center of mass and bounding box [default: prints everything]";
   parser.prog(prog).description(desc);
 
-  parser.add_option("--dims").action("store").type("bool").set_default(false).help("Whether to display image dimensions");
-  parser.add_option("--spacing").action("store").type("bool").set_default(false).help("Whether to display physical spacing");
-  parser.add_option("--size").action("store").type("bool").set_default(false).help("Whether to display size");
-  parser.add_option("--origin").action("store").type("bool").set_default(false).help("Whether to display physical origin");
-  parser.add_option("--direction").action("store").type("bool").set_default(false).help("Whether to display direction");
-  parser.add_option("--center").action("store").type("bool").set_default(false).help("Whether to display center");
-  parser.add_option("--centerofmass").action("store").type("bool").set_default(false).help("Whether to display center of mass");
-  parser.add_option("--boundingbox").action("store").type("bool").set_default(false).help("Whether to display bounding box");
+  parser.add_option("--dims").action("store_true").set_default(false).help("Whether to display image dimensions");
+  parser.add_option("--spacing").action("store_true").set_default(false).help("Whether to display physical spacing");
+  parser.add_option("--size").action("store_true").set_default(false).help("Whether to display size");
+  parser.add_option("--origin").action("store_true").set_default(false).help("Whether to display physical origin");
+  parser.add_option("--direction").action("store_true").set_default(false).help("Whether to display direction");
+  parser.add_option("--center").action("store_true").set_default(false).help("Whether to display center");
+  parser.add_option("--centerofmass").action("store_true").set_default(false).help("Whether to display center of mass");
+  parser.add_option("--boundingbox").action("store_true").set_default(false).help("Whether to display bounding box");
 
   Command::buildParser();
 }
@@ -321,7 +321,7 @@ void Translate::buildParser()
   const std::string desc = "translates image by specified physical (image space) distance";
   parser.prog(prog).description(desc);
 
-  parser.add_option("--centerofmass").action("store").type("bool").set_default(false).help("Use center of mass [default: false].");
+  parser.add_option("--centerofmass").action("store_true").set_default(false).help("Use center of mass [default: false].");
   parser.add_option("--tx", "-x").action("store").type("double").set_default(0).help("X distance");
   parser.add_option("--ty", "-y").action("store").type("double").set_default(0).help("Y distance");
   parser.add_option("--tz", "-z").action("store").type("double").set_default(0).help("Z distance");
@@ -1037,7 +1037,7 @@ void Compare::buildParser()
   parser.prog(prog).description(desc);
 
   parser.add_option("--name").action("store").type("string").set_default("").help("Compare this image with another");
-  parser.add_option("--verifyall").action("store").type("bool").set_default(true).help("Verify origin, spacing, and direction of both images match [default: true]");
+  parser.add_option("--verifyall").action("store").type("bool").set_default(true).help("Also verify origin, spacing, and direction matches [default: true]");
   parser.add_option("--tolerance").action("store").type("double").set_default(0.0).help("Allowed percentage of pixel differences [default: 0.0]");
   parser.add_option("--precision").action("store").type("double").set_default(1e-12).help("Allowed difference between two pixels for them to still be considered equal [default: 0.0]");
 

--- a/Applications/shapeworks/Commands.cpp
+++ b/Applications/shapeworks/Commands.cpp
@@ -160,7 +160,7 @@ bool ImageInfo::execute(const optparse::Values &options, SharedCommandData &shar
     std::cout << "bounding box:          " << sharedData.image.boundingBox() << std::endl;
   if (direction)
     std::cout << "direction (coordsys):  " << std::endl
-              << sharedData.image.coordsys() << std::endl;
+              << sharedData.image.coordsys();
   
   return true;
 }
@@ -211,16 +211,13 @@ bool Antialias::execute(const optparse::Values &options, SharedCommandData &shar
 void ResampleImage::buildParser()
 {
   const std::string prog = "resample";
-  const std::string desc = "resamples an image";
+  const std::string desc = "resamples an image using new physical spacing (computes new dims)";
   parser.prog(prog).description(desc);
 
   parser.add_option("--isospacing").action("store").type("double").set_default(0.0f).help("Use this spacing in all dimensions.");
   parser.add_option("--spacex").action("store").type("double").set_default(1.0f).help("Pixel spacing in x-direction [default: 1.0].");
   parser.add_option("--spacey").action("store").type("double").set_default(1.0f).help("Pixel spacing in y-direction [default: 1.0].");
   parser.add_option("--spacez").action("store").type("double").set_default(1.0f).help("Pixel spacing in z-direction [default: 1.0].");
-  parser.add_option("--sizex").action("store").type("unsigned").set_default(0).help("Output size in x-direction [default: calculated using current size and desired spacing].");
-  parser.add_option("--sizey").action("store").type("unsigned").set_default(0).help("Output size in y-direction [default: calculated using current size and desired spacing].");
-  parser.add_option("--sizez").action("store").type("unsigned").set_default(0).help("Output size in z-direction [default: calculated using current size and desired spacing].");
 
   Command::buildParser();
 }
@@ -237,14 +234,44 @@ bool ResampleImage::execute(const optparse::Values &options, SharedCommandData &
   double spaceX = static_cast<double>(options.get("spacex"));
   double spaceY = static_cast<double>(options.get("spacey"));
   double spaceZ = static_cast<double>(options.get("spacez"));
+
+  if (isoSpacing > 0.0)
+    ImageUtils::isoresample(sharedData.image, isoSpacing);
+  else
+    sharedData.image.resample(Point3({spaceX, spaceY, spaceZ}));
+
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// ResizeImage
+///////////////////////////////////////////////////////////////////////////////
+void ResizeImage::buildParser()
+{
+  const std::string prog = "resize";
+  const std::string desc = "resizes an image (computes new physical spacing)";
+  parser.prog(prog).description(desc);
+
+  parser.add_option("--sizex").action("store").type("unsigned").set_default(0).help("Output size in x-direction [default: current size].");
+  parser.add_option("--sizey").action("store").type("unsigned").set_default(0).help("Output size in y-direction [default: current size].");
+  parser.add_option("--sizez").action("store").type("unsigned").set_default(0).help("Output size in z-direction [default: current size].");
+
+  Command::buildParser();
+}
+
+bool ResizeImage::execute(const optparse::Values &options, SharedCommandData &sharedData)
+{
+  if (!sharedData.validImage())
+  {
+    std::cerr << "No image to operate on\n";
+    return false;
+  }
+
   unsigned sizeX = static_cast<unsigned>(options.get("sizex"));
   unsigned sizeY = static_cast<unsigned>(options.get("sizey"));
   unsigned sizeZ = static_cast<unsigned>(options.get("sizez"));
 
-  if (isoSpacing > 0.0)
-    ImageUtils::isoresample(sharedData.image, isoSpacing, Dims({sizeX, sizeY, sizeZ}));
-  else
-    sharedData.image.resample(Point3({spaceX, spaceY, spaceZ}), Dims({sizeX, sizeY, sizeZ}));
+  sharedData.image.resize(Dims({sizeX, sizeY, sizeZ}));
 
   return true;
 }

--- a/Applications/shapeworks/Commands.h
+++ b/Applications/shapeworks/Commands.h
@@ -10,6 +10,7 @@ COMMAND_DECLARE(WriteImage, ImageCommand);
 COMMAND_DECLARE(ImageInfo, ImageCommand);
 COMMAND_DECLARE(Antialias, ImageCommand);
 COMMAND_DECLARE(ResampleImage, ImageCommand);
+COMMAND_DECLARE(ResizeImage, ImageCommand);
 COMMAND_DECLARE(RecenterImage, ImageCommand);
 COMMAND_DECLARE(PadImage, ImageCommand);
 COMMAND_DECLARE(Translate, ImageCommand);

--- a/Applications/shapeworks/Executable.cpp
+++ b/Applications/shapeworks/Executable.cpp
@@ -8,7 +8,7 @@ void Executable::buildParser()
 {  
   parser.description("Unified ShapeWorks executable that includes command line utilities for automated construction of compact statistical landmark-based shape models of ensembles of shapes");
   parser.usage("Usage: %prog <command> [args]...");
-  parser.version("ShapeWorks Framework version X.Y.Z (executable version 1.0.0)"); # TODO: add frameworks version to this string
+  parser.version("ShapeWorks Framework version X.Y.Z (executable version 1.0.0)"); // TODO: add frameworks version to this string
   parser.epilog("Available commands:");
   parser.disable_interspersed_args(); // so everything after a command's name will be passed to that command (ex: its --help argumemnt)
   

--- a/Applications/shapeworks/Executable.cpp
+++ b/Applications/shapeworks/Executable.cpp
@@ -8,7 +8,7 @@ void Executable::buildParser()
 {  
   parser.description("Unified ShapeWorks executable that includes command line utilities for automated construction of compact statistical landmark-based shape models of ensembles of shapes");
   parser.usage("Usage: %prog <command> [args]...");
-  parser.version("%prog 1.0\nMIT license (todo: verify)");
+  parser.version("ShapeWorks Framework version X.Y.Z (executable version 1.0.0)"); # TODO: add frameworks version to this string
   parser.epilog("Available commands:");
   parser.disable_interspersed_args(); // so everything after a command's name will be passed to that command (ex: its --help argumemnt)
   
@@ -113,7 +113,7 @@ int Executable::run(int argc, char const *const *argv)
   const optparse::Values options = parser.parse_args(argc, argv);
   
   // shapeworks global options
-  // todo: handle --quiet, --verbose, whatever else is global
+  // todo: handle --quiet, --verbose, --version, etc.
 
   if (parser.args().empty())
   {

--- a/Applications/shapeworks/shapeworks.cpp
+++ b/Applications/shapeworks/shapeworks.cpp
@@ -23,6 +23,7 @@ int main(int argc, char *argv[])
   shapeworks.addCommand(ImageInfo::getCommand());
   shapeworks.addCommand(Antialias::getCommand());
   shapeworks.addCommand(ResampleImage::getCommand());
+  shapeworks.addCommand(ResizeImage::getCommand());
   shapeworks.addCommand(RecenterImage::getCommand());
   shapeworks.addCommand(PadImage::getCommand());
   shapeworks.addCommand(Translate::getCommand());

--- a/Examples/Python/RunUseCase.py
+++ b/Examples/Python/RunUseCase.py
@@ -34,7 +34,8 @@ if platform.system() == "Darwin":
     default_binpath = "/Applications/ShapeWorks/bin:/Applications/ShapeWorks/bin/ShapeWorksStudio.app/Contents/MacOS"
 
 parser = argparse.ArgumentParser(description='Example ShapeWorks Pipeline')
-parser.add_argument("--use_case", help="Specify which use case to run, either: ellipsoid, ellipsoid_fd, left_atrium, or femur.")
+parser.add_argument("--use_case", help="Specify which use case to run",
+                    choices=["ellipsoid", "ellipsoid_fd", "left_atrium", "femur"])
 parser.add_argument("--use_subsample", help="Set number of samples to run the pipeline for a subset of data.")
 parser.add_argument("--interactive", help="Run in interactive mode", action="store_true")
 parser.add_argument("--start_with_prepped_data", help="Start with already prepped data", action="store_true")

--- a/Libs/Image/Image.cpp
+++ b/Libs/Image/Image.cpp
@@ -414,7 +414,7 @@ Image& Image::scale(const Vector3 &s)
     throw std::invalid_argument("Invalid scale point");
 
   auto origOrigin(origin());       // scale centered at origin, so temporarily set origin to be the center
-  setOrigin(negate(center()));     // move center _away_ from origin since ITK applies transformations backwards.
+  recenter();
 
   AffineTransformPtr xform(AffineTransform::New());
   xform->Scale(invert(Vector(s)));         // invert scale ratio because ITK applies transformations backwards.  
@@ -429,7 +429,7 @@ Image& Image::rotate(const double angle, const Vector3 &axis)
   if (!axis_is_valid(axis)) { throw std::invalid_argument("Invalid axis"); }
 
   auto origOrigin(origin());       // rotation is around origin, so temporarily set origin to be the center
-  setOrigin(negate(center()));     // move center _away_ from origin since ITK applies transformations backwards.
+  recenter();
 
   AffineTransformPtr xform(AffineTransform::New());
   xform->Rotate3D(axis, -angle);   // negate angle because ITK applies transformations backwards.  

--- a/Libs/Image/Image.h
+++ b/Libs/Image/Image.h
@@ -132,8 +132,11 @@ public:
   /// helper identical to setOrigin(image.center()) changing origin (in the image header) to physcial center of the image
   Image& recenter();
 
-  /// Resamples image with new physical spacing and logical size [same size if unspecified]
-  Image& resample(const Point3& physicalSpacing, Dims logicalDims);
+  /// Resamples image to new size based on desired physical spacing
+  Image& resample(const Point3& physicalSpacing);
+
+  /// Resizes image with new physical spacing based on desired logical size
+  Image& resize(Dims logicalDims);
 
   /// pads an image in all directions with constant value
   Image& pad(int padding, PixelType value = 0.0);

--- a/Libs/Image/ImageUtils.cpp
+++ b/Libs/Image/ImageUtils.cpp
@@ -115,10 +115,10 @@ Image& ImageUtils::topologyPreservingSmooth(Image& image, float scaling, float s
   return image.applyTPLevelSetFilter(featureImage, scaling);
 }
 
-Image& ImageUtils::isoresample(Image& image, double isoSpacing, Dims outputSize)
+Image& ImageUtils::isoresample(Image& image, double isoSpacing)
 {
   Point3 spacing({isoSpacing, isoSpacing, isoSpacing});
-  return image.resample(spacing, outputSize);
+  return image.resample(spacing);
 }
 
 } //shapeworks

--- a/Libs/Image/ImageUtils.h
+++ b/Libs/Image/ImageUtils.h
@@ -34,7 +34,7 @@ public:
   ///
   /// \param isoSpacing     size of an [isotropic (n x n x n)] output voxel [default n=1]
   /// \param outputSize     image size can be changed [default stays the same]
-  static Image& isoresample(Image& img, double isoSpacing = 1.0, Dims outputSize = Dims());
+  static Image& isoresample(Image& img, double isoSpacing = 1.0);
 };
 
 } // shapeworks

--- a/Testing/ImageTests/ImageTests.cpp
+++ b/Testing/ImageTests/ImageTests.cpp
@@ -252,6 +252,17 @@ TEST(ImageTests, scaleTest2)
   ASSERT_TRUE(image == ground_truth);
 }
 
+TEST(ImageTests, rotateTest0)
+{
+  std::string test_location = std::string(TEST_DATA_DIR) + std::string("/rotate/");
+
+  Image image(test_location + "la1-small.nrrd");
+  image.rotate(Pi / 2.0, makeVector({0,0,1})); // 90 degrees around the z axis
+  Image ground_truth(test_location + "rotate0_baseline.nrrd");
+
+  ASSERT_TRUE(image == ground_truth);
+}
+
 TEST(ImageTests, rotateTest1)
 {
   std::string test_location = std::string(TEST_DATA_DIR) + std::string("/rotate/");
@@ -1055,3 +1066,48 @@ TEST(ImageTests, divideTest2)
 
   ASSERT_TRUE(image == baseline);
 }
+
+TEST(ImageTests, resample1)
+{
+  std::string test_location = std::string(TEST_DATA_DIR) + std::string("/resample/");
+
+  Image image(test_location + "la1-small.nrrd");
+  image.resample(Point({0.78, 1.0, 10.0}));
+  Image ground_truth(test_location + "baseline_resample1.nrrd");
+
+  ASSERT_TRUE(image == ground_truth);
+}
+
+TEST(ImageTests, resample2)
+{
+  std::string test_location = std::string(TEST_DATA_DIR) + std::string("/resample/");
+
+  Image image(test_location + "la1-small.nrrd");
+  image.resample(Point({0.98, 1.02, 3.14159}));
+  Image ground_truth(test_location + "baseline_resample2.nrrd");
+
+  ASSERT_TRUE(image == ground_truth);
+}
+
+TEST(ImageTests, resize1)
+{
+  std::string test_location = std::string(TEST_DATA_DIR) + std::string("/resize/");
+
+  Image image(test_location + "la1-small.nrrd");
+  image.resize(Dims({20, 40, 60}));
+  Image ground_truth(test_location + "baseline_resize1.nrrd");
+
+  ASSERT_TRUE(image == ground_truth);
+}
+
+TEST(ImageTests, resize2)
+{
+  std::string test_location = std::string(TEST_DATA_DIR) + std::string("/resize/");
+
+  Image image(test_location + "la1-small.nrrd");
+  image.resize(Dims({12, 14, 80}));
+  Image ground_truth(test_location + "baseline_resize2.nrrd");
+
+  ASSERT_TRUE(image == ground_truth);
+}
+

--- a/Testing/data/resample/baseline_resample1.nrrd
+++ b/Testing/data/resample/baseline_resample1.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9030de013b69f9452b3b7369b693d8c5acec3598704fdab2b604da09f6bcc84
+size 84442

--- a/Testing/data/resample/baseline_resample2.nrrd
+++ b/Testing/data/resample/baseline_resample2.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30d9ae58b5c99d4fd5cf6504bbbe94cf1b4a210167f2ab1338024b9f7bdead0c
+size 219561

--- a/Testing/data/resample/la1-small.nrrd
+++ b/Testing/data/resample/la1-small.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c83f22b699271558b8016be930171f50ed006f896b0335b283b6dc591e0664e
+size 1107

--- a/Testing/data/resize/baseline_resize1.nrrd
+++ b/Testing/data/resize/baseline_resize1.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dd870901db432e6b9081aa4a76f21d6ee2738a92d4de2f351d81ea3fe00295a
+size 2538

--- a/Testing/data/resize/baseline_resize2.nrrd
+++ b/Testing/data/resize/baseline_resize2.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9d1dc764a4547b57bec5b8bb7c838b8db8e72375adb7d2305c4bc773c2107a0
+size 916

--- a/Testing/data/resize/la1-small.nrrd
+++ b/Testing/data/resize/la1-small.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c83f22b699271558b8016be930171f50ed006f896b0335b283b6dc591e0664e
+size 1107

--- a/Testing/data/rotate/la1-small.nrrd
+++ b/Testing/data/rotate/la1-small.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c83f22b699271558b8016be930171f50ed006f896b0335b283b6dc591e0664e
+size 1107

--- a/Testing/data/rotate/rotate0_baseline.nrrd
+++ b/Testing/data/rotate/rotate0_baseline.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f13ff4b4fd9da9b995b9f2828006104d99d972f1efeb466bba76d7e48b64080
+size 1153

--- a/Testing/data/scale/scale1_baseline.nrrd
+++ b/Testing/data/scale/scale1_baseline.nrrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dcfb8c96d34c81ced6c923871e439ad22322d41f5a2f70da094cd99d8c155632
-size 17621
+oid sha256:d2b681db92817a0787f21b404fea47c3771c9525a35cf20a48d45ab4672ef06f
+size 14451

--- a/Testing/data/shapeworks/cropped.nrrd
+++ b/Testing/data/shapeworks/cropped.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eccb328f5d203ee66e74d78f4aacbc583059de0ecdadb38e4fac8b6907bbeed1
+size 661

--- a/Testing/data/shapeworks/info.txt
+++ b/Testing/data/shapeworks/info.txt
@@ -2,14 +2,13 @@ image dimensions:      [100, 50, 50]
 physical spacing:      [1, 2, 2]
 size (spacing * dims): [100, 100, 100]
 physical origin:       [0, 0.5, 0.5]
-direction (coordsys):  
-1 0 0
-0 1 0
-0 0 1
-
 center:                [50, 50.5, 50.5]
 center of mass (0,1]:  [49.9917, 49.8699, 49.8699]
 bounding box:          {
 	min: [41, 21, 21],
 	max: [59, 29, 29]
 }
+direction (coordsys):  
+1 0 0
+0 1 0
+0 0 1

--- a/Testing/data/shapeworks/la1-small.nrrd
+++ b/Testing/data/shapeworks/la1-small.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c83f22b699271558b8016be930171f50ed006f896b0335b283b6dc591e0664e
+size 1107

--- a/Testing/data/shapeworks/resample4.nrrd
+++ b/Testing/data/shapeworks/resample4.nrrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7aebb6874d9da5a8dbbd5ea1ad811283ff9d1832ff1258e9deb06b2bf1bd87e6
-size 322
+oid sha256:b41b3b04334c203f1804426725a552762acbf612e5be6246f0731f8159152496
+size 96008

--- a/Testing/data/shapeworks/resize2.nrrd
+++ b/Testing/data/shapeworks/resize2.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53e2ab117b7a5e60d27f0b97ceb81352eb8bcbe0b53076674be3172503aafc81
+size 433

--- a/Testing/data/shapeworks/resize3.nrrd
+++ b/Testing/data/shapeworks/resize3.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12d8becb877fad4f7ca8678cd28c49f04c6f9e9e0619180411630da6e366fc13
+size 3640

--- a/Testing/data/shapeworks/resize4.nrrd
+++ b/Testing/data/shapeworks/resize4.nrrd
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:086d5f9c916c1e8d731def77fbd170bffd1f1c595a7a84fef62c5bf711662754
+size 1193

--- a/Testing/data/shapeworks/scale1.nrrd
+++ b/Testing/data/shapeworks/scale1.nrrd
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d720abbfb3eaeea1398449d174c109f10f9168ddb03cd3e1424ef4177996613
-size 12421
+oid sha256:a8a35cd77a1a0661ab1b5b61f33065983b8b1bf7b1ad4191bf83d48e73349046
+size 10011

--- a/Testing/shapeworksTests/centerofmass.sh
+++ b/Testing/shapeworksTests/centerofmass.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
-shapeworks readimage --name $DATA/1x2x2.nrrd translate --centerofmass 1 compare --name $DATA/centerofmass1.nrrd
+shapeworks readimage --name $DATA/1x2x2.nrrd translate --centerofmass compare --name $DATA/centerofmass1.nrrd
 if [[ $? != 0 ]]; then exit -1; fi
-shapeworks readimage --name $DATA/la-bin.nrrd translate --centerofmass 1 compare --name $DATA/centerofmass2.nrrd
+shapeworks readimage --name $DATA/la-bin.nrrd translate --centerofmass compare --name $DATA/centerofmass2.nrrd

--- a/Testing/shapeworksTests/crop.sh
+++ b/Testing/shapeworksTests/crop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+shapeworks readimage --name $DATA/1x2x2.nrrd crop --xmin 25 --xmax 50 --ymin 1 --ymax 40 --zmin 12 --zmax 23 compare --name $DATA/cropped.nrrd

--- a/Testing/shapeworksTests/resample.sh
+++ b/Testing/shapeworksTests/resample.sh
@@ -6,4 +6,4 @@ shapeworks readimage --name $DATA/1x2x2.nrrd resample --isospacing 1.5 compare -
 if [[ $? != 0 ]]; then exit -1; fi
 shapeworks readimage --name $DATA/1x2x2.nrrd resample --spacex 1.5 --spacey 1.5 --spacez 1.5 compare --name $DATA/resample3.nrrd
 if [[ $? != 0 ]]; then exit -1; fi
-shapeworks readimage --name $DATA/1x2x2.nrrd resample --sizex 1.5 --sizey 1.5 --sizez 1.5 compare --name $DATA/resample4.nrrd
+shapeworks readimage --name $DATA/la1-small.nrrd resample --spacex 0.9 --spacey 3.14159 --spacez 2.5 compare --name $DATA/resample4.nrrd

--- a/Testing/shapeworksTests/resize.sh
+++ b/Testing/shapeworksTests/resize.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+shapeworks readimage --name $DATA/1x2x2.nrrd resize compare --name $DATA/1x2x2.nrrd
+if [[ $? != 0 ]]; then exit -1; fi
+shapeworks readimage --name $DATA/la1-small.nrrd resize --sizex 2 compare --name $DATA/resize2.nrrd
+if [[ $? != 0 ]]; then exit -1; fi
+shapeworks readimage --name $DATA/la1-small.nrrd resize --sizex 96 --sizey 96 --sizez 12 compare --name $DATA/resize3.nrrd
+if [[ $? != 0 ]]; then exit -1; fi
+shapeworks readimage --name $DATA/la1-small.nrrd resize --sizex 24 --sizey 120 --sizez 6 compare --name $DATA/resize4.nrrd

--- a/Testing/shapeworksTests/shapeworksTests.cpp
+++ b/Testing/shapeworksTests/shapeworksTests.cpp
@@ -41,6 +41,13 @@ TEST(shapeworksTests, resample)
 }
 
 //---------------------------------------------------------------------------
+TEST(shapeworksTests, resize)
+{
+  shapeworksEnvSetup();
+  ASSERT_FALSE(system("bash resize.sh"));
+}
+
+//---------------------------------------------------------------------------
 TEST(shapeworksTests, recenter)
 {
   shapeworksEnvSetup();

--- a/Testing/shapeworksTests/shapeworksTests.cpp
+++ b/Testing/shapeworksTests/shapeworksTests.cpp
@@ -292,3 +292,10 @@ TEST(shapeworksTests, division)
   ASSERT_FALSE(system("bash div.sh"));
 }
 
+//---------------------------------------------------------------------------
+TEST(shapeworksTests, crop)
+{
+  shapeworksEnvSetup();
+  ASSERT_FALSE(system("bash crop.sh"));
+}
+

--- a/conda_installs.sh
+++ b/conda_installs.sh
@@ -35,16 +35,16 @@ function install_conda() {
   #update anaconda
   conda config --add channels anaconda
   conda config --add channels conda-forge
-  
+
   if ! conda update --yes -n base conda; then return 1; fi
   if ! conda update --yes --all; then return 1; fi
 
-  #create and activate shapeworks env 
+  #create and activate shapeworks env
   CONDAENV=shapeworks
   if ! conda create --yes --name $CONDAENV python=3.7; then return 1; fi
   eval "$(conda shell.bash hook)"
   if ! conda activate $CONDAENV; then return 1; fi
-  
+
   # pip is needed in sub-environments or the base env's pip will silently install to base
   if ! conda install --yes pip; then return 1; fi
   if ! python -m pip install --upgrade pip; then return 1; fi
@@ -73,20 +73,20 @@ function install_conda() {
   # linux and mac (only) deps
   if [[ "$(uname)" == "Linux" || "$(uname)" == "Darwin" ]]; then
       if ! conda install --yes \
-	   xorg-libx11=1.6.9 \
-	   xorg-libsm=1.2.3 \
-	   libxrandr-devel-cos6-x86_64=1.5.1 \
-	   libxinerama-devel-cos6-x86_64=1.1.3 \
-	   libxcursor-devel-cos6-x86_64=1.1.14 \
-	   libxi-devel-cos6-x86_64=1.7.8 \
-	   git-lfs=2.6.1 \
-	   openmp=8.0.1 \
-	   ncurses=6.1 \
-	   libuuid=2.32.1
+           xorg-libx11=1.6.9 \
+           xorg-libsm=1.2.3 \
+           libxrandr-devel-cos6-x86_64=1.5.1 \
+           libxinerama-devel-cos6-x86_64=1.1.3 \
+           libxcursor-devel-cos6-x86_64=1.1.14 \
+           libxi-devel-cos6-x86_64=1.7.8 \
+           git-lfs=2.6.1 \
+           openmp=8.0.1 \
+           ncurses=6.1 \
+           libuuid=2.32.1
       then return 1; fi
   fi
 
-  
+
   if ! pip install termcolor==1.1.0; then return 1; fi
   if ! pip install grip==4.5.2; then return 1; fi
   if ! pip install matplotlib==3.1.2; then return 1; fi
@@ -111,4 +111,3 @@ else
   echo "Problem encountered creating/updating $CONDAENV conda environment."
   return 1;
 fi
-


### PR DESCRIPTION
biggest items:
- added resize command
- simplified resample command
- fixed scale and rotate commands
- added use cases as options, not merely strings to python example
- updated and added and improved unit tests for image and executable

other:
- un-tabified conda_installs.sh
- improved readability of info command output
- added text to shapeworks --version where release version can be added (and corresponding github issue)
