### PR TITLE
cleaning up dataset download/unzip logic for ellipsoid,lumps

### DIFF
--- a/Examples/Python/.gitignore
+++ b/Examples/Python/.gitignore
@@ -1,11 +1,12 @@
 TestEllipsoidsFD/
 TestEllipsoids/
 TestEllipsoidsMesh/
+TestLeftAtrium/
 TestFemur/
 TestFemurMesh/
 TestScapula/
 TestCan/
 TestLumps/
-left_atrium.zip
-femur.zip
-lumps.zip
+left_atrium*.zip
+femur*.zip
+lumps*.zip

--- a/Examples/Python/ellipsoid.py
+++ b/Examples/Python/ellipsoid.py
@@ -48,21 +48,26 @@ def Run_Pipeline(args):
         input("Press Enter to continue")
 
     datasetName = "ellipsoid-v0"
-    filename = datasetName + ".zip"
-    # Check if the data is in the right place
-    if not os.path.exists(filename):
-        print("Can't find " + filename + " in the current directory.")
-        import DatasetUtils
-        DatasetUtils.downloadDataset(datasetName)
+    testDirectory = "TestEllipsoids/"
+    originalDataDirectory = testDirectory + datasetName + "/"
+    zipfile = datasetName + ".zip"
+    
+    if not os.path.exists(testDirectory):
+        os.makedirs(testDirectory)
+        
+    # Check if the unzipped data is present
+    if not os.path.exists(originalDataDirectory):
+        # check if the zipped data is present
+        if not os.path.exists(zipfile):
+            print("Can't find " + zipfile)
+            import DatasetUtils
+            DatasetUtils.downloadDataset(datasetName)
+        print("Unzipping " + zipfile + " into " + testDirectory)
+        with ZipFile(zipfile, 'r') as zipObj:
+            zipObj.extractall(path=testDirectory)
 
-    parentDir = "TestEllipsoids/"
-    if not os.path.exists(parentDir):
-        os.makedirs(parentDir)
-    # extract the zipfile
-    with ZipFile(filename, 'r') as zipObj:
-        zipObj.extractall(path=parentDir)
-        parentDir = parentDir + datasetName + "/"
-        fileList = sorted(glob.glob(parentDir + "segmentations/*.nrrd"))
+    parentDir = testDirectory + datasetName + "/"
+    fileList = sorted(glob.glob(parentDir + "segmentations/*.nrrd"))
 
     fileList = fileList[:15]
     if args.tiny_test:

--- a/Examples/Python/ellipsoid_fd.py
+++ b/Examples/Python/ellipsoid_fd.py
@@ -45,23 +45,30 @@ def Run_Pipeline(args):
     if int(args.interactive) != 0:
         input("Press Enter to continue")
 
-    datasetName = "ellipsoid_fd-v0"
-    filename = datasetName + ".zip"
-    # Check if the data is in the right place
-    if not os.path.exists(filename):
-        print("Can't find " + filename + " in the current directory.")
-        import DatasetUtils
-        DatasetUtils.downloadDataset(datasetName)
 
-    parentDir = "TestEllipsoidsFD/"
-    if not os.path.exists(parentDir):
-        os.makedirs(parentDir)
-    # extract the zipfile
-    with ZipFile(filename, 'r') as zipObj:
-        zipObj.extractall(path=parentDir)
-        parentDir = parentDir + datasetName + "/"
-        fileListDT = sorted(glob.glob(parentDir + "distance_transforms/*.nrrd"))
-        fileListNew = sorted(glob.glob(parentDir + "new_distance_transforms/*.nrrd"))
+    
+    datasetName = "ellipsoid_fd-v0"
+    testDirectory = "TestEllipsoidsFD/"
+    originalDataDirectory = testDirectory + datasetName + "/"
+    zipfile = datasetName + ".zip"
+    
+    if not os.path.exists(testDirectory):
+        os.makedirs(testDirectory)
+        
+    # Check if the unzipped data is present
+    if not os.path.exists(originalDataDirectory):
+        # check if the zipped data is present
+        if not os.path.exists(zipfile):
+            print("Can't find " + zipfile)
+            import DatasetUtils
+            DatasetUtils.downloadDataset(datasetName)
+        print("Unzipping " + zipfile + " into " + testDirectory)
+        with ZipFile(zipfile, 'r') as zipObj:
+            zipObj.extractall(path=testDirectory)
+
+    parentDir = testDirectory + datasetName + "/"
+    fileListDT = sorted(glob.glob(originalDataDirectory + "distance_transforms/*.nrrd"))
+    fileListNew = sorted(glob.glob(originalDataDirectory + "new_distance_transforms/*.nrrd"))
 
     """
     ## GROOM : Data Pre-processing 

--- a/Examples/Python/lumps.py
+++ b/Examples/Python/lumps.py
@@ -29,11 +29,11 @@ def Run_Pipeline(args):
         input("Press Enter to continue")
 
     datasetName = "lumps-v0"
-    testDirectory = f"TestLumps/"
+    testDirectory = "TestLumps/"
     originalDataDirectory = testDirectory + datasetName + "/"
     meshFileDirectory = originalDataDirectory + "meshes/"
-    pointFilesDirectory = testDirectory + "PointFiles/"
-    zipfilename = datasetName + ".zip"
+    shapeModelDirectory = testDirectory + "shape_models/"
+    zipfile = datasetName + ".zip"
 
     if not os.path.exists(testDirectory):
         os.makedirs(testDirectory)
@@ -41,12 +41,12 @@ def Run_Pipeline(args):
     # Check if the unzipped data is present
     if not os.path.exists(originalDataDirectory):
         # check if the zipped data is present
-        if not os.path.exists(zipfilename):
-            print("Can't find " + zipfilename + " in the current directory.")
+        if not os.path.exists(zipfile):
+            print("Can't find " + zipfile + " in the current directory.")
             import DatasetUtils
             DatasetUtils.downloadDataset(datasetName)
-        print("Unzipping " + zipfilename + " into " + testDirectory)
-        with ZipFile(zipfilename, 'r') as zipObj:
+        print("Unzipping " + zipfile + " into " + testDirectory)
+        with ZipFile(zipfile, 'r') as zipObj:
             zipObj.extractall(path=testDirectory)
 
 
@@ -60,8 +60,8 @@ def Run_Pipeline(args):
         meshFiles = meshFiles[:2]
 
 
-    if not os.path.exists(pointFilesDirectory):
-        os.makedirs(pointFilesDirectory)
+    if not os.path.exists(shapeModelDirectory):
+        os.makedirs(shapeModelDirectory)
 
     parameterDictionary = {
         "number_of_particles": 512,
@@ -96,12 +96,12 @@ def Run_Pipeline(args):
         parameterDictionary["use_shape_statistics_after"] = 32
 
 
-    [localPointFiles, worldPointFiles] = runShapeWorksOptimize(pointFilesDirectory, meshFiles, parameterDictionary)
+    [localPointFiles, worldPointFiles] = runShapeWorksOptimize(shapeModelDirectory, meshFiles, parameterDictionary)
 
     if args.tiny_test:
         print("Done with tiny test")
         exit()
     
 
-    launchShapeWorksStudio(pointFilesDirectory, meshFiles, localPointFiles, worldPointFiles)
+    launchShapeWorksStudio(shapeModelDirectory, meshFiles, localPointFiles, worldPointFiles)
 


### PR DESCRIPTION
The data folder should now be considered read-only for these three use cases (the usecase won't re-unzip unless the data folder is missing)
Tested:
- [x] ellipsoid
- [x] ellipsoid_fd
- [x] lumps
