### PR TITLE
Set verbosity to 0 for OptimizeTests

### DIFF
--- a/Testing/data/cutting_plane/cutting_plane.xml
+++ b/Testing/data/cutting_plane/cutting_plane.xml
@@ -8,7 +8,7 @@
 <procrustes_scaling> 0 </procrustes_scaling>
 <procrustes_interval> 0 </procrustes_interval>
 <save_init_splits>0</save_init_splits>
-<verbosity>1</verbosity>
+<verbosity>0</verbosity>
 
 <!-- needed to fully turn on cutting planes -->
 <adaptivity_mode> 3 </adaptivity_mode>

--- a/Testing/data/fixed_domain/fixed_domain.xml
+++ b/Testing/data/fixed_domain/fixed_domain.xml
@@ -7,7 +7,7 @@
 <checkpointing_interval> 20 </checkpointing_interval>
 <procrustes_scaling> 0 </procrustes_scaling>
 <procrustes_interval> 0 </procrustes_interval>
-<verbosity>3</verbosity>
+<verbosity>0</verbosity>
 
 <output_dir>
 output

--- a/Testing/data/hemisphere/hemisphere.xml
+++ b/Testing/data/hemisphere/hemisphere.xml
@@ -8,7 +8,7 @@
 <procrustes_scaling> 0 </procrustes_scaling>
 <procrustes_interval> 0 </procrustes_interval>
 <domain_type>mesh</domain_type>
-<verbosity>1</verbosity>
+<verbosity>0</verbosity>
 <save_init_splits>0</save_init_splits>
 
 <output_dir>

--- a/Testing/data/sphere/sphere.xml
+++ b/Testing/data/sphere/sphere.xml
@@ -7,7 +7,7 @@
 <checkpointing_interval> 20 </checkpointing_interval>
 <procrustes_scaling> 1 </procrustes_scaling>
 <procrustes_interval> 1 </procrustes_interval>
-<verbosity>3</verbosity>
+<verbosity>0</verbosity>
 
 <output_dir>
 output


### PR DESCRIPTION
This PR cuts the verbosity of the OptimizeTests down to 0.