### PR TITLE
Revamp checkpointing.

### DIFF
--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -2120,22 +2120,31 @@ void Optimize::PrintDoneMessage(unsigned int vlevel) const
 //---------------------------------------------------------------------------
 std::string Optimize::GetCheckpointDir()
 {
-
   int num_digits = std::to_string(abs(m_total_iterations)).length();
   std::stringstream ss;
-  ss << std::setw(num_digits) << std::setfill('0')
+  ss << std::setw(num_digits) << std::setfill('0') // set leading zeros
      << m_iteration_count + m_optimization_iterations_completed;
 
+  int num_particles = this->m_number_of_particles[0];   // size from domain 0
+  num_digits = std::to_string(num_particles).length();
   std::stringstream ssp;
-  ssp << m_sampler->GetParticleSystem()->GetNumberOfParticles();   // size from domain 0
+  ssp << std::setw(num_digits) << std::setfill('0') // set leading zeros
+      << m_sampler->GetParticleSystem()->GetNumberOfParticles();
 
   std::string suffix = "_init";
   if (this->m_optimizing) {
     suffix = "_opt";
   }
 
-  std::string out_path = m_output_dir;
-  out_path = out_path + "/iter" + ss.str() + "_p" + ssp.str() + suffix;
+  std::string out_path = m_output_dir + "/checkpoints";
+
+#ifdef _WIN32
+  mkdir(out_path.c_str());
+#else
+  mkdir(out_path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+#endif
+
+  out_path = out_path + "/p" + ssp.str() + suffix + "_iter" + ss.str();
 
   return out_path;
 }

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -556,6 +556,9 @@ void Optimize::AddSinglePoint()
   typedef ParticleSystemType::PointType PointType;
 
   PointType firstPointPosition;
+  firstPointPosition[0] = 0;
+  firstPointPosition[1] = 0;
+  firstPointPosition[2] = 0;
   firstPointPosition = m_sampler->GetParticleSystem()->GetDomain(0)->GetValidLocationNear(firstPointPosition);
 
   for (unsigned int i = 0; i < m_sampler->GetParticleSystem()->GetNumberOfDomains(); i++) {

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -354,7 +354,7 @@ protected:
   double m_starting_regularization = 1000;
   double m_ending_regularization = 1.0;
   int m_recompute_regularization_interval = 1;
-  bool m_save_init_splits = true;
+  bool m_save_init_splits = false;
   unsigned int m_checkpointing_interval = 50;
   int m_keep_checkpoints = 0;
   double m_cotan_sigma_factor = 5.0;

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -287,7 +287,7 @@ protected:
   void WritePointFilesWithFeatures(std::string iter_prefix);
   void WriteEnergyFiles();
   void WriteCuttingPlanePoints(int iter = -1);
-  void WriteParameters(int iter = -1);
+  void WriteParameters(std::string output_dir = "");
   void ReportBadParticles();
 
   void SetParameters();
@@ -298,6 +298,9 @@ protected:
   void PrintDoneMessage(unsigned int vlevel = 0) const;
 
   virtual void UpdateExportablePoints();
+
+  // return a checkpoint dir for the current iteration
+  std::string GetCheckpointDir();
 
   std::shared_ptr<Sampler> m_sampler;
   itk::ParticleProcrustesRegistration<3>::Pointer m_procrustes;
@@ -311,7 +314,6 @@ protected:
   int m_procrustes_counter = 0;
   int m_saturation_counter = 0;
   bool m_disable_procrustes = true;
-  bool m_disable_checkpointing = true;
   bool m_use_cutting_planes = false;
   bool m_optimizing = false;
   bool m_use_regression = false;
@@ -391,7 +393,7 @@ protected:
 
   //itk::MemberCommand<Optimize>::Pointer m_iterate_command;
   int m_total_iterations = 0;
-  size_t m_iteration_count = 0;
+  int m_iteration_count = 0;
 
   int m_split_number{0};
 

--- a/Testing/data/hemisphere/hemisphere.xml
+++ b/Testing/data/hemisphere/hemisphere.xml
@@ -8,7 +8,7 @@
 <procrustes_scaling> 0 </procrustes_scaling>
 <procrustes_interval> 0 </procrustes_interval>
 <domain_type>mesh</domain_type>
-<verbosity>0</verbosity>
+<verbosity>5</verbosity>
 <save_init_splits>0</save_init_splits>
 
 <output_dir>

--- a/Testing/data/hemisphere/hemisphere.xml
+++ b/Testing/data/hemisphere/hemisphere.xml
@@ -8,7 +8,7 @@
 <procrustes_scaling> 0 </procrustes_scaling>
 <procrustes_interval> 0 </procrustes_interval>
 <domain_type>mesh</domain_type>
-<verbosity>5</verbosity>
+<verbosity>0</verbosity>
 <save_init_splits>0</save_init_splits>
 
 <output_dir>


### PR DESCRIPTION
This PR revamps the checkpointing to make it more organized and handle multiscale better.  We now have a "checkpoints" directory in the output directory.  Inside will be folders such as:

p02_init_iter010
...
p64_opt_iter900

The format, is, now with leading padded zeros:

P<particle count>_<init/opt>_iter<iteration number>

This PR also fixes a bug in the initialization where an uninitialized point is used to find the first location.  If this undefined value is NaN it can cause this initial position to fail.  This was causing the Mac GH action to hang on open_mesh_test.  Setting the point to [0,0,0] fixes it. 