### PR TITLE
Libigl build included

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: cmake
       shell: bash -l {0}
-      run: conda activate shapeworks && mkdir build && cd build && cmake -DVXL_DIR=$HOME/install/share/vxl/cmake -DITK_DIR=$HOME/install/lib/cmake/ITK-5.0 -DVTK_DIR=$HOME/install/lib/cmake/vtk-8.2 -DEigen3_DIR=$HOME/install/share/eigen3/cmake -DXLNT_DIR=$HOME/install -DOpenVDB_DIR=$HOME/install/lib/cmake/OpenVDB -DCMAKE_BUILD_TYPE=Release -DBuild_Studio=ON -DBuild_View2=ON -DCMAKE_PREFIX_PATH=${CONDA_PREFIX} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/shapeworks-install ..
+      run: conda activate shapeworks && mkdir build && cd build && cmake -DVXL_DIR=$HOME/install/share/vxl/cmake -DITK_DIR=$HOME/install/lib/cmake/ITK-5.0 -DVTK_DIR=$HOME/install/lib/cmake/vtk-8.2 -DEigen3_DIR=$HOME/install/share/eigen3/cmake -DXLNT_DIR=$HOME/install -DLIBIGL_DIR=$HOME/install -DOpenVDB_DIR=$HOME/install/lib/cmake/OpenVDB -DCMAKE_BUILD_TYPE=Release -DBuild_Studio=ON -DBuild_View2=ON -DCMAKE_PREFIX_PATH=${CONDA_PREFIX} -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/shapeworks-install ..
 
     - name: make
       shell: bash -l {0}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -84,7 +84,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: conda activate shapeworks && cmake $GITHUB_WORKSPACE -DCMAKE_CXX_FLAGS="-FS" -DCMAKE_C_FLAGS="-FS" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DVXL_DIR="${{runner.workspace}}\deps\vxl\build" -DITK_DIR="${{runner.workspace}}\deps\lib\cmake\ITK-5.0" -DVTK_DIR="${{runner.workspace}}\deps\lib\cmake\vtk-8.2" -DEigen3_DIR="${{runner.workspace}}\deps\share\eigen3\cmake" -DXLNT_DIR="${{runner.workspace}}\deps" -DOpenVDB_DIR="${{runner.workspace}}\deps\lib\cmake\OpenVDB" -DBuild_Studio=ON -DBuild_View2=ON
+      run: conda activate shapeworks && cmake $GITHUB_WORKSPACE -DCMAKE_CXX_FLAGS="-FS" -DCMAKE_C_FLAGS="-FS" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DVXL_DIR="${{runner.workspace}}\deps\vxl\build" -DITK_DIR="${{runner.workspace}}\deps\lib\cmake\ITK-5.0" -DVTK_DIR="${{runner.workspace}}\deps\lib\cmake\vtk-8.2" -DEigen3_DIR="${{runner.workspace}}\deps\share\eigen3\cmake" -DXLNT_DIR="${{runner.workspace}}\deps" -DLIBIGL_DIR="${{runner.workspace}}\deps" -DOpenVDB_DIR="${{runner.workspace}}\deps\lib\cmake\OpenVDB" -DBuild_Studio=ON -DBuild_View2=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/CMake/FindLIBIGL.cmake
+++ b/CMake/FindLIBIGL.cmake
@@ -1,0 +1,34 @@
+# - Try to find the LIBIGL library
+# Once done this will define
+#
+#  LIBIGL_FOUND - system has LIBIGL
+#  LIBIGL_INCLUDE_DIR - **the** LIBIGL include directory
+if(LIBIGL_FOUND)
+    return()
+endif()
+
+find_path(LIBIGL_INCLUDE_DIR igl/readOBJ.h
+    HINTS
+        ${LIBIGL_DIR}
+        ENV LIBIGL_DIR
+    PATHS
+        ${CMAKE_SOURCE_DIR}/../..
+        ${CMAKE_SOURCE_DIR}/..
+        ${CMAKE_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/libigl
+        ${CMAKE_SOURCE_DIR}/../libigl
+        ${CMAKE_SOURCE_DIR}/../../libigl
+        /usr
+        /usr/local
+        /usr/local/igl/libigl
+    PATH_SUFFIXES include
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LIBIGL
+    "\nlibigl not found --- You can download it using:\n\tgit clone https://github.com/libigl/libigl.git ${CMAKE_SOURCE_DIR}/../libigl"
+    LIBIGL_INCLUDE_DIR)
+mark_as_advanced(LIBIGL_INCLUDE_DIR)
+
+list(APPEND CMAKE_MODULE_PATH "${LIBIGL_INCLUDE_DIR}/../cmake")
+include(libigl)

--- a/CMake/FindLIBIGL.cmake
+++ b/CMake/FindLIBIGL.cmake
@@ -10,12 +10,10 @@ endif()
 set(LIBIGL_DIR "$ENV{LIBIGL_DIR}" CACHE PATH "LIBIGL root directory.")
 message("Looking for LIBIGL in ${LIBIGL_DIR}")
 
-find_path(LIBIGL_INCLUDE_DIR libigl/include/igl/readOBJ.h
-    PATHS
-        ${CMAKE_SOURCE_DIR}
-        /usr
-        /usr/local
-        /usr/local/igl/libigl
+find_path(LIBIGL_INCLUDE_DIR
+  NAMES libigl/include/igl/readOBJ.h
+  HINTS ${CMAKE_SOURCE_DIR}
+  HINTS ${LIBIGL_DIR}
 )
 
 set(LIBIGL_INCLUDE_DIR ${LIBIGL_INCLUDE_DIR}/libigl/cmake)

--- a/CMake/FindLIBIGL.cmake
+++ b/CMake/FindLIBIGL.cmake
@@ -7,28 +7,27 @@ if(LIBIGL_FOUND)
     return()
 endif()
 
-find_path(LIBIGL_INCLUDE_DIR igl/readOBJ.h
-    HINTS
-        ${LIBIGL_DIR}
-        ENV LIBIGL_DIR
+set(LIBIGL_DIR "$ENV{LIBIGL_DIR}" CACHE PATH "LIBIGL root directory.")
+message("Looking for LIBIGL in ${LIBIGL_DIR}")
+
+find_path(LIBIGL_INCLUDE_DIR libigl/include/igl/readOBJ.h
     PATHS
-        ${CMAKE_SOURCE_DIR}/../..
-        ${CMAKE_SOURCE_DIR}/..
         ${CMAKE_SOURCE_DIR}
-        ${CMAKE_SOURCE_DIR}/libigl
-        ${CMAKE_SOURCE_DIR}/../libigl
-        ${CMAKE_SOURCE_DIR}/../../libigl
         /usr
         /usr/local
         /usr/local/igl/libigl
-    PATH_SUFFIXES include
 )
 
+set(LIBIGL_INCLUDE_DIR ${LIBIGL_INCLUDE_DIR}/libigl/cmake)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LIBIGL
     "\nlibigl not found --- You can download it using:\n\tgit clone https://github.com/libigl/libigl.git ${CMAKE_SOURCE_DIR}/../libigl"
     LIBIGL_INCLUDE_DIR)
 mark_as_advanced(LIBIGL_INCLUDE_DIR)
+
+if(LIBIGL_FOUND)
+  message("-- Found LIBIGL under ${LIBIGL_INCLUDE_DIR}")
+endif(LIBIGL_FOUND)
 
 list(APPEND CMAKE_MODULE_PATH "${LIBIGL_INCLUDE_DIR}/../cmake")
 include(libigl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,9 @@ find_package (Eigen3 3.3 REQUIRED NO_MODULE)
 ### XLNT
 find_package (XLNT REQUIRED)
 
+### Libigl set include path
+include_directories("${CMAKE_INSTALL_PREFIX}/../build/libigl/include")
+
 if(USE_OPENMP)
   find_package(OpenMP REQUIRED)
   add_definitions(-DSW_USE_OPENMP) # used in ExternalLibs/trimesh2/include/TriMesh.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,8 @@ find_package (Eigen3 3.3 REQUIRED NO_MODULE)
 find_package (XLNT REQUIRED)
 
 ### Libigl set include path
-include_directories("${CMAKE_INSTALL_PREFIX}/../build/libigl/include")
+include_directories("${CMAKE_PREFIX_PATH}/../build/libigl/include/")
+#MESSAGE("THIS ISNISANOSBCDOSCF ${CMAKE_PREFIX_PATH}")
 
 if(USE_OPENMP)
   find_package(OpenMP REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,9 @@ find_package (Eigen3 3.3 REQUIRED NO_MODULE)
 find_package (XLNT REQUIRED)
 
 ### Libigl set include path
-include_directories("${CMAKE_PREFIX_PATH}/../build/libigl/include/")
+find_package(LIBIGL REQUIRED QUIET)
+
+#include_directories("${CMAKE_PREFIX_PATH}/install/libigl/include/")
 
 if(USE_OPENMP)
   find_package(OpenMP REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,6 @@ find_package (XLNT REQUIRED)
 ### Libigl set include path
 find_package(LIBIGL REQUIRED QUIET)
 
-#include_directories("${CMAKE_PREFIX_PATH}/install/libigl/include/")
-
 if(USE_OPENMP)
   find_package(OpenMP REQUIRED)
   add_definitions(-DSW_USE_OPENMP) # used in ExternalLibs/trimesh2/include/TriMesh.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,6 @@ find_package (XLNT REQUIRED)
 
 ### Libigl set include path
 include_directories("${CMAKE_PREFIX_PATH}/../build/libigl/include/")
-#MESSAGE("THIS ISNISANOSBCDOSCF ${CMAKE_PREFIX_PATH}")
 
 if(USE_OPENMP)
   find_package(OpenMP REQUIRED)

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -277,7 +277,7 @@ build_igl()
   cd libigl
   git checkout -f tags/${libigl_VER}
 
-  LIBIGL_DIR=${INSTALL_DIR}/libigl/include
+  LIBIGL_DIR=${INSTALL_DIR}/libigl/cmake
 }
 
 show_shapeworks_build()
@@ -326,8 +326,8 @@ verify_qt()
 build_all()
 {
   ## create build and install directories
-  if [[ -z $BUILD_DIR ]];   then BUILD_DIR=${SRC}/dependencies/build;     fi
-  if [[ -z $INSTALL_DIR ]]; then INSTALL_DIR=${SRC}/dependencies/install; fi
+  if [[ -z $BUILD_DIR ]];   then BUILD_DIR=${SRC}/dependencies3/build;     fi
+  if [[ -z $INSTALL_DIR ]]; then INSTALL_DIR=${SRC}/dependencies3/install; fi
   mkdir -p ${BUILD_DIR}
   mkdir -p ${INSTALL_DIR}
 

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -20,6 +20,7 @@ ITK_VER_STR="5.0"
 QT_MIN_VER="5.9.8"  # NOTE: 5.x is required, but this restriction is a clever way to ensure the anaconda version of Qt (5.9.6 or 5.9.7) isn't used since it won't work on most systems.
 XLNT_VER="v1.4.0"
 OpenVDB_VER="v7.0.0"
+libigl_VER="v2.2.0"
 
 usage()
 {
@@ -267,6 +268,15 @@ build_openvdb()
   OpenVDB_DIR=${INSTALL_DIR}/lib64/cmake/OpenVDB/
 }
 
+build_igl()
+{
+  echo " "
+  echo "## Building Libigl..."
+  cd ${BUILD_DIR}
+  git clone https://github.com/libigl/libigl.git
+  cd libigl
+  git checkout -f tags/${libigl_VER}
+}
 
 show_shapeworks_build()
 {
@@ -342,6 +352,10 @@ build_all()
 
   if [[ -z $XLNT_DIR ]]; then
     build_xlnt
+  fi
+
+  if [[ -z $LIBIGL_DIR ]]; then
+    build_igl
   fi
 
   # echo dependency directories for easy reference in case the user is independently building ShapeWorks

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -272,12 +272,12 @@ build_igl()
 {
   echo " "
   echo "## Building Libigl..."
-  cd ${BUILD_DIR}
+  cd ${INSTALL_DIR}
   git clone https://github.com/libigl/libigl.git
   cd libigl
   git checkout -f tags/${libigl_VER}
 
-  LIBIGL_DIR=${BUILD_DIR}/libigl/include
+  LIBIGL_DIR=${INSTALL_DIR}/libigl/include
 }
 
 show_shapeworks_build()

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -326,8 +326,8 @@ verify_qt()
 build_all()
 {
   ## create build and install directories
-  if [[ -z $BUILD_DIR ]];   then BUILD_DIR=${SRC}/dependencies3/build;     fi
-  if [[ -z $INSTALL_DIR ]]; then INSTALL_DIR=${SRC}/dependencies3/install; fi
+  if [[ -z $BUILD_DIR ]];   then BUILD_DIR=${SRC}/dependencies/build;     fi
+  if [[ -z $INSTALL_DIR ]]; then INSTALL_DIR=${SRC}/dependencies/install; fi
   mkdir -p ${BUILD_DIR}
   mkdir -p ${INSTALL_DIR}
 

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -276,6 +276,8 @@ build_igl()
   git clone https://github.com/libigl/libigl.git
   cd libigl
   git checkout -f tags/${libigl_VER}
+
+  LIBIGL_DIR=${BUILD_DIR}/libigl/include
 }
 
 show_shapeworks_build()
@@ -366,6 +368,7 @@ build_all()
   echo "  ITK_DIR: ${ITK_DIR}"
   echo "  EIGEN_DIR: ${EIGEN_DIR}"
   echo "  OpenVDB_DIR: ${OpenVDB_DIR}"
+  echo "  LIBIGL_DIR: ${LIBIGL_DIR}"
   echo ""
   
   show_shapeworks_build


### PR DESCRIPTION
This is a very small PR which includes the download for libigl via `build_dependencies.sh` script.
Additionally, I included the include path to the header files to the libigl in the `CMakeLists.txt`.

To include any libigl function we just perform 
``` #include <igl/function.h>```

Here is a simple test which can be performed to check, execute this snippet of code after adding the appropriate changes to the CMake for adding a new script

```
#include <igl/cotmatrix.h>
#include <Eigen/Dense>
#include <Eigen/Sparse>
#include <iostream>
int main()
{
  Eigen::MatrixXd V(4,2);
  V<<0,0,
     1,0,
     1,1,
     0,1;
  Eigen::MatrixXi F(2,3);
  F<<0,1,2,
     0,2,3;
  Eigen::SparseMatrix<double> L;
  igl::cotmatrix(V,F,L);
  std::cout<<"Hello, mesh: "<<std::endl<<L*V<<std::endl;
  return 0;
}
```

I have tried this out and it works.
This PR will set the ball rolling for #684 and stuff that @medakk is working on with libigl (Do mention the issues).

