### PR TITLE
Use case tiny test and subsampling

### DIFF
--- a/Examples/Python/CommonUtils.py
+++ b/Examples/Python/CommonUtils.py
@@ -97,32 +97,6 @@ def sampledata(inDataList, num_sample):
     print("###########################################\n")
     return samples_idx
 
-def convert_to_vtk_mesh(input_file, printCmd=False):
-    file_format = input_file.split(".")[-1]
-    input_vtk = input_file.replace(file_format, "vtk")
-    if file_format == "nrrd":
-        print("\nCreating mesh from: " + input_file)
-        print("\nSaving as: " + input_vtk)
-        xml_filename = os.path.join(os.path.dirname(input_file), "cutting_plane_nrrd2vtk.xml")
-        create_meshfromDT_xml(xml_filename, input_file, input_vtk)
-        execCommand = ["MeshFromDistanceTransforms", xml_filename]
-        if printCmd:
-            print("CMD: " + " ".join(execCommand))
-        subprocess.check_call(execCommand)
-    elif file_format == "ply":
-        execCommand = ["ply2vtk", input_file, input_vtk]
-        if printCmd:
-            print("CMD: " + " ".join(execCommand))
-        subprocess.check_call(execCommand)
-    elif file_format == "stl":
-        execCommand = ["stl2vtk", input_file, input_vtk]
-        if printCmd:
-            print("CMD: " + " ".join(execCommand))
-        subprocess.check_call(execCommand)
-    elif file_format == "vtk":
-        pass
-    return input_vtk
-
 def samplemesh(inMeshList, num_sample, printCmd=False):
     D = np.zeros((len(inMeshList), len(inMeshList)))
     inMeshList = GroomUtils.getVTKmeshes(inMeshList, printCmd)

--- a/Examples/Python/ellipsoid.py
+++ b/Examples/Python/ellipsoid.py
@@ -40,7 +40,7 @@ def Run_Pipeline(args):
         fileList = fileList[:3]
     # Select data if using subsample
     if args.use_subsample:
-        sample_idx = sampledata(fileList, int(args.use_subsample))
+        sample_idx = sampledata(fileList, int(args.num_subsample))
         fileList = [fileList[i] for i in sample_idx]
     else:
         sample_idx = []

--- a/Examples/Python/ellipsoid_cut.py
+++ b/Examples/Python/ellipsoid_cut.py
@@ -38,7 +38,7 @@ def Run_Pipeline(args):
         fileList = fileList[:3]
     # Select data if using subsample
     if args.use_subsample:
-        sample_idx = sampledata(fileList, int(args.use_subsample))
+        sample_idx = sampledata(fileList, int(args.num_subsample))
         fileList = [fileList[i] for i in sample_idx]
     else:
         sample_idx = []

--- a/Examples/Python/ellipsoid_mesh.py
+++ b/Examples/Python/ellipsoid_mesh.py
@@ -37,8 +37,8 @@ def Run_Pipeline(args):
     imageFiles = imageFiles[:15]
     if args.tiny_test:
         args.use_single_scale = 1
-        meshFiles = meshFiles[:2]
-        imageFiles = imageFiles[:2]
+        meshFiles = meshFiles[:3]
+        imageFiles = imageFiles[:3]
 
     pointDir = outputDirectory + 'shape_models/'
     if not os.path.exists(pointDir):

--- a/Examples/Python/ellipsoid_mesh.py
+++ b/Examples/Python/ellipsoid_mesh.py
@@ -31,14 +31,14 @@ def Run_Pipeline(args):
     CommonUtils.download_and_unzip_dataset(datasetName, outputDirectory)
 
     meshFiles = sorted(glob.glob(outputDirectory + datasetName + "/meshes/*.ply"))
-    imageFiles = sorted(glob.glob(outputDirectory + datasetName + "/images/*.nrrd"))
-
-    meshFiles = meshFiles[:15]
-    imageFiles = imageFiles[:15]
+    
     if args.tiny_test:
         args.use_single_scale = 1
         meshFiles = meshFiles[:3]
-        imageFiles = imageFiles[:3]
+    # Select data if using subsample
+    if args.use_subsample:
+        sample_idx = samplemesh(meshFiles, int(args.num_subsample))
+        meshFiles = [meshFiles[i] for i in sample_idx]
 
     pointDir = outputDirectory + 'shape_models/'
     if not os.path.exists(pointDir):
@@ -86,5 +86,4 @@ def Run_Pipeline(args):
     if args.interactive != 0:
         input("Press Enter to continue")
 
-    # Image files are passed because Studio does not support viewing meshes yet.
-    launchShapeWorksStudio(pointDir, imageFiles, localPointFiles, worldPointFiles)
+    launchShapeWorksStudio(pointDir, meshFiles, localPointFiles, worldPointFiles)

--- a/Examples/Python/femur.py
+++ b/Examples/Python/femur.py
@@ -51,7 +51,7 @@ def Run_Pipeline(args):
         args.interactive = False
     # Select data if using subsample
     if args.use_subsample:
-        sample_idx = sampledata(files_img, int(args.use_subsample))
+        sample_idx = sampledata(files_img, int(args.num_subsample))
         files_img = [files_img[i] for i in sample_idx]
         files_mesh = [files_mesh[i] for i in sample_idx]
     else:

--- a/Examples/Python/femur_cut.py
+++ b/Examples/Python/femur_cut.py
@@ -52,7 +52,7 @@ def Run_Pipeline(args):
         args.interactive = False
     # Select data if using subsample
     if args.use_subsample:
-        sample_idx = sampledata(files_img, int(args.use_subsample))
+        sample_idx = sampledata(files_img, int(args.num_subsample))
         files_img = [files_img[i] for i in sample_idx]
         files_mesh = [files_mesh[i] for i in sample_idx]
     else:

--- a/Examples/Python/femur_mesh.py
+++ b/Examples/Python/femur_mesh.py
@@ -36,6 +36,10 @@ def Run_Pipeline(args):
         print('Zero mesh files found in', meshDir)
         return
 
+    if args.tiny_test:
+        args.use_single_scale = 1
+        meshFiles = meshFiles[:3]
+
     pointDir = outputDirectory + 'shape_models/'
 
     if not os.path.exists(pointDir):

--- a/Examples/Python/femur_mesh.py
+++ b/Examples/Python/femur_mesh.py
@@ -39,6 +39,10 @@ def Run_Pipeline(args):
     if args.tiny_test:
         args.use_single_scale = 1
         meshFiles = meshFiles[:3]
+    # Select data if using subsample
+    if args.use_subsample:
+        sample_idx = samplemesh(meshFiles, int(args.num_subsample))
+        meshFiles = [meshFiles[i] for i in sample_idx]
 
     pointDir = outputDirectory + 'shape_models/'
 

--- a/Examples/Python/left_atrium.py
+++ b/Examples/Python/left_atrium.py
@@ -45,7 +45,7 @@ def Run_Pipeline(args):
         args.use_single_scale = True
     # Get data if using subsample
     if args.use_subsample:
-        sample_idx = sampledata(fileList_seg, int(args.use_subsample))
+        sample_idx = sampledata(fileList_seg, int(args.num_subsample))
         fileList_seg= [fileList_seg[i] for i in sample_idx]
         fileList_img = [fileList_img[i] for i in sample_idx]
     else:

--- a/Examples/Python/lumps.py
+++ b/Examples/Python/lumps.py
@@ -26,7 +26,7 @@ def Run_Pipeline(args):
 
     if args.tiny_test:
         args.use_single_scale = 1
-        meshFiles = meshFiles[:2]
+        meshFiles = meshFiles[:3]
 
     shapeModelDirectory = outputDirectory + 'shape_models/'
     if not os.path.exists(shapeModelDirectory):

--- a/Examples/Python/lumps.py
+++ b/Examples/Python/lumps.py
@@ -27,6 +27,10 @@ def Run_Pipeline(args):
     if args.tiny_test:
         args.use_single_scale = 1
         meshFiles = meshFiles[:3]
+    # Select data if using subsample
+    if args.use_subsample:
+        sample_idx = samplemesh(meshFiles, int(args.num_subsample))
+        meshFiles = [meshFiles[i] for i in sample_idx]
 
     shapeModelDirectory = outputDirectory + 'shape_models/'
     if not os.path.exists(shapeModelDirectory):


### PR DESCRIPTION
Updated use cases to:
- Include a tiny test which always runs on the first 3 shapes (issue #789)
- Include the option to run on a subset of the shapes based on clustering on segs or meshes (issue #790)
- Updated documentation on mkdocs branch to specify these options are necessary in new-use-case.md 

The only use case which does not have these options is the ellipsoid fixed domains because these options don't make sense in that context. 

To test tiny_test run:
`python RunUseCase.py --use_case <use_case> --tiny_test`

To test subsampling run:
`python RunUseCase.py --use_case <use_case> --use_subsample --num_subsample <integer>`
(Defaults to 3 if `num_subsample` is not specified)