### PR TITLE
Optimizer switch to TBB

### DIFF
--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1975,7 +1975,7 @@ void Optimize::AddImage(ImageType::Pointer image)
 }
 
 //---------------------------------------------------------------------------
-void Optimize::AddMesh(shapeworks::MeshWrapper* mesh)
+void Optimize::AddMesh(std::shared_ptr<shapeworks::MeshWrapper> mesh)
 {
   this->m_sampler->AddMesh(mesh);
   this->m_num_shapes++;

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1147,11 +1147,6 @@ void Optimize::PrintParamInfo()
     return;
   }
 
-#ifdef SW_USE_OPENMP
-  std::cout << "OpenMP is enabled ... \n" << std::flush;
-#else
-  std::cout << "OpenMP is disabled ... \n" << std::flush;
-#endif
   // Write out the parameters
   std::cout << "---------------------" << std::endl;
   std::cout << "   I/O parameters" << std::endl;

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -191,7 +191,7 @@ public:
 
   //! Set the shape input images
   void AddImage(ImageType::Pointer image);
-  void AddMesh(shapeworks::MeshWrapper* mesh);
+  void AddMesh(std::shared_ptr<shapeworks::MeshWrapper> mesh);
 
   //! Set the shape filenames (TODO: details)
   void SetFilenames(const std::vector<std::string>& filenames);

--- a/Libs/Optimize/OptimizeParameterFile.cpp
+++ b/Libs/Optimize/OptimizeParameterFile.cpp
@@ -496,10 +496,9 @@ bool OptimizeParameterFile::read_mesh_inputs(TiXmlHandle* docHandle, Optimize* o
       if (this->verbosity_level_ <= 1) {
         TriMesh::set_verbose(0);
       }
-      TriMesh *themesh = TriMesh::read(meshFiles[index].c_str());
-      if (themesh != NULL) {
-        shapeworks::MeshWrapper *mesh = new shapeworks::TriMeshWrapper(themesh);
-        optimize->AddMesh(mesh);
+      auto themesh = std::shared_ptr<TriMesh>(TriMesh::read(meshFiles[index].c_str()));
+      if (themesh) {
+        optimize->AddMesh(std::make_shared<shapeworks::TriMeshWrapper>(themesh));
       }
       else {
         std::cerr << "Failed to read " << meshFiles[index] << "\n";

--- a/Libs/Optimize/ParticleSystem/MeshDomain.h
+++ b/Libs/Optimize/ParticleSystem/MeshDomain.h
@@ -104,7 +104,7 @@ public:
     // TODO Change this to a generic delete function
   }
 
-  void SetMesh(shapeworks::MeshWrapper* mesh_)  {
+  void SetMesh(std::shared_ptr<shapeworks::MeshWrapper> mesh_)  {
     this->m_FixedDomain = false;
     meshWrapper = mesh_;
   }
@@ -123,7 +123,7 @@ protected:
   }
 
 private:
-  shapeworks::MeshWrapper* meshWrapper;
+  std::shared_ptr<shapeworks::MeshWrapper> meshWrapper;
   PointType m_ZeroCrossingPoint;
 
 };

--- a/Libs/Optimize/ParticleSystem/OptimizationVisualizer.cpp
+++ b/Libs/Optimize/ParticleSystem/OptimizationVisualizer.cpp
@@ -29,7 +29,7 @@ namespace shapeworks {
     this->wireFrame = enabled;
   }
 
-  void OptimizationVisualizer::AddMesh(vtkPolyData* mesh, trimesh::TriMesh * tmesh) {
+  void OptimizationVisualizer::AddMesh(vtkPolyData* mesh, std::shared_ptr<trimesh::TriMesh> tmesh) {
     if (this->wireFrame) {
       vtkSmartPointer<vtkExtractEdges> edges = vtkSmartPointer<vtkExtractEdges>::New();
       edges->SetInputData(mesh);

--- a/Libs/Optimize/ParticleSystem/OptimizationVisualizer.h
+++ b/Libs/Optimize/ParticleSystem/OptimizationVisualizer.h
@@ -22,7 +22,7 @@ namespace shapeworks
   {
   public:
 
-    void AddMesh(vtkPolyData *mesh, trimesh::TriMesh *tmesh);
+    void AddMesh(vtkPolyData *mesh, std::shared_ptr<trimesh::TriMesh> tmesh);
     void IterationCallback(itk::ParticleSystem<3> * particleSystem);
 
     void SetWireFrame(bool enabled);
@@ -46,7 +46,7 @@ namespace shapeworks
     double radius;
 
     std::vector<vtkSmartPointer<vtkPolyData>> meshes;
-    std::vector<trimesh::TriMesh *> tmeshes;
+    std::vector<std::shared_ptr<trimesh::TriMesh>> tmeshes;
 
     vtkSmartPointer<vtkPolyDataMapper> mapper = vtkSmartPointer<vtkPolyDataMapper>::New();
     vtkSmartPointer<vtkActor> actor = vtkSmartPointer<vtkActor>::New();

--- a/Libs/Optimize/ParticleSystem/Sampler.cpp
+++ b/Libs/Optimize/ParticleSystem/Sampler.cpp
@@ -282,7 +282,7 @@ void Sampler::ReInitialize()
   this->m_MeanCurvatureCache->ZeroAllValues();
 }
 
-void Sampler::AddMesh(shapeworks::MeshWrapper* mesh)
+void Sampler::AddMesh(std::shared_ptr<shapeworks::MeshWrapper> mesh)
 {
   itk::MeshDomain* domain = new itk::MeshDomain();
   m_NeighborhoodList.push_back(itk::ParticleSurfaceNeighborhood<ImageType>::New());

--- a/Libs/Optimize/ParticleSystem/Sampler.h
+++ b/Libs/Optimize/ParticleSystem/Sampler.h
@@ -134,7 +134,7 @@ public:
       }
   }
 
-  void AddMesh(shapeworks::MeshWrapper* mesh);
+  void AddMesh(std::shared_ptr<shapeworks::MeshWrapper> mesh);
 
   void SetFidsFiles(const std::vector<std::string>& s)
   { m_FidsFiles = s; }

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -352,7 +352,7 @@ namespace shapeworks
     mesh->need_curvatures();
     ComputeMeshBounds();
 
-    kdTree = new KDtree(mesh->vertices);
+    kdTree = std::make_shared<KDtree>(mesh->vertices);
   }
 
   TriMeshWrapper::PointType TriMeshWrapper::GetPointOnMesh() const {

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -55,7 +55,7 @@ namespace shapeworks
     return inter;
   }
 
-  int SlideAlongEdge(Eigen::Vector3d &point_, Eigen::Vector3d &remainingVector_, int face_, int edge_, TriMesh *mesh) {
+  int SlideAlongEdge(Eigen::Vector3d &point_, Eigen::Vector3d &remainingVector_, int face_, int edge_, std::shared_ptr<trimesh::TriMesh> mesh) {
     int indexa = (edge_ + 1) % 3;
     int indexb = (edge_ + 2) % 3;
     int vertexindexa = mesh->faces[face_][indexa];
@@ -339,7 +339,7 @@ namespace shapeworks
     return convert<point, PointType>(snappedPoint);
   }
 
-  TriMeshWrapper::TriMeshWrapper(TriMesh *_mesh) {
+  TriMeshWrapper::TriMeshWrapper(std::shared_ptr<trimesh::TriMesh> _mesh) {
     mesh = _mesh;
     mesh->need_neighbors();
     mesh->need_faces();

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -2,7 +2,6 @@
 #include "TriMeshWrapper.h"
 
 #include <set>
-#include <random>
 
 using namespace trimesh;
 
@@ -10,7 +9,6 @@ namespace shapeworks
 {
   namespace {
     static float epsilon = 1e-6;
-    static std::mt19937 m_rand{42};
 
     template<class T>
     inline std::string PrintValue(T value) {
@@ -297,7 +295,6 @@ namespace shapeworks
         }
       }
     }
-    vec bary = this->ComputeBarycentricCoordinates(pt, closestFace);
     return closestFace;
   }
   vec3 TriMeshWrapper::ComputeBarycentricCoordinates(point pt, int face) const {
@@ -356,9 +353,8 @@ namespace shapeworks
   }
 
   TriMeshWrapper::PointType TriMeshWrapper::GetPointOnMesh() const {
-    int faceIndex = m_rand() % mesh->faces.size();
+    int faceIndex = 0;
     vec center = mesh->centroid(faceIndex);
-    vec bary = ComputeBarycentricCoordinates(center, faceIndex);
     return convert<vec, PointType>(center);
   }
 
@@ -373,10 +369,10 @@ namespace shapeworks
     meshUpperBound = GetPointOnMesh();
     for (int index = 0; index < mesh->vertices.size(); index++) {
       for (int dimension = 0; dimension < 3; dimension++) {
-        meshLowerBound[dimension] = mesh->vertices[index][dimension] < meshLowerBound[dimension]
-          ? mesh->vertices[index][dimension] : meshLowerBound[dimension];
-        meshUpperBound[dimension] = mesh->vertices[index][dimension] > meshUpperBound[dimension]
-          ? mesh->vertices[index][dimension] : meshUpperBound[dimension];
+        meshLowerBound[dimension] = std::min<double>(mesh->vertices[index][dimension],
+                                                     meshLowerBound[dimension]);
+        meshUpperBound[dimension] = std::max<double>(mesh->vertices[index][dimension],
+                                                     meshUpperBound[dimension]);
       }
     }
     double buffer = 1;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -5,33 +5,38 @@
 
 using namespace trimesh;
 
-namespace shapeworks
+namespace shapeworks {
+namespace {
+static float epsilon = 1e-6;
+
+template<class T>
+inline std::string PrintValue(T value)
 {
-  namespace {
-    static float epsilon = 1e-6;
+  return "(" + std::to_string(value[0]) + ", " + std::to_string(value[1]) + ", " +
+         std::to_string(value[2]) + ")";
+}
 
-    template<class T>
-    inline std::string PrintValue(T value) {
-      return "(" + std::to_string(value[0]) + ", " + std::to_string(value[1]) + ", " + std::to_string(value[2]) + ")";
-    }
-
-    inline void PrintTriangle(TriMesh *mesh, int face) {
-      for (int i = 0; i < 3; i++) {
-        fprintf(stderr, "v[%d]=%s\n", i, PrintValue<point>(mesh->vertices[mesh->faces[face][i]]).c_str());
-      }
-    }
-
-    template<class FROM, class TO>
-    inline TO convert(FROM &value) {
-      TO converted;
-      converted[0] = value[0];
-      converted[1] = value[1];
-      converted[2] = value[2];
-      return converted;
-    }
+inline void PrintTriangle(TriMesh* mesh, int face)
+{
+  for (int i = 0; i < 3; i++) {
+    fprintf(stderr, "v[%d]=%s\n", i,
+            PrintValue<point>(mesh->vertices[mesh->faces[face][i]]).c_str());
   }
+}
 
-TriMeshWrapper::TriMeshWrapper(std::shared_ptr<trimesh::TriMesh> mesh) {
+template<class FROM, class TO>
+inline TO convert(FROM& value)
+{
+  TO converted;
+  converted[0] = value[0];
+  converted[1] = value[1];
+  converted[2] = value[2];
+  return converted;
+}
+}
+
+TriMeshWrapper::TriMeshWrapper(std::shared_ptr<trimesh::TriMesh> mesh)
+{
   mesh_ = mesh;
   mesh_->need_neighbors();
   mesh_->need_faces();
@@ -44,345 +49,392 @@ TriMeshWrapper::TriMeshWrapper(std::shared_ptr<trimesh::TriMesh> mesh) {
   kd_tree_ = std::make_shared<KDtree>(mesh_->vertices);
 }
 
+double TriMeshWrapper::ComputeDistance(PointType pointa, PointType pointb) const
+{
+  return pointa.EuclideanDistanceTo(pointb);
+}
 
-double TriMeshWrapper::ComputeDistance(PointType pointa, PointType pointb) const {
-    return pointa.EuclideanDistanceTo(pointb);
+/** start in barycentric coords of currentFace
+    end in barycentric coords of currentFace
+    edge is the edge we are intersecting with.
+*/
+point
+TriMeshWrapper::GetBarycentricIntersection(vec3 start, vec3 end, int currentFace, int edge) const
+{
+  vec3 delta = end - start;
+  if (delta[edge] == 0) {
+    // If going parallel to the edge, it is allowed to go all the way to the end where it wants to go
+    return end;
   }
+  double ratio = -start[edge] / delta[edge];
+  vec3 intersect = start + delta * vec3(ratio, ratio, ratio);
 
-  /** start in barycentric coords of currentFace
-      end in barycentric coords of currentFace
-      edge is the edge we are intersecting with.
-  */
-  point TriMeshWrapper::GetBarycentricIntersection(vec3 start, vec3 end, int currentFace, int edge) const {
-    vec3 delta = end - start;
-    if (delta[edge] == 0) {
-      // If going parallel to the edge, it is allowed to go all the way to the end where it wants to go
-      return end;
+  point inter(0, 0, 0);
+  for (int q = 0; q < 3; q++) {
+    inter += mesh_->vertices[mesh_->faces[currentFace][q]] * intersect[q];
+  }
+  return inter;
+}
+
+int SlideAlongEdge(Eigen::Vector3d& point_, Eigen::Vector3d& remainingVector_, int face_, int edge_,
+                   std::shared_ptr<trimesh::TriMesh> mesh)
+{
+  int indexa = (edge_ + 1) % 3;
+  int indexb = (edge_ + 2) % 3;
+  int vertexindexa = mesh->faces[face_][indexa];
+  int vertexindexb = mesh->faces[face_][indexb];
+  Eigen::Vector3d pointa = convert<trimesh::point, Eigen::Vector3d>(mesh->vertices[vertexindexa]);
+  Eigen::Vector3d pointb = convert<trimesh::point, Eigen::Vector3d>(mesh->vertices[vertexindexb]);
+  Eigen::Vector3d meshEdge(pointb[0] - pointa[0], pointb[1] - pointa[1], pointb[2] - pointa[2]);
+  meshEdge.normalize();
+  double dotprod = meshEdge.dot(remainingVector_);
+  Eigen::Vector3d projectedVector = meshEdge.normalized() * dotprod;
+
+  Eigen::Vector3d maxSlide = pointb - point_;
+  double newDot = projectedVector.dot(meshEdge);
+  int towardsEdge = indexa;
+  if (newDot < 0) {
+    // going in opposite direction as mesh edge
+    meshEdge = -meshEdge;
+    maxSlide = pointa - point_;
+    towardsEdge = indexb;
+  }
+  if (projectedVector.norm() > maxSlide.norm()) {
+    point_ += maxSlide;
+    remainingVector_ = projectedVector - maxSlide;
+    return mesh->across_edge[face_][towardsEdge];
+  }
+  else {
+    point_ += projectedVector;
+    remainingVector_ = Eigen::Vector3d(0, 0, 0);
+    return face_;
+  }
+}
+
+Eigen::Vector3d TriMeshWrapper::GeodesicWalkOnFace(Eigen::Vector3d point_a,
+                                                   Eigen::Vector3d projected_vector,
+                                                   int face_index) const
+{
+
+  int currentFace = face_index;
+  Eigen::Vector3d currentPoint = point_a;
+  Eigen::Vector3d remainingVector = projected_vector;
+  double minimumUpdate = 0.0000000001;
+  double barycentricEpsilon = 0.0001;
+  std::vector<int> facesTraversed;
+  while (remainingVector.norm() > minimumUpdate && currentFace != -1) {
+    facesTraversed.push_back(currentFace);
+    vec3 currentBary = ComputeBarycentricCoordinates(
+      point(currentPoint[0], currentPoint[1], currentPoint[2]), currentFace);
+    Eigen::Vector3d targetPoint = currentPoint + remainingVector;
+    vec3 targetBary = ComputeBarycentricCoordinates(
+      point(targetPoint[0], targetPoint[1], targetPoint[2]), currentFace);
+
+    if (facesTraversed.size() >= 3 &&
+        facesTraversed[facesTraversed.size() - 1] == facesTraversed[facesTraversed.size() - 3]) {
+      // When at the intersection of two faces while also being at the edge of the mesh, the edge-sliding will keep alternating
+      // between the two faces without actually going anywhere since it is at a corner in the mesh.
+      //std::cerr << "exiting due to face repetition\n";
+      break;
     }
-    double ratio = -start[edge] / delta[edge];
-    vec3 intersect = start + delta * vec3(ratio, ratio, ratio);
-
-    point inter(0, 0, 0);
-    for (int q = 0; q < 3; q++) {
-      inter += mesh_->vertices[mesh_->faces[currentFace][q]] * intersect[q];
+    if (facesTraversed.size() > 100) {
+      for (int i = 0; i < facesTraversed.size(); i++) {
+        std::cerr << facesTraversed[i] << ": "
+                  << PrintValue<TriMesh::Face>(mesh_->faces[facesTraversed[i]]) << ", ";
+      }
+      std::cerr << "Current point: " << PrintValue<Eigen::Vector3d>(currentPoint) << "\n";
+      std::cerr << "remaining vector: " << PrintValue<Eigen::Vector3d>(remainingVector) << "\n";
+      std::cerr << "currentBary: " << PrintValue<vec3>(currentBary) << "\n";
+      std::cerr << "targetPoint: " << PrintValue<Eigen::Vector3d>(targetPoint) << "\n";
+      std::cerr << "targetBary: " << PrintValue<vec3>(targetBary) << "\n";
+      std::cerr << std::endl;
+      break;
     }
-    return inter;
-  }
 
-  int SlideAlongEdge(Eigen::Vector3d &point_, Eigen::Vector3d &remainingVector_, int face_, int edge_, std::shared_ptr<trimesh::TriMesh> mesh) {
-    int indexa = (edge_ + 1) % 3;
-    int indexb = (edge_ + 2) % 3;
-    int vertexindexa = mesh->faces[face_][indexa];
-    int vertexindexb = mesh->faces[face_][indexb];
-    Eigen::Vector3d pointa = convert<trimesh::point, Eigen::Vector3d>(mesh->vertices[vertexindexa]);
-    Eigen::Vector3d pointb = convert<trimesh::point, Eigen::Vector3d>(mesh->vertices[vertexindexb]);
-    Eigen::Vector3d meshEdge(pointb[0] - pointa[0], pointb[1] - pointa[1], pointb[2] - pointa[2]);
-    meshEdge.normalize();
-    double dotprod = meshEdge.dot(remainingVector_);
-    Eigen::Vector3d projectedVector = meshEdge.normalized() * dotprod;
-
-    Eigen::Vector3d maxSlide = pointb - point_;
-    double newDot = projectedVector.dot(meshEdge);
-    int towardsEdge = indexa;
-    if (newDot < 0) {
-      // going in opposite direction as mesh edge
-      meshEdge = -meshEdge;
-      maxSlide = pointa - point_;
-      towardsEdge = indexb;
+    if (targetBary[0] + barycentricEpsilon >= 0 && targetBary[1] + barycentricEpsilon >= 0 &&
+        targetBary[2] + barycentricEpsilon >= 0 && targetBary[0] - barycentricEpsilon <= 1 &&
+        targetBary[1] - barycentricEpsilon <= 1 && targetBary[2] - barycentricEpsilon <= 1) {
+      currentPoint = targetPoint;
+      break;
     }
-    if (projectedVector.norm() > maxSlide.norm()) {
-      point_ += maxSlide;
-      remainingVector_ = projectedVector - maxSlide;
-      return mesh->across_edge[face_][towardsEdge];
-    }
-    else {
-      point_ += projectedVector;
-      remainingVector_ = Eigen::Vector3d(0, 0, 0);
-      return face_;
-    }
-  }
-
-  Eigen::Vector3d TriMeshWrapper::GeodesicWalkOnFace(Eigen::Vector3d pointa__, Eigen::Vector3d projectedVector__, int faceIndex__, int prevFace__) const {
-
-    int currentFace = faceIndex__;
-    Eigen::Vector3d currentPoint = pointa__;
-    Eigen::Vector3d remainingVector = projectedVector__;
-    double minimumUpdate = 0.0000000001;
-    double barycentricEpsilon = 0.0001;
-    std::vector<int> facesTraversed;
-    while (remainingVector.norm() > minimumUpdate && currentFace != -1) {
-      facesTraversed.push_back(currentFace);
-      vec3 currentBary = ComputeBarycentricCoordinates(point(currentPoint[0], currentPoint[1], currentPoint[2]), currentFace);
-      Eigen::Vector3d targetPoint = currentPoint + remainingVector;
-      vec3 targetBary = ComputeBarycentricCoordinates(point(targetPoint[0], targetPoint[1], targetPoint[2]), currentFace);
-
-      if (facesTraversed.size() >= 3 && facesTraversed[facesTraversed.size() - 1] == facesTraversed[facesTraversed.size() - 3]) {
-        // When at the intersection of two faces while also being at the edge of the mesh, the edge-sliding will keep alternating
-        // between the two faces without actually going anywhere since it is at a corner in the mesh.
-        //std::cerr << "exiting due to face repetition\n";
-        break;
-      }
-      if (facesTraversed.size() > 100) {
-        for (int i = 0; i < facesTraversed.size(); i++) {
-          std::cerr << facesTraversed[i] << ": " << PrintValue<TriMesh::Face>(mesh_->faces[facesTraversed[i]]) << ", ";
-        }
-        std::cerr << "Current point: " << PrintValue<Eigen::Vector3d>(currentPoint) << "\n";
-        std::cerr << "remaining vector: " << PrintValue<Eigen::Vector3d>(remainingVector) << "\n";
-        std::cerr << "currentBary: " << PrintValue<vec3>(currentBary) << "\n";
-        std::cerr << "targetPoint: " << PrintValue<Eigen::Vector3d>(targetPoint) << "\n";
-        std::cerr << "targetBary: " << PrintValue<vec3>(targetBary) << "\n";
-        std::cerr << std::endl;
-        break;
-      }
-
-      if (targetBary[0] + barycentricEpsilon >= 0 && targetBary[1] + barycentricEpsilon >= 0 && targetBary[2] + barycentricEpsilon >= 0 && targetBary[0] - barycentricEpsilon <= 1 && targetBary[1] - barycentricEpsilon <= 1 && targetBary[2] - barycentricEpsilon <= 1) {
-        currentPoint = targetPoint;
-        break;
-      }
-      int positiveVertex = -1;
-      std::vector<int> negativeVertices;
-      for (int i = 0; i < 3; i++) {
-        if (targetBary[i] >= 0) {
-          positiveVertex = i;
-        }
-        else {
-          negativeVertices.push_back(i);
-        }
-      }
-
-      if (negativeVertices.size() == 0 || negativeVertices.size() > 2) {
-        std::cerr << "ERROR ERROR invalid number of negative vertices. Point is not on surface.\n";
-        break;
-      }
-      int negativeEdge = negativeVertices[0];
-      auto value = GetBarycentricIntersection(currentBary, targetBary, currentFace, negativeEdge);
-      Eigen::Vector3d intersect = convert<point, Eigen::Vector3d>(value);
-
-      // When more than 1 negative barycentric coordinate, compute both intersections and take the closest one.
-      if (negativeVertices.size() == 2) {
-        int negativeEdge1 = negativeVertices[1];
-        auto value = GetBarycentricIntersection(currentBary, targetBary, currentFace, negativeEdge1);
-        Eigen::Vector3d intersect1 = convert<point, Eigen::Vector3d>(value);
-
-        double length0 = (intersect - currentPoint).norm();
-        double length1 = (intersect1 - currentPoint).norm();
-
-        if (length0 < length1) {
-          intersect = intersect;
-          negativeEdge = negativeEdge;
-        }
-        else {
-          intersect = intersect1;
-          negativeEdge = negativeEdge1;
-        }
-      }
-
-      Eigen::Vector3d remaining = targetPoint - intersect;
-      int nextFace = mesh_->across_edge[currentFace][negativeEdge];
-      if (nextFace == -1) {
-        nextFace = SlideAlongEdge(intersect, remaining, currentFace, negativeEdge, mesh_);
-      }
-      remainingVector = remaining;
-      if (nextFace != -1) {
-        remainingVector = RotateVectorToFace(GetFaceNormal(currentFace), GetFaceNormal(nextFace), remainingVector);
-      }
-      currentPoint = intersect;
-      currentFace = nextFace;
-    }
-    return currentPoint;
-  }
-
-  TriMeshWrapper::PointType TriMeshWrapper::GeodesicWalk(PointType pointa, vnl_vector_fixed<double, DIMENSION> vector) const {
-
-    PointType snapped = this->SnapToMesh(pointa);
-    int faceIndex = GetTriangleForPoint(convert<PointType, point>(snapped));
-
-    Eigen::Vector3d vectorEigen = convert<vnl_vector_fixed<double, DIMENSION>, Eigen::Vector3d>(vector);
-    Eigen::Vector3d projectedVector = this->ProjectVectorToFace(GetFaceNormal(faceIndex), vectorEigen);
-
-    Eigen::Vector3d snappedPoint = convert<PointType, Eigen::Vector3d>(snapped);
-    Eigen::Vector3d newPoint = GeodesicWalkOnFace(snappedPoint, projectedVector, faceIndex, -1);
-
-    PointType newPointpt;
-    newPointpt[0] = newPoint[0]; newPointpt[1] = newPoint[1]; newPointpt[2] = newPoint[2];
-    return newPointpt;
-  }
-
-  vnl_vector_fixed<double, DIMENSION> TriMeshWrapper::ProjectVectorToSurfaceTangent(const PointType &pointa, vnl_vector_fixed<double, DIMENSION> &vector) const {
-    int faceIndex = GetTriangleForPoint(convert<const PointType, point>(pointa));
-    const Eigen::Vector3d normal = GetFaceNormal(faceIndex);
-    Eigen::Vector3d result = ProjectVectorToFace(normal, convert<vnl_vector_fixed<double, DIMENSION>, Eigen::Vector3d>(vector));
-    vnl_vector_fixed<double, DIMENSION> resultvnl(result[0], result[1], result[2]);
-    return resultvnl;
-  }
-
-  Eigen::Vector3d TriMeshWrapper::ProjectVectorToFace(const Eigen::Vector3d &normal, const Eigen::Vector3d &vector) const {
-    return vector - normal * normal.dot(vector);
-  }
-
-  Eigen::Vector3d TriMeshWrapper::RotateVectorToFace(const Eigen::Vector3d &prevnormal, const Eigen::Vector3d &nextnormal, const Eigen::Vector3d &vector) const {
-    float dotprod = prevnormal.normalized().dot(nextnormal.normalized());
-    if (dotprod >= 1) {
-      return vector;
-    }
-    float angle = acos(dotprod);
-    Eigen::Vector3d rotationAxis = prevnormal.normalized().cross(nextnormal.normalized()).normalized();
-    Eigen::AngleAxisd transform(angle, rotationAxis);
-    Eigen::Vector3d rotated = transform * vector;
-    return rotated;
-  }
-
-  vnl_vector_fixed<float, DIMENSION> TriMeshWrapper::SampleNormalAtPoint(PointType p) const {
-    point pointa = convert<PointType, point>(p);
-    int face = GetTriangleForPoint(pointa);
-    vec3 bary = ComputeBarycentricCoordinates(pointa, face);
-
-    vnl_vector_fixed<float, DIMENSION> weightedNormal(0, 0, 0);
+    int positiveVertex = -1;
+    std::vector<int> negativeVertices;
     for (int i = 0; i < 3; i++) {
-      vnl_vector_fixed<float, DIMENSION> normal = convert<vec3, vnl_vector_fixed<float, DIMENSION>>(mesh_->normals[mesh_->faces[face][i]]);
-      weightedNormal += normal.normalize() * bary[i];
+      if (targetBary[i] >= 0) {
+        positiveVertex = i;
+      }
+      else {
+        negativeVertices.push_back(i);
+      }
     }
-    return weightedNormal;
-  }
 
-  int TriMeshWrapper::GetNearestVertex(point pt) const {
-    const float * match = kd_tree_->closest_to_pt(pt, 99999999);
-    int match_ind = ( const point *) match - &(mesh_->vertices[0]);
-    return match_ind;
-  }
-
-  std::vector<int> TriMeshWrapper::GetKNearestVertices(point pt, int k) const {
-    std::vector<const float *> knn;
-    kd_tree_->find_k_closest_to_pt(knn, k, pt, 9999999);
-    std::vector<int> vertices;
-    for (int i = 0; i < knn.size(); i++) {
-      int match_ind = ( const point *) knn[i] - &(mesh_->vertices[0]);
-      vertices.push_back(match_ind);
+    if (negativeVertices.size() == 0 || negativeVertices.size() > 2) {
+      std::cerr << "ERROR ERROR invalid number of negative vertices. Point is not on surface.\n";
+      break;
     }
-    return vertices;
+    int negativeEdge = negativeVertices[0];
+    auto value = GetBarycentricIntersection(currentBary, targetBary, currentFace, negativeEdge);
+    Eigen::Vector3d intersect = convert<point, Eigen::Vector3d>(value);
+
+    // When more than 1 negative barycentric coordinate, compute both intersections and take the closest one.
+    if (negativeVertices.size() == 2) {
+      int negativeEdge1 = negativeVertices[1];
+      auto value2 = GetBarycentricIntersection(currentBary, targetBary, currentFace, negativeEdge1);
+      Eigen::Vector3d intersect1 = convert<point, Eigen::Vector3d>(value2);
+
+      double length0 = (intersect - currentPoint).norm();
+      double length1 = (intersect1 - currentPoint).norm();
+
+      if (length0 < length1) {
+        intersect = intersect;
+        negativeEdge = negativeEdge;
+      }
+      else {
+        intersect = intersect1;
+        negativeEdge = negativeEdge1;
+      }
+    }
+
+    Eigen::Vector3d remaining = targetPoint - intersect;
+    int nextFace = mesh_->across_edge[currentFace][negativeEdge];
+    if (nextFace == -1) {
+      nextFace = SlideAlongEdge(intersect, remaining, currentFace, negativeEdge, mesh_);
+    }
+    remainingVector = remaining;
+    if (nextFace != -1) {
+      remainingVector = RotateVectorToFace(GetFaceNormal(currentFace), GetFaceNormal(nextFace),
+                                           remainingVector);
+    }
+    currentPoint = intersect;
+    currentFace = nextFace;
   }
+  return currentPoint;
+}
 
-  vec normalizeBary(const vec &bary) {
-    float sum =abs(bary[0]) + abs(bary[1]) + abs(bary[2]);
-    return vec(bary / sum);
+TriMeshWrapper::PointType
+TriMeshWrapper::GeodesicWalk(PointType pointa, vnl_vector_fixed<double, DIMENSION> vector) const
+{
+
+  PointType snapped = this->SnapToMesh(pointa);
+  int faceIndex = GetTriangleForPoint(convert<PointType, point>(snapped));
+
+  Eigen::Vector3d vectorEigen = convert<vnl_vector_fixed<double, DIMENSION>, Eigen::Vector3d>(
+    vector);
+  Eigen::Vector3d projectedVector = this->ProjectVectorToFace(GetFaceNormal(faceIndex),
+                                                              vectorEigen);
+
+  Eigen::Vector3d snappedPoint = convert<PointType, Eigen::Vector3d>(snapped);
+  Eigen::Vector3d newPoint = GeodesicWalkOnFace(snappedPoint, projectedVector, faceIndex);
+
+  PointType newPointpt;
+  newPointpt[0] = newPoint[0];
+  newPointpt[1] = newPoint[1];
+  newPointpt[2] = newPoint[2];
+  return newPointpt;
+}
+
+vnl_vector_fixed<double, DIMENSION>
+TriMeshWrapper::ProjectVectorToSurfaceTangent(const PointType& pointa,
+                                              vnl_vector_fixed<double, DIMENSION>& vector) const
+{
+  int faceIndex = GetTriangleForPoint(convert<const PointType, point>(pointa));
+  const Eigen::Vector3d normal = GetFaceNormal(faceIndex);
+  Eigen::Vector3d result = ProjectVectorToFace(normal,
+                                               convert<vnl_vector_fixed<double, DIMENSION>, Eigen::Vector3d>(
+                                                 vector));
+  vnl_vector_fixed<double, DIMENSION> resultvnl(result[0], result[1], result[2]);
+  return resultvnl;
+}
+
+Eigen::Vector3d TriMeshWrapper::ProjectVectorToFace(const Eigen::Vector3d& normal,
+                                                    const Eigen::Vector3d& vector) const
+{
+  return vector - normal * normal.dot(vector);
+}
+
+Eigen::Vector3d TriMeshWrapper::RotateVectorToFace(const Eigen::Vector3d& prevnormal,
+                                                   const Eigen::Vector3d& nextnormal,
+                                                   const Eigen::Vector3d& vector) const
+{
+  float dotprod = prevnormal.normalized().dot(nextnormal.normalized());
+  if (dotprod >= 1) {
+    return vector;
   }
+  float angle = acos(dotprod);
+  Eigen::Vector3d rotationAxis = prevnormal.normalized().cross(
+    nextnormal.normalized()).normalized();
+  Eigen::AngleAxisd transform(angle, rotationAxis);
+  Eigen::Vector3d rotated = transform * vector;
+  return rotated;
+}
 
-  // Checks all of the neighbor faces of the 10 nearest vertices to pt.
-  // Returns index of the first face that has valid barycentric coordinates.
-  int TriMeshWrapper::GetTriangleForPoint(point pt) const {
+vnl_vector_fixed<float, DIMENSION> TriMeshWrapper::SampleNormalAtPoint(PointType p) const
+{
+  point pointa = convert<PointType, point>(p);
+  int face = GetTriangleForPoint(pointa);
+  vec3 bary = ComputeBarycentricCoordinates(pointa, face);
 
-    double closestDistance = 99999999;
-    int closestFace = -1;
+  vnl_vector_fixed<float, DIMENSION> weightedNormal(0, 0, 0);
+  for (int i = 0; i < 3; i++) {
+    vnl_vector_fixed<float, DIMENSION> normal = convert<vec3, vnl_vector_fixed<float, DIMENSION>>(
+      mesh_->normals[mesh_->faces[face][i]]);
+    weightedNormal += normal.normalize() * bary[i];
+  }
+  return weightedNormal;
+}
 
-    std::vector<int> vertices = GetKNearestVertices(pt, 10);
-    std::set<int> faceCandidatesSet;
-    for (int j = 0; j < vertices.size(); j++) {
-      int vert = vertices[j];
-      for (int i = 0; i < mesh_->adjacentfaces[vert].size(); i++) {
-        int face = mesh_->adjacentfaces[vert][i];
+int TriMeshWrapper::GetNearestVertex(point pt) const
+{
+  const float* match = kd_tree_->closest_to_pt(pt, 99999999);
+  int match_ind = (const point*) match - &(mesh_->vertices[0]);
+  return match_ind;
+}
 
-        // Only check each face once
-        if (faceCandidatesSet.find(face) == faceCandidatesSet.end()) {
-          faceCandidatesSet.insert(face);
-          vec bary = this->ComputeBarycentricCoordinates(pt, face);
-          bary = normalizeBary(bary);
-          if (((bary[0] >= -epsilon) && (bary[0] <= 1 + epsilon)) &&
+std::vector<int> TriMeshWrapper::GetKNearestVertices(point pt, int k) const
+{
+  std::vector<const float*> knn;
+  kd_tree_->find_k_closest_to_pt(knn, k, pt, 9999999);
+  std::vector<int> vertices;
+  for (int i = 0; i < knn.size(); i++) {
+    int match_ind = (const point*) knn[i] - &(mesh_->vertices[0]);
+    vertices.push_back(match_ind);
+  }
+  return vertices;
+}
+
+vec normalizeBary(const vec& bary)
+{
+  float sum = abs(bary[0]) + abs(bary[1]) + abs(bary[2]);
+  return vec(bary / sum);
+}
+
+// Checks all of the neighbor faces of the 10 nearest vertices to pt.
+// Returns index of the first face that has valid barycentric coordinates.
+int TriMeshWrapper::GetTriangleForPoint(point pt) const
+{
+
+  double closestDistance = 99999999;
+  int closestFace = -1;
+
+  std::vector<int> vertices = GetKNearestVertices(pt, 10);
+  std::set<int> faceCandidatesSet;
+  for (int j = 0; j < vertices.size(); j++) {
+    int vert = vertices[j];
+    for (int i = 0; i < mesh_->adjacentfaces[vert].size(); i++) {
+      int face = mesh_->adjacentfaces[vert][i];
+
+      // Only check each face once
+      if (faceCandidatesSet.find(face) == faceCandidatesSet.end()) {
+        faceCandidatesSet.insert(face);
+        vec bary = this->ComputeBarycentricCoordinates(pt, face);
+        bary = normalizeBary(bary);
+        if (((bary[0] >= -epsilon) && (bary[0] <= 1 + epsilon)) &&
             ((bary[1] >= -epsilon) && (bary[1] <= 1 + epsilon)) &&
-              ((bary[2] >= -epsilon) && (bary[2] <= 1 + epsilon))) {
-            return face;
+            ((bary[2] >= -epsilon) && (bary[2] <= 1 + epsilon))) {
+          return face;
+        }
+        else {
+          float distance = 0;
+          for (int k = 0; k < 3; k++) {
+            if (bary[k] < 0) {
+              distance += -bary[k];
+            }
+            else if (bary[k] > 1) {
+              distance += bary[k] - 1;
+            }
           }
-          else {
-            float distance = 0;
-            for (int j = 0; j < 3; j++) {
-              if (bary[j] < 0) {
-                distance += -bary[j];
-              }
-              else if (bary[j] > 1) {
-                distance += bary[j] - 1;
-              }
-            }
-            if (distance < closestDistance) {
-              closestFace = face;
-              closestDistance = distance;
-            }
+          if (distance < closestDistance) {
+            closestFace = face;
+            closestDistance = distance;
           }
         }
       }
     }
-    return closestFace;
   }
-  vec3 TriMeshWrapper::ComputeBarycentricCoordinates(point pt, int face) const {
-    vec3 bCoords; bCoords.clear();
-    point a, b, c;
-    a = mesh_->vertices[mesh_->faces[face][0]];
-    b = mesh_->vertices[mesh_->faces[face][1]];
-    c = mesh_->vertices[mesh_->faces[face][2]];
+  return closestFace;
+}
 
-    point n = (b - a) CROSS(c - a);
-    normalize(n);
+vec3 TriMeshWrapper::ComputeBarycentricCoordinates(point pt, int face) const
+{
+  vec3 bCoords;
+  bCoords.clear();
+  point a, b, c;
+  a = mesh_->vertices[mesh_->faces[face][0]];
+  b = mesh_->vertices[mesh_->faces[face][1]];
+  c = mesh_->vertices[mesh_->faces[face][2]];
 
-    float area = ((b - a) CROSS(c - a)) DOT n;
-    float inv_area = 1.0f / (area + epsilon);
-    bCoords[0] = (((c - b) CROSS(pt - b)) DOT n) * inv_area;
-    bCoords[1] = (((a - c) CROSS(pt - c)) DOT n) * inv_area;
-    bCoords[2] = (((b - a) CROSS(pt - a)) DOT n) * inv_area;
+  point n = (b - a) CROSS (c - a);
+  normalize(n);
 
-    float sum = bCoords.sum();
-    bCoords[0] /= sum;
-    bCoords[1] /= sum;
-    bCoords[2] /= sum;
+  float area = ((b - a) CROSS (c - a)) DOT n;
+  float inv_area = 1.0f / (area + epsilon);
+  bCoords[0] = (((c - b) CROSS (pt - b)) DOT n) * inv_area;
+  bCoords[1] = (((a - c) CROSS (pt - c)) DOT n) * inv_area;
+  bCoords[2] = (((b - a) CROSS (pt - a)) DOT n) * inv_area;
 
-    return bCoords;
+  float sum = bCoords.sum();
+  bCoords[0] /= sum;
+  bCoords[1] /= sum;
+  bCoords[2] /= sum;
+
+  return bCoords;
+}
+
+// snaps the point to the mesh by getting the barycentric coordinates and normalizing them to sum to 1.
+TriMeshWrapper::PointType TriMeshWrapper::SnapToMesh(PointType pointtype) const
+{
+  point pt = convert<PointType, point>(pointtype);
+  int face = GetTriangleForPoint(pt);
+  vec bary = ComputeBarycentricCoordinates(pt, face);
+  for (int i = 0; i < 3; i++) {
+    if (bary[i] < -epsilon) bary[i] = 0;
+    else if (bary[i] > 1 + epsilon) bary[i] = 1;
   }
+  float sum = abs(bary[0]) + abs(bary[1]) + abs(bary[2]);
+  bary[0] /= sum;
+  bary[1] /= sum;
+  bary[2] /= sum;
+  point snappedPoint(0, 0, 0);
+  for (int i = 0; i < 3; i++) {
+    snappedPoint += mesh_->vertices[mesh_->faces[face][i]] * bary[i];
+  }
+  return convert<point, PointType>(snappedPoint);
+}
 
-  // snaps the point to the mesh by getting the barycentric coordinates and normalizing them to sum to 1.
-  TriMeshWrapper::PointType TriMeshWrapper::SnapToMesh(PointType pointtype) const {
-    point pt = convert<PointType, point>(pointtype);
-    int face = GetTriangleForPoint(pt);
-    vec bary = ComputeBarycentricCoordinates(pt, face);
-    for (int i = 0; i < 3; i++) {
-      if (bary[i] < -epsilon) bary[i] = 0;
-      else if (bary[i] > 1 + epsilon) bary[i] = 1;
+TriMeshWrapper::PointType TriMeshWrapper::GetPointOnMesh() const
+{
+  int faceIndex = 0;
+  vec center = mesh_->centroid(faceIndex);
+  return convert<vec, PointType>(center);
+}
+
+const Eigen::Vector3d TriMeshWrapper::GetFaceNormal(int face_index) const
+{
+  vec n = mesh_->trinorm(face_index);
+  Eigen::Vector3d normal = convert<vec, Eigen::Vector3d>(n);
+  return normal.normalized();
+}
+
+void TriMeshWrapper::ComputeMeshBounds()
+{
+  mesh_lower_bound_ = GetPointOnMesh();
+  mesh_upper_bound_ = GetPointOnMesh();
+  for (auto& vertex : mesh_->vertices) {
+    for (int dimension = 0; dimension < 3; dimension++) {
+      mesh_lower_bound_[dimension] = std::min<double>(vertex[dimension],
+                                                      mesh_lower_bound_[dimension]);
+      mesh_upper_bound_[dimension] = std::max<double>(vertex[dimension],
+                                                      mesh_upper_bound_[dimension]);
     }
-    float sum = abs(bary[0]) + abs(bary[1]) + abs(bary[2]);
-    bary[0] /= sum; bary[1] /= sum; bary[2] /= sum;
-    point snappedPoint(0, 0, 0);
-    for (int i = 0; i < 3; i++) {
-      snappedPoint += mesh_->vertices[mesh_->faces[face][i]] * bary[i];
-    }
-    return convert<point, PointType>(snappedPoint);
   }
-
-  TriMeshWrapper::PointType TriMeshWrapper::GetPointOnMesh() const {
-    int faceIndex = 0;
-    vec center = mesh_->centroid(faceIndex);
-    return convert<vec, PointType>(center);
+  double buffer = 1;
+  for (int i = 0; i < 3; i++) {
+    mesh_lower_bound_[i] = mesh_lower_bound_[i] - buffer;
+    mesh_upper_bound_[i] = mesh_upper_bound_[i] + buffer;
   }
-
-  const Eigen::Vector3d TriMeshWrapper::GetFaceNormal(int face_index) const {
-    vec n = mesh_->trinorm(face_index);
-    Eigen::Vector3d normal = convert<vec, Eigen::Vector3d>(n);
-    return normal.normalized();
+  if (TriMesh::verbose) {
+    std::cerr << "Mesh bounds: " << PrintValue<PointType>(mesh_lower_bound_) << " -> "
+              << PrintValue<PointType>(mesh_upper_bound_) << "\n";
   }
-
-  void TriMeshWrapper::ComputeMeshBounds() {
-    mesh_lower_bound_ = GetPointOnMesh();
-    mesh_upper_bound_ = GetPointOnMesh();
-    for (int index = 0; index < mesh_->vertices.size(); index++) {
-      for (int dimension = 0; dimension < 3; dimension++) {
-        mesh_lower_bound_[dimension] = std::min<double>(mesh_->vertices[index][dimension],
-                                                        mesh_lower_bound_[dimension]);
-        mesh_upper_bound_[dimension] = std::max<double>(mesh_->vertices[index][dimension],
-                                                        mesh_upper_bound_[dimension]);
-      }
-    }
-    double buffer = 1;
-    for (int i = 0; i < 3; i++) {
-      mesh_lower_bound_[i] = mesh_lower_bound_[i] - buffer;
-      mesh_upper_bound_[i] = mesh_upper_bound_[i] + buffer;
-    }
-    if (TriMesh::verbose) {
-      std::cerr << "Mesh bounds: " << PrintValue<PointType>(mesh_lower_bound_) << " -> " << PrintValue<PointType>(mesh_upper_bound_) << "\n";
-    }
-  }
+}
 }

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -57,7 +57,7 @@ private:
   vec3 ComputeBarycentricCoordinates(point pt, int face) const;
 
   TriMesh* mesh;
-  KDtree *kdTree;
+  std::shared_ptr<KDtree> kdTree;
 
   PointType meshLowerBound;
   PointType meshUpperBound;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -14,10 +14,9 @@ namespace shapeworks {
 class TriMeshWrapper : public MeshWrapper {
 public:
 
-  TriMeshWrapper(std::shared_ptr<trimesh::TriMesh> mesh);
+  explicit TriMeshWrapper(std::shared_ptr<trimesh::TriMesh> mesh);
 
-  ~TriMeshWrapper()
-  {}
+  ~TriMeshWrapper() = default;
 
   typedef typename MeshWrapper::PointType PointType;
 
@@ -49,8 +48,8 @@ public:
 private:
 
   Eigen::Vector3d
-  GeodesicWalkOnFace(Eigen::Vector3d point_a, Eigen::Vector3d projected_vector, int face_index,
-                     int prev_face) const;
+  GeodesicWalkOnFace(Eigen::Vector3d point_a,
+                     Eigen::Vector3d projected_vector, int face_index) const;
 
   Eigen::Vector3d
   ProjectVectorToFace(const Eigen::Vector3d& normal, const Eigen::Vector3d& vector) const;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -17,6 +17,9 @@ class TriMeshWrapper : public MeshWrapper
 {
 public:
 
+  TriMeshWrapper(std::shared_ptr<trimesh::TriMesh> _mesh);
+  ~TriMeshWrapper() {}
+
   typedef typename MeshWrapper::PointType PointType;
 
   double ComputeDistance(PointType pointa, PointType pointb) const override;
@@ -29,8 +32,6 @@ public:
 
   PointType SnapToMesh(PointType pointa) const override;
 
-  TriMeshWrapper(trimesh::TriMesh *_mesh);
-  ~TriMeshWrapper() {}
 
   PointType GetPointOnMesh() const override;
 
@@ -55,7 +56,7 @@ private:
   std::vector<int> GetKNearestVertices(trimesh::point pt, int k) const;
   trimesh::vec3 ComputeBarycentricCoordinates(trimesh::point pt, int face) const;
 
-  trimesh::TriMesh* mesh;
+  std::shared_ptr<trimesh::TriMesh> mesh;
   std::shared_ptr<trimesh::KDtree> kdTree;
 
   PointType meshLowerBound;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -9,7 +9,6 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
-using namespace trimesh;
 
 namespace shapeworks
 {
@@ -30,7 +29,7 @@ public:
 
   PointType SnapToMesh(PointType pointa) const override;
 
-  TriMeshWrapper(TriMesh *_mesh);
+  TriMeshWrapper(trimesh::TriMesh *_mesh);
   ~TriMeshWrapper() {}
 
   PointType GetPointOnMesh() const override;
@@ -49,15 +48,15 @@ private:
   const Eigen::Vector3d GetFaceNormal(int faceIndex) const;
   void ComputeMeshBounds();
 
-  point GetBarycentricIntersection(vec3 start, vec3 end, int currentFace, int edge) const;
+  trimesh::point GetBarycentricIntersection(trimesh::vec3 start, trimesh::vec3 end, int currentFace, int edge) const;
 
-  int GetNearestVertex(point pt) const;
-  int GetTriangleForPoint(point pt) const;
-  std::vector<int> GetKNearestVertices(point pt, int k) const;
-  vec3 ComputeBarycentricCoordinates(point pt, int face) const;
+  int GetNearestVertex(trimesh::point pt) const;
+  int GetTriangleForPoint(trimesh::point pt) const;
+  std::vector<int> GetKNearestVertices(trimesh::point pt, int k) const;
+  trimesh::vec3 ComputeBarycentricCoordinates(trimesh::point pt, int face) const;
 
-  TriMesh* mesh;
-  std::shared_ptr<KDtree> kdTree;
+  trimesh::TriMesh* mesh;
+  std::shared_ptr<trimesh::KDtree> kdTree;
 
   PointType meshLowerBound;
   PointType meshUpperBound;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -9,58 +9,73 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+namespace shapeworks {
 
-namespace shapeworks
-{
-
-class TriMeshWrapper : public MeshWrapper
-{
+class TriMeshWrapper : public MeshWrapper {
 public:
 
-  TriMeshWrapper(std::shared_ptr<trimesh::TriMesh> _mesh);
-  ~TriMeshWrapper() {}
+  TriMeshWrapper(std::shared_ptr<trimesh::TriMesh> mesh);
+
+  ~TriMeshWrapper()
+  {}
 
   typedef typename MeshWrapper::PointType PointType;
 
   double ComputeDistance(PointType pointa, PointType pointb) const override;
 
-  PointType GeodesicWalk(PointType pointa, vnl_vector_fixed<double, DIMENSION> vector) const override;
+  PointType
+  GeodesicWalk(PointType pointa, vnl_vector_fixed<double, DIMENSION> vector) const override;
 
-  vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(const PointType &pointa, vnl_vector_fixed<double, DIMENSION> &vector) const override;
+  vnl_vector_fixed<double, DIMENSION>
+  ProjectVectorToSurfaceTangent(const PointType& pointa,
+                                vnl_vector_fixed<double, DIMENSION>& vector) const override;
 
   vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(PointType p) const override;
 
   PointType SnapToMesh(PointType pointa) const override;
 
-
   PointType GetPointOnMesh() const override;
 
-  inline const PointType &GetMeshLowerBound() const override {
-    return meshLowerBound;
+  inline const PointType& GetMeshLowerBound() const override
+  {
+    return mesh_lower_bound_;
   }
-  inline const PointType &GetMeshUpperBound() const override {
-    return meshUpperBound;
+
+  inline const PointType& GetMeshUpperBound() const override
+  {
+    return mesh_upper_bound_;
   }
 
 private:
-  Eigen::Vector3d GeodesicWalkOnFace(Eigen::Vector3d pointa__, Eigen::Vector3d projectedVector__, int faceIndex__, int prevFace__) const;
-  Eigen::Vector3d ProjectVectorToFace(const Eigen::Vector3d &normal, const Eigen::Vector3d &vector) const;
-  Eigen::Vector3d RotateVectorToFace(const Eigen::Vector3d &prevnormal, const Eigen::Vector3d &nextnormal, const Eigen::Vector3d &vector) const;
-  const Eigen::Vector3d GetFaceNormal(int faceIndex) const;
+
+  Eigen::Vector3d
+  GeodesicWalkOnFace(Eigen::Vector3d point_a, Eigen::Vector3d projected_vector, int face_index,
+                     int prev_face) const;
+
+  Eigen::Vector3d
+  ProjectVectorToFace(const Eigen::Vector3d& normal, const Eigen::Vector3d& vector) const;
+
+  Eigen::Vector3d
+  RotateVectorToFace(const Eigen::Vector3d& prev_normal, const Eigen::Vector3d& next_normal,
+                     const Eigen::Vector3d& vector) const;
+
+  const Eigen::Vector3d GetFaceNormal(int face_index) const;
+
   void ComputeMeshBounds();
 
-  trimesh::point GetBarycentricIntersection(trimesh::vec3 start, trimesh::vec3 end, int currentFace, int edge) const;
+  trimesh::point GetBarycentricIntersection(trimesh::vec3 start, trimesh::vec3 end,
+                                            int currentFace, int edge) const;
 
   int GetNearestVertex(trimesh::point pt) const;
   int GetTriangleForPoint(trimesh::point pt) const;
   std::vector<int> GetKNearestVertices(trimesh::point pt, int k) const;
   trimesh::vec3 ComputeBarycentricCoordinates(trimesh::point pt, int face) const;
 
-  std::shared_ptr<trimesh::TriMesh> mesh;
-  std::shared_ptr<trimesh::KDtree> kdTree;
+  std::shared_ptr<trimesh::TriMesh> mesh_;
+  std::shared_ptr<trimesh::KDtree> kd_tree_;
 
-  PointType meshLowerBound;
-  PointType meshUpperBound;
+  PointType mesh_lower_bound_;
+  PointType mesh_upper_bound_;
 };
 
 }

--- a/Libs/Optimize/ParticleSystem/itkParticleGradientDescentPositionOptimizer.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleGradientDescentPositionOptimizer.txx
@@ -22,6 +22,10 @@ const int global_iteration = 1;
 #include "MemoryUsage.h"
 #include <chrono>
 
+#include <tbb/parallel_for.h>
+#include <tbb/task_scheduler_init.h>
+
+
 namespace itk
 {
   template <class TGradientNumericType, unsigned int VDimension>
@@ -64,6 +68,9 @@ namespace itk
   void ParticleGradientDescentPositionOptimizer<TGradientNumericType, VDimension>
     ::StartAdaptiveGaussSeidelOptimization()
   {
+    /// uncomment this to run single threaded
+    //tbb::task_scheduler_init init(1);
+
     if (this->m_AbortProcessing) {
       return;
     }

--- a/Libs/Optimize/ParticleSystem/itkParticleGradientDescentPositionOptimizer.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleGradientDescentPositionOptimizer.txx
@@ -9,9 +9,6 @@
 #ifndef __itkParticleGradientDescentPositionOptimizer_txx
 #define __itkParticleGradientDescentPositionOptimizer_txx
 
-#ifdef SW_USE_OPENMP
-#include <omp.h>
-#endif /* SW_USE_OPENMP */
 const int global_iteration = 1;
 
 #include <algorithm>
@@ -118,15 +115,16 @@ namespace itk
           // skip any flagged domains
           if (m_ParticleSystem->GetDomainFlag(dom) == true)
           {
+            // note that this is really a 'continue' statement for the loop, but using TBB,
+            // we are in an anonymous function, not a loop, so return is equivalent to continue here
             return;
           }
 
           const ParticleDomain *domain = m_ParticleSystem->GetDomain(dom);
 
           typename GradientFunctionType::Pointer localGradientFunction = m_GradientFunction;
-#ifdef SW_USE_OPENMP
-//            localGradientFunction = m_GradientFunction->Clone();
-#endif
+
+          // must clone this as we are in a thread and the gradient function is not thread-safe
           localGradientFunction = m_GradientFunction->Clone();
 
           // Tell function which domain we are working on.

--- a/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
@@ -121,14 +121,6 @@ ParticleMeshBasedGeneralEntropyGradientFunction<VDimension>
 #pragma omp for
     for (int j = 0; j < num_samples; j++)
     {
-        int tid = 1;
-        int num_threads = 1;
-
-#ifdef SW_USE_OPENMP
-        tid = omp_get_thread_num() + 1;
-        num_threads = omp_get_num_threads();
-#endif /* SW_USE_OPENMP */
-
         int num = 0;
         int num2 = 0;
         for (unsigned int d = 0; d < m_DomainsPerShape; d++)

--- a/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleMeshBasedGeneralEntropyGradientFunction.txx
@@ -114,11 +114,9 @@ ParticleMeshBasedGeneralEntropyGradientFunction<VDimension>
     // Jacobian.  Each shape gradient must be transformed by a different Jacobian
     // so we have to do this individually for each shape (sample).
 
-#pragma omp parallel
     {
     vnl_matrix_type Jmatrix;
     vnl_matrix_type v;
-#pragma omp for
     for (int j = 0; j < num_samples; j++)
     {
         int num = 0;


### PR DESCRIPTION
This PR changes out OpenMP for TBB.  The main driver for this is to enable multithreading on Mac, which doesn't support OpenMP (at least not without great difficulty).  TBB has a nearly equivalent parallel-for construct.  I would prefer to use C++17's parallel-for, but we are compiling as C++14 for now (due to limited C++17 support on some platforms).  TBB may also allow us more control over threading than OpenMP should we choose to further parallelize the code.

* Note: This does not add an additional dependency as we already had TBB as a sub-dependency of OpenVDB.

* Diff of point files shows this to be identical before/after.  I did not run *all* the use cases, but I don't there is no reason to think that there would be a difference.

* Speed on windows/linux seems comparable (or faster).

* Speed on Mac is greatly improved.  For example, the left atrium use case runs 4x faster on my mac laptop.

* I left the USE_OPENMP option since there are still OpenMP pragmas in the trimesh code.