### PR TITLE
Fix specificity memory issue

### DIFF
--- a/Libs/Particles/ShapeEvaluation.cpp
+++ b/Libs/Particles/ShapeEvaluation.cpp
@@ -111,8 +111,8 @@ double ShapeEvaluation<VDimension>::ComputeSpecificity(const ParticleSystem &par
 
   Eigen::JacobiSVD<Eigen::MatrixXd> svd(Y, Eigen::ComputeFullU);
   const auto epsi = svd.matrixU().block(0, 0, D, nModes);
-  auto eigenValues = svd.singularValues();
-  eigenValues = eigenValues.segment(0, nModes);
+  const auto allEigenValues = svd.singularValues();
+  const auto eigenValues = allEigenValues.head(nModes);
 
   Eigen::MatrixXd samplingBetas(nModes, nSamples);
   MultiVariateNormalRandom sampling{eigenValues.asDiagonal()};


### PR DESCRIPTION
@akenmorris with this change, valgrind stops complaining. Could you check if it works on Mac?

If this solves the issue, do you think its an issue with Eigen dropping memory it shouldn't, or our usage of the function? I can't see anything about this usage pattern [on their docs](https://eigen.tuxfamily.org/dox/group__TutorialBlockOperations.html).