### PR TITLE
Set arbitrarily large limit when querying for item list.

### DIFF
--- a/Python/DatasetUtilsPackage/DatasetUtils/GirderAPI.py
+++ b/Python/DatasetUtilsPackage/DatasetUtils/GirderAPI.py
@@ -155,7 +155,7 @@ def listItemsInFolder(serverAddress, accessToken, folderId):
     actionMessage = 'listing items in folder'
     response = _makeGetRequest(
         url = serverAddress + "api/v1/item", 
-        params = {'folderId': folderId}, 
+        params = {'folderId': folderId, 'limit': 99999}, 
         headers = {'Girder-Token': accessToken}, 
         actionMessage = actionMessage)
     return response.json()


### PR DESCRIPTION
The API call I was using to get list of items has a default limit of 50. 
There doesn't seem to be a way to remove the limit so I set arbitrarily large limit of 99999