### PR TITLE
Cache particle -> triangle index

### DIFF
--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -964,6 +964,10 @@ void Optimize::RunOptimize()
   this->WriteParameters();
   if (m_verbosity_level > 0) {
     std::cout << "Finished optimization!!!" << std::endl;
+    for(int i=0; i< m_sampler->GetParticleSystem()->GetNumberOfDomains(); i++) {
+      const auto& dom = m_sampler->GetParticleSystem()->GetDomain(i);
+      dom->PrintStats();
+    }
   }
 }
 

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -964,10 +964,6 @@ void Optimize::RunOptimize()
   this->WriteParameters();
   if (m_verbosity_level > 0) {
     std::cout << "Finished optimization!!!" << std::endl;
-    for(int i=0; i< m_sampler->GetParticleSystem()->GetNumberOfDomains(); i++) {
-      const auto& dom = m_sampler->GetParticleSystem()->GetDomain(i);
-      dom->PrintStats();
-    }
   }
 }
 

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1480,7 +1480,7 @@ void Optimize::WritePointFilesWithFeatures(std::string iter_prefix)
         }
 
         if (m_use_normals[i % m_domains_per_shape]) {
-          vnl_vector_fixed<float, DIMENSION> pG = domain->SampleNormalAtPoint(pos);
+          vnl_vector_fixed<float, DIMENSION> pG = domain->SampleNormalAtPoint(pos, j);
           VectorType pN;
           pN[0] = pG[0];
           pN[1] = pG[1];

--- a/Libs/Optimize/ParticleSystem/MeshDomain.cpp
+++ b/Libs/Optimize/ParticleSystem/MeshDomain.cpp
@@ -11,8 +11,8 @@
 
 namespace itk
 {
-  bool MeshDomain::ApplyConstraints(PointType &p, bool dbg) const {
-    p = meshWrapper->SnapToMesh(p);
+  bool MeshDomain::ApplyConstraints(PointType &p, int idx, bool dbg) const {
+    p = meshWrapper->SnapToMesh(p, idx);
     return true;
   }
 
@@ -22,14 +22,14 @@ namespace itk
     return true;
   }
 
-  vnl_vector_fixed<double, DIMENSION> MeshDomain::ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos) const {
-    return meshWrapper->ProjectVectorToSurfaceTangent(pos, gradE);
+  vnl_vector_fixed<double, DIMENSION> MeshDomain::ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos, int idx) const {
+    return meshWrapper->ProjectVectorToSurfaceTangent(pos, idx, gradE);
   }
 
-  MeshDomain::PointType MeshDomain::UpdateParticlePosition(const PointType &point, vnl_vector_fixed<double, DIMENSION> &update) const {
+  MeshDomain::PointType MeshDomain::UpdateParticlePosition(const PointType &point, int idx, vnl_vector_fixed<double, DIMENSION> &update) const {
     vnl_vector_fixed<double, DIMENSION> negativeUpdate;
     for (unsigned int i = 0; i < DIMENSION; i++) { negativeUpdate[i] = -update[i]; }
-    PointType newPoint = meshWrapper->GeodesicWalk(point, negativeUpdate);
+    PointType newPoint = meshWrapper->GeodesicWalk(point, idx, negativeUpdate);
     return newPoint;
   }
 

--- a/Libs/Optimize/ParticleSystem/MeshDomain.h
+++ b/Libs/Optimize/ParticleSystem/MeshDomain.h
@@ -33,10 +33,6 @@ public:
   vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos, int idx) const override;
   PointType UpdateParticlePosition(const PointType &point, int idx, vnl_vector_fixed<double, DIMENSION> &update) const override;
 
-  void PrintStats() override {
-    meshWrapper->PrintStats();
-  }
-
   double GetCurvature(const PointType &p, int idx) const override {
     //TODO Why not return the actual curvature
     return GetSurfaceMeanCurvature();

--- a/Libs/Optimize/ParticleSystem/MeshDomain.h
+++ b/Libs/Optimize/ParticleSystem/MeshDomain.h
@@ -28,12 +28,13 @@ public:
     return shapeworks::DomainType::Mesh;
   }
 
-  bool ApplyConstraints(PointType &p, bool dbg = false) const override;
+  bool ApplyConstraints(PointType &p, int idx, bool dbg = false) const override;
   bool ApplyVectorConstraints(vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos) const;
-  vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos) const override;
-  PointType UpdateParticlePosition(const PointType &point, vnl_vector_fixed<double, DIMENSION> &update) const override;
+  vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos, int idx) const override;
+  PointType UpdateParticlePosition(const PointType &point, int idx, vnl_vector_fixed<double, DIMENSION> &update) const override;
 
-  double GetCurvature(const PointType &p) const override {
+  double GetCurvature(const PointType &p, int idx) const override {
+    //TODO Why not return the actual curvature
     return GetSurfaceMeanCurvature();
   }
 
@@ -66,7 +67,7 @@ public:
   PointType GetValidLocationNear(PointType p) const override {
     PointType valid;
     valid[0] = p[0]; valid[1] = p[1]; valid[2] = p[2];
-    ApplyConstraints(valid);
+    ApplyConstraints(valid, -1);
     return valid;
   }
 
@@ -77,13 +78,13 @@ public:
 
   double GetMaxDiameter() const override;
 
-  inline vnl_vector_fixed<float, DIMENSION> SampleGradientAtPoint(const PointType &point) const override {
-    return meshWrapper->SampleNormalAtPoint(point);
+  inline vnl_vector_fixed<float, DIMENSION> SampleGradientAtPoint(const PointType &point, int idx) const override {
+    return meshWrapper->SampleNormalAtPoint(point, idx);
   }
-  inline vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(const PointType & point) const override {
-    return meshWrapper->SampleNormalAtPoint(point);
+  inline vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(const PointType & point, int idx) const override {
+    return meshWrapper->SampleNormalAtPoint(point, idx);
   }
-  inline vnl_matrix_fixed<float, DIMENSION, DIMENSION> SampleHessianAtPoint(const PointType &p) const override {
+  inline vnl_matrix_fixed<float, DIMENSION, DIMENSION> SampleHessianAtPoint(const PointType &p, int idx) const override {
     //return meshWrapper->SampleHessianAtPoint(p);
     // TODO need to figure out how to compute Hessians at mesh vertices.
     return vnl_matrix_fixed<float, DIMENSION, DIMENSION>();

--- a/Libs/Optimize/ParticleSystem/MeshDomain.h
+++ b/Libs/Optimize/ParticleSystem/MeshDomain.h
@@ -33,6 +33,10 @@ public:
   vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos, int idx) const override;
   PointType UpdateParticlePosition(const PointType &point, int idx, vnl_vector_fixed<double, DIMENSION> &update) const override;
 
+  void PrintStats() override {
+    meshWrapper->PrintStats();
+  }
+
   double GetCurvature(const PointType &p, int idx) const override {
     //TODO Why not return the actual curvature
     return GetSurfaceMeanCurvature();

--- a/Libs/Optimize/ParticleSystem/MeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/MeshWrapper.h
@@ -17,6 +17,8 @@ public:
   // Returns updated point position after applying the update vector to the initial position.
   virtual PointType GeodesicWalk(PointType pointa, int idx, vnl_vector_fixed<double, DIMENSION> vector) const = 0;
 
+  virtual void PrintStats()=0;
+
   // Returns a point on the mesh.
   virtual PointType GetPointOnMesh() const = 0;
 

--- a/Libs/Optimize/ParticleSystem/MeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/MeshWrapper.h
@@ -15,7 +15,7 @@ public:
   // Computed distance between points. (Currently euclidean)
   virtual double ComputeDistance(PointType pointa, PointType pointb) const = 0;
   // Returns updated point position after applying the update vector to the initial position.
-  virtual PointType GeodesicWalk(PointType pointa, vnl_vector_fixed<double, DIMENSION> vector) const = 0;
+  virtual PointType GeodesicWalk(PointType pointa, int idx, vnl_vector_fixed<double, DIMENSION> vector) const = 0;
 
   // Returns a point on the mesh.
   virtual PointType GetPointOnMesh() const = 0;
@@ -25,11 +25,11 @@ public:
   // Returns maximum corner of bounding box.
   virtual const PointType &GetMeshUpperBound() const = 0;
 
-  virtual vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(const PointType & pointa, vnl_vector_fixed<double, DIMENSION> & vector) const = 0;
-  virtual vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(PointType p) const = 0;
+  virtual vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(const PointType & pointa, int idx, vnl_vector_fixed<double, DIMENSION> & vector) const = 0;
+  virtual vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(PointType p, int idx) const = 0;
 
   // Returns closest point on mesh to pointa.
-  virtual PointType SnapToMesh(PointType pointa) const = 0;
+  virtual PointType SnapToMesh(PointType pointa, int idx) const = 0;
 };
 
 }

--- a/Libs/Optimize/ParticleSystem/MeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/MeshWrapper.h
@@ -17,8 +17,6 @@ public:
   // Returns updated point position after applying the update vector to the initial position.
   virtual PointType GeodesicWalk(PointType pointa, int idx, vnl_vector_fixed<double, DIMENSION> vector) const = 0;
 
-  virtual void PrintStats()=0;
-
   // Returns a point on the mesh.
   virtual PointType GetPointOnMesh() const = 0;
 

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -316,6 +316,7 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx) const
   // given a guess, just check whether it is still valid.
   if(idx != -1) {
     int guess = particleIdx2faceIdx[idx];
+    //TODO does this suffice or do we have to check the normal
     vec bary = this->ComputeBarycentricCoordinates(pt, guess);
     bary = normalizeBary(bary);
     if (((bary[0] >= -epsilon) && (bary[0] <= 1 + epsilon)) &&

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -310,7 +310,7 @@ vec normalizeBary(const vec& bary)
   return vec(bary / sum);
 }
 
-inline bool TriMeshWrapper::IsBarycentricCoordinateValid(trimesh::vec3 &bary) {
+inline bool TriMeshWrapper::IsBarycentricCoordinateValid(trimesh::vec3& bary) {
   return ((bary[0] >= -epsilon) && (bary[0] <= 1 + epsilon)) &&
          ((bary[1] >= -epsilon) && (bary[1] <= 1 + epsilon)) &&
          ((bary[2] >= -epsilon) && (bary[2] <= 1 + epsilon));
@@ -323,16 +323,15 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx, vec& baryOut) const
 {
   // given a guess, just check whether it is still valid.
   if(idx != -1) {
-    triQueries++;
     // ensure that the cache has enough elements. this will never be resized to more than the number of particles,
-    // and will be a noop if the vector is already correctly resized
-    particle2tri.resize(idx+1, 0);
+    if(idx >= particle2tri.size()) {
+      particle2tri.resize(idx+1, 0);
+    }
 
     const int guess = particle2tri[idx];
     baryOut = this->ComputeBarycentricCoordinates(pt, guess);
     baryOut = normalizeBary(baryOut);
     if(IsBarycentricCoordinateValid(baryOut)) {
-      triQueriesHits++;
       return guess;
     }
   }

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -315,6 +315,7 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx) const
 {
   // given a guess, just check whether it is still valid.
   if(idx != -1) {
+    triQueries++;
     int guess = particleIdx2faceIdx[idx];
     //TODO does this suffice or do we have to check the normal
     vec bary = this->ComputeBarycentricCoordinates(pt, guess);
@@ -322,6 +323,7 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx) const
     if (((bary[0] >= -epsilon) && (bary[0] <= 1 + epsilon)) &&
         ((bary[1] >= -epsilon) && (bary[1] <= 1 + epsilon)) &&
         ((bary[2] >= -epsilon) && (bary[2] <= 1 + epsilon))) {
+      triQueriesHits++;
       return guess;
     }
   }
@@ -344,6 +346,9 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx) const
         if (((bary[0] >= -epsilon) && (bary[0] <= 1 + epsilon)) &&
             ((bary[1] >= -epsilon) && (bary[1] <= 1 + epsilon)) &&
             ((bary[2] >= -epsilon) && (bary[2] <= 1 + epsilon))) {
+          if(idx != -1) {
+            particleIdx2faceIdx[idx] = face;
+          }
           return face;
         }
         else {

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -212,11 +212,11 @@ Eigen::Vector3d TriMeshWrapper::GeodesicWalkOnFace(Eigen::Vector3d point_a,
 }
 
 TriMeshWrapper::PointType
-TriMeshWrapper::GeodesicWalk(PointType pointa, vnl_vector_fixed<double, DIMENSION> vector) const
+TriMeshWrapper::GeodesicWalk(PointType pointa, int idx, vnl_vector_fixed<double, DIMENSION> vector) const
 {
 
-  PointType snapped = this->SnapToMesh(pointa);
-  int faceIndex = GetTriangleForPoint(convert<PointType, point>(snapped));
+  PointType snapped = this->SnapToMesh(pointa, idx);
+  int faceIndex = GetTriangleForPoint(convert<PointType, point>(snapped), idx);
 
   Eigen::Vector3d vectorEigen = convert<vnl_vector_fixed<double, DIMENSION>, Eigen::Vector3d>(
     vector);
@@ -234,10 +234,10 @@ TriMeshWrapper::GeodesicWalk(PointType pointa, vnl_vector_fixed<double, DIMENSIO
 }
 
 vnl_vector_fixed<double, DIMENSION>
-TriMeshWrapper::ProjectVectorToSurfaceTangent(const PointType& pointa,
+TriMeshWrapper::ProjectVectorToSurfaceTangent(const PointType& pointa, int idx,
                                               vnl_vector_fixed<double, DIMENSION>& vector) const
 {
-  int faceIndex = GetTriangleForPoint(convert<const PointType, point>(pointa));
+  int faceIndex = GetTriangleForPoint(convert<const PointType, point>(pointa), idx);
   const Eigen::Vector3d normal = GetFaceNormal(faceIndex);
   Eigen::Vector3d result = ProjectVectorToFace(normal,
                                                convert<vnl_vector_fixed<double, DIMENSION>, Eigen::Vector3d>(
@@ -268,10 +268,10 @@ Eigen::Vector3d TriMeshWrapper::RotateVectorToFace(const Eigen::Vector3d& prevno
   return rotated;
 }
 
-vnl_vector_fixed<float, DIMENSION> TriMeshWrapper::SampleNormalAtPoint(PointType p) const
+vnl_vector_fixed<float, DIMENSION> TriMeshWrapper::SampleNormalAtPoint(PointType p, int idx) const
 {
   point pointa = convert<PointType, point>(p);
-  int face = GetTriangleForPoint(pointa);
+  int face = GetTriangleForPoint(pointa, idx);
   vec3 bary = ComputeBarycentricCoordinates(pointa, face);
 
   vnl_vector_fixed<float, DIMENSION> weightedNormal(0, 0, 0);
@@ -310,8 +310,20 @@ vec normalizeBary(const vec& bary)
 
 // Checks all of the neighbor faces of the 10 nearest vertices to pt.
 // Returns index of the first face that has valid barycentric coordinates.
-int TriMeshWrapper::GetTriangleForPoint(point pt) const
+//TODO Return barycentric coordinate as well, everyone seems to want it
+int TriMeshWrapper::GetTriangleForPoint(point pt, int idx) const
 {
+  // given a guess, just check whether it is still valid.
+  if(idx != -1) {
+    int guess = particleIdx2faceIdx[idx];
+    vec bary = this->ComputeBarycentricCoordinates(pt, guess);
+    bary = normalizeBary(bary);
+    if (((bary[0] >= -epsilon) && (bary[0] <= 1 + epsilon)) &&
+        ((bary[1] >= -epsilon) && (bary[1] <= 1 + epsilon)) &&
+        ((bary[2] >= -epsilon) && (bary[2] <= 1 + epsilon))) {
+      return guess;
+    }
+  }
 
   double closestDistance = 99999999;
   int closestFace = -1;
@@ -351,6 +363,9 @@ int TriMeshWrapper::GetTriangleForPoint(point pt) const
       }
     }
   }
+  if(idx != -1) {
+    particleIdx2faceIdx[idx] = closestFace;
+  }
   return closestFace;
 }
 
@@ -381,10 +396,10 @@ vec3 TriMeshWrapper::ComputeBarycentricCoordinates(point pt, int face) const
 }
 
 // snaps the point to the mesh by getting the barycentric coordinates and normalizing them to sum to 1.
-TriMeshWrapper::PointType TriMeshWrapper::SnapToMesh(PointType pointtype) const
+TriMeshWrapper::PointType TriMeshWrapper::SnapToMesh(PointType pointtype, int idx) const
 {
   point pt = convert<PointType, point>(pointtype);
-  int face = GetTriangleForPoint(pt);
+  int face = GetTriangleForPoint(pt, idx);
   vec bary = ComputeBarycentricCoordinates(pt, face);
   for (int i = 0; i < 3; i++) {
     if (bary[i] < -epsilon) bary[i] = 0;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -324,11 +324,11 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx, vec& baryOut) const
   // given a guess, just check whether it is still valid.
   if(idx != -1) {
     // ensure that the cache has enough elements. this will never be resized to more than the number of particles,
-    if(idx >= particle2tri.size()) {
-      particle2tri.resize(idx+1, 0);
+    if(idx >= particle2tri_.size()) {
+      particle2tri_.resize(idx + 1, 0);
     }
 
-    const int guess = particle2tri[idx];
+    const int guess = particle2tri_[idx];
     baryOut = this->ComputeBarycentricCoordinates(pt, guess);
     baryOut = normalizeBary(baryOut);
     if(IsBarycentricCoordinateValid(baryOut)) {
@@ -354,7 +354,7 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx, vec& baryOut) const
         if (IsBarycentricCoordinateValid(baryOut)) {
           if(idx != -1) {
             // update cache
-            particle2tri[idx] = face;
+            particle2tri_[idx] = face;
           }
           return face;
         }
@@ -378,7 +378,7 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx, vec& baryOut) const
   }
   if(idx != -1) {
     // update cache
-    particle2tri[idx] = closestFace;
+    particle2tri_[idx] = closestFace;
   }
   return closestFace;
 }

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -310,7 +310,7 @@ vec normalizeBary(const vec& bary)
   return vec(bary / sum);
 }
 
-inline bool TriMeshWrapper::IsBarycentricCoordinateValid(trimesh::vec3& bary) {
+inline bool TriMeshWrapper::IsBarycentricCoordinateValid(const trimesh::vec3& bary) {
   return ((bary[0] >= -epsilon) && (bary[0] <= 1 + epsilon)) &&
          ((bary[1] >= -epsilon) && (bary[1] <= 1 + epsilon)) &&
          ((bary[2] >= -epsilon) && (bary[2] <= 1 + epsilon));
@@ -330,8 +330,8 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx, vec& baryOut) const
 
     const int guess = particle2tri_[idx];
     baryOut = this->ComputeBarycentricCoordinates(pt, guess);
-    baryOut = normalizeBary(baryOut);
-    if(IsBarycentricCoordinateValid(baryOut)) {
+    const vec norBary = normalizeBary(baryOut);
+    if(IsBarycentricCoordinateValid(norBary)) {
       return guess;
     }
   }
@@ -350,8 +350,8 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx, vec& baryOut) const
       if (faceCandidatesSet.find(face) == faceCandidatesSet.end()) {
         faceCandidatesSet.insert(face);
         baryOut = this->ComputeBarycentricCoordinates(pt, face);
-        baryOut = normalizeBary(baryOut);
-        if (IsBarycentricCoordinateValid(baryOut)) {
+        const vec norBary = normalizeBary(baryOut);
+        if (IsBarycentricCoordinateValid(norBary)) {
           if(idx != -1) {
             // update cache
             particle2tri_[idx] = face;
@@ -361,11 +361,11 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx, vec& baryOut) const
         else {
           float distance = 0;
           for (int k = 0; k < 3; k++) {
-            if (baryOut[k] < 0) {
-              distance += -baryOut[k];
+            if (norBary[k] < 0) {
+              distance += -norBary[k];
             }
-            else if (baryOut[k] > 1) {
-              distance += baryOut[k] - 1;
+            else if (norBary[k] > 1) {
+              distance += norBary[k] - 1;
             }
           }
           if (distance < closestDistance) {
@@ -376,6 +376,7 @@ int TriMeshWrapper::GetTriangleForPoint(point pt, int idx, vec& baryOut) const
       }
     }
   }
+  baryOut = this->ComputeBarycentricCoordinates(pt, closestFace);
   if(idx != -1) {
     // update cache
     particle2tri_[idx] = closestFace;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -72,16 +72,20 @@ private:
                                             int currentFace, int edge) const;
 
   int GetNearestVertex(trimesh::point pt) const;
-  int GetTriangleForPoint(trimesh::point pt, int idx) const;
+  int GetTriangleForPoint(trimesh::point pt, int idx, trimesh::vec& bary) const;
   std::vector<int> GetKNearestVertices(trimesh::point pt, int k) const;
   trimesh::vec3 ComputeBarycentricCoordinates(trimesh::point pt, int face) const;
+
+  static inline bool IsBarycentricCoordinateValid(trimesh::vec3& b);
 
   std::shared_ptr<trimesh::TriMesh> mesh_;
   std::shared_ptr<trimesh::KDtree> kd_tree_;
 
-  mutable std::unordered_map<int, int> particleIdx2faceIdx;
-  mutable unsigned long triQueries{0};
+  // Maintains a map of particle index -> triangle index
+  // Has to be mutable because all of the accessor APIs are const
+  mutable std::vector<int> particle2tri; //todo convention _
   mutable unsigned long triQueriesHits{0};
+  mutable unsigned long triQueries{0};
 
   PointType mesh_lower_bound_;
   PointType mesh_upper_bound_;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -19,6 +19,11 @@ public:
 
   ~TriMeshWrapper() = default;
 
+  virtual void PrintStats() override {
+    double hitRate = (double) triQueriesHits / (double) triQueries;
+    std::cout << "Hits: " << triQueriesHits << " / " << triQueries << " | " << hitRate << std::endl;
+  }
+
   typedef typename MeshWrapper::PointType PointType;
 
   double ComputeDistance(PointType pointa, PointType pointb) const override;
@@ -75,6 +80,8 @@ private:
   std::shared_ptr<trimesh::KDtree> kd_tree_;
 
   mutable std::unordered_map<int, int> particleIdx2faceIdx;
+  mutable unsigned long triQueries{0};
+  mutable unsigned long triQueriesHits{0};
 
   PointType mesh_lower_bound_;
   PointType mesh_upper_bound_;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -8,7 +8,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <unordered_map>
+#include <vector>
 
 namespace shapeworks {
 
@@ -78,7 +78,7 @@ private:
 
   // Maintains a map of particle index -> triangle index
   // Has to be mutable because all of the accessor APIs are const
-  mutable std::vector<int> particle2tri; //todo convention _
+  mutable std::vector<int> particle2tri_;
 
   PointType mesh_lower_bound_;
   PointType mesh_upper_bound_;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -71,7 +71,7 @@ private:
   std::vector<int> GetKNearestVertices(trimesh::point pt, int k) const;
   trimesh::vec3 ComputeBarycentricCoordinates(trimesh::point pt, int face) const;
 
-  static inline bool IsBarycentricCoordinateValid(trimesh::vec3& b);
+  static inline bool IsBarycentricCoordinateValid(const trimesh::vec3& b);
 
   std::shared_ptr<trimesh::TriMesh> mesh_;
   std::shared_ptr<trimesh::KDtree> kd_tree_;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -19,11 +19,6 @@ public:
 
   ~TriMeshWrapper() = default;
 
-  virtual void PrintStats() override {
-    double hitRate = (double) triQueriesHits / (double) triQueries;
-    std::cout << "Hits: " << triQueriesHits << " / " << triQueries << " | " << hitRate << std::endl;
-  }
-
   typedef typename MeshWrapper::PointType PointType;
 
   double ComputeDistance(PointType pointa, PointType pointb) const override;
@@ -84,8 +79,6 @@ private:
   // Maintains a map of particle index -> triangle index
   // Has to be mutable because all of the accessor APIs are const
   mutable std::vector<int> particle2tri; //todo convention _
-  mutable unsigned long triQueriesHits{0};
-  mutable unsigned long triQueries{0};
 
   PointType mesh_lower_bound_;
   PointType mesh_upper_bound_;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -8,6 +8,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <unordered_map>
 
 namespace shapeworks {
 
@@ -23,15 +24,15 @@ public:
   double ComputeDistance(PointType pointa, PointType pointb) const override;
 
   PointType
-  GeodesicWalk(PointType pointa, vnl_vector_fixed<double, DIMENSION> vector) const override;
+  GeodesicWalk(PointType pointa, int idx, vnl_vector_fixed<double, DIMENSION> vector) const override;
 
   vnl_vector_fixed<double, DIMENSION>
-  ProjectVectorToSurfaceTangent(const PointType& pointa,
+  ProjectVectorToSurfaceTangent(const PointType& pointa, int idx,
                                 vnl_vector_fixed<double, DIMENSION>& vector) const override;
 
-  vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(PointType p) const override;
+  vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(PointType p, int idx) const override;
 
-  PointType SnapToMesh(PointType pointa) const override;
+  PointType SnapToMesh(PointType pointa, int idx) const override;
 
   PointType GetPointOnMesh() const override;
 
@@ -66,12 +67,14 @@ private:
                                             int currentFace, int edge) const;
 
   int GetNearestVertex(trimesh::point pt) const;
-  int GetTriangleForPoint(trimesh::point pt) const;
+  int GetTriangleForPoint(trimesh::point pt, int idx) const;
   std::vector<int> GetKNearestVertices(trimesh::point pt, int k) const;
   trimesh::vec3 ComputeBarycentricCoordinates(trimesh::point pt, int face) const;
 
   std::shared_ptr<trimesh::TriMesh> mesh_;
   std::shared_ptr<trimesh::KDtree> kd_tree_;
+
+  mutable std::unordered_map<int, int> particleIdx2faceIdx;
 
   PointType mesh_lower_bound_;
   PointType mesh_upper_bound_;

--- a/Libs/Optimize/ParticleSystem/itkParticleConstrainedModifiedCotangentEntropyGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleConstrainedModifiedCotangentEntropyGradientFunction.txx
@@ -148,7 +148,7 @@ ParticleConstrainedModifiedCotangentEntropyGradientFunction<TGradientNumericType
     }
 
     // Get the neighborhood surrounding the point "pos".
-    m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, m_CurrentWeights, neighborhood_radius, d);
+    m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, idx,m_CurrentWeights, neighborhood_radius, d);
 
     if (system->GetDomain(d)->GetDomainType() == shapeworks::DomainType::Image) {
       // Grab a pointer to the domain.  We need a Domain that has surface normal
@@ -157,7 +157,7 @@ ParticleConstrainedModifiedCotangentEntropyGradientFunction<TGradientNumericType
         = static_cast<const ParticleImplicitSurfaceDomain<TGradientNumericType> *>(system->GetDomain(d));
       // PRATEEP
       vnl_vector_fixed<double, VDimension> x;
-      vnl_vector_fixed<float, VDimension> grad = system->GetDomain(d)->SampleGradientAtPoint(pos);
+      vnl_vector_fixed<float, VDimension> grad = system->GetDomain(d)->SampleGradientAtPoint(pos, idx);
       vnl_vector_fixed<double, VDimension> cppt;
       vnl_vector_fixed<double, VDimension> cpnorm;
       for (unsigned int i = 0; i < VDimension; i++) {

--- a/Libs/Optimize/ParticleSystem/itkParticleCurvatureEntropyGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleCurvatureEntropyGradientFunction.txx
@@ -161,7 +161,7 @@ ParticleCurvatureEntropyGradientFunction<TGradientNumericType, VDimension>
   
   
   // Get the neighborhood surrounding the point "pos".
-   m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, m_CurrentWeights, neighborhood_radius, d);
+   m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, idx, m_CurrentWeights, neighborhood_radius, d);
 
    //    m_CurrentNeighborhood
    //   = system->FindNeighborhoodPoints(pos, neighborhood_radius, d);
@@ -194,7 +194,7 @@ ParticleCurvatureEntropyGradientFunction<TGradientNumericType, VDimension>
       m_CurrentSigma = neighborhood_radius / this->GetNeighborhoodToSigmaRatio();
       }
     
-    m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, m_CurrentWeights,    
+    m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, idx, m_CurrentWeights,
                                                                neighborhood_radius, d);
     //  m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, neighborhood_radius, d);
     //    this->ComputeAngularWeights(pos,m_CurrentNeighborhood,domain,m_CurrentWeights);
@@ -209,7 +209,7 @@ ParticleCurvatureEntropyGradientFunction<TGradientNumericType, VDimension>
     {
     m_CurrentSigma = this->GetMaximumNeighborhoodRadius() / this->GetNeighborhoodToSigmaRatio();
     neighborhood_radius = this->GetMaximumNeighborhoodRadius();
-        m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, m_CurrentWeights,
+        m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, idx,m_CurrentWeights,
                                                                neighborhood_radius, d);
         //  m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, neighborhood_radius, d);
         //      this->ComputeAngularWeights(pos,m_CurrentNeighborhood,domain,m_CurrentWeights);

--- a/Libs/Optimize/ParticleSystem/itkParticleDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleDomain.h
@@ -51,6 +51,7 @@ public:
     return a.SquaredEuclideanDistanceTo(b);
   }
 
+  virtual void PrintStats() =0;
 
   /** Used in ParticleMeanCurvatureAttribute */
   virtual double GetCurvature(const PointType &p, int idx) const = 0;

--- a/Libs/Optimize/ParticleSystem/itkParticleDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleDomain.h
@@ -30,17 +30,18 @@ public:
 
   /** Apply any constraints to the given point location.
       This should force the point to a position on the surface that satisfies all constraints. */
-  virtual bool ApplyConstraints(PointType& p, bool dbg = false) const = 0;
+  //TODO: default value for ALL idx?
+  virtual bool ApplyConstraints(PointType& p, int idx, bool dbg = false) const = 0;
 
   /** Applies the update to the point and returns the new point position. */
-  virtual PointType UpdateParticlePosition(const PointType &point, vnl_vector_fixed<double, DIMENSION> &update) const = 0;
+  virtual PointType UpdateParticlePosition(const PointType &point, int idx, vnl_vector_fixed<double, DIMENSION> &update) const = 0;
 
   /** Projects the vector to the surface tangent at the point. */
-  virtual vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION>& gradE, const PointType& pos) const = 0;
+  virtual vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION>& gradE, const PointType& pos, int idx) const = 0;
 
-  virtual vnl_vector_fixed<float, DIMENSION> SampleGradientAtPoint(const PointType &point) const = 0;
-  virtual vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(const PointType & point) const = 0;
-  virtual vnl_matrix_fixed<float, DIMENSION, DIMENSION> SampleHessianAtPoint(const PointType &p) const = 0;
+  virtual vnl_vector_fixed<float, DIMENSION> SampleGradientAtPoint(const PointType &point, int idx) const = 0;
+  virtual vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(const PointType & point, int idx) const = 0;
+  virtual vnl_matrix_fixed<float, DIMENSION, DIMENSION> SampleHessianAtPoint(const PointType &p, int idx) const = 0;
   /** Distance between locations is used for computing energy and neighborhoods. */
   virtual double Distance(const PointType &a, const PointType &b) const {
     return a.EuclideanDistanceTo(b);
@@ -52,7 +53,7 @@ public:
 
 
   /** Used in ParticleMeanCurvatureAttribute */
-  virtual double GetCurvature(const PointType &p) const = 0;
+  virtual double GetCurvature(const PointType &p, int idx) const = 0;
   /** Used in ParticleMeanCurvatureAttribute */
   virtual double GetSurfaceMeanCurvature() const = 0;
   /** Used in ParticleMeanCurvatureAttribute */

--- a/Libs/Optimize/ParticleSystem/itkParticleDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleDomain.h
@@ -30,7 +30,6 @@ public:
 
   /** Apply any constraints to the given point location.
       This should force the point to a position on the surface that satisfies all constraints. */
-  //TODO: default value for ALL idx?
   virtual bool ApplyConstraints(PointType& p, int idx, bool dbg = false) const = 0;
 
   /** Applies the update to the point and returns the new point position. */

--- a/Libs/Optimize/ParticleSystem/itkParticleDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleDomain.h
@@ -51,8 +51,6 @@ public:
     return a.SquaredEuclideanDistanceTo(b);
   }
 
-  virtual void PrintStats() =0;
-
   /** Used in ParticleMeanCurvatureAttribute */
   virtual double GetCurvature(const PointType &p, int idx) const = 0;
   /** Used in ParticleMeanCurvatureAttribute */

--- a/Libs/Optimize/ParticleSystem/itkParticleEntropyGradientFunction.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleEntropyGradientFunction.h
@@ -181,6 +181,7 @@ public:
       central point and each of its neighbors.  Difference of > 90 degrees
       results in a weight of 0. */
   void ComputeAngularWeights(const PointType &,
+                             int,
                              const typename ParticleSystemType::PointVectorType &,
                              const ParticleDomain *,
                              std::vector<double> &) const;

--- a/Libs/Optimize/ParticleSystem/itkParticleEntropyGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleEntropyGradientFunction.txx
@@ -43,11 +43,12 @@ template <class TGradientNumericType, unsigned int VDimension>
 void
 ParticleEntropyGradientFunction<TGradientNumericType, VDimension>
 ::ComputeAngularWeights(const PointType &pos,
+                        int idx,
                         const typename ParticleSystemType::PointVectorType &neighborhood,
                         const ParticleDomain *domain,
                         std::vector<double> &weights) const
 {
-  GradientVectorType posnormal = domain->SampleNormalAtPoint(pos, -1); //TODO What index
+  GradientVectorType posnormal = domain->SampleNormalAtPoint(pos, idx);
   weights.resize(neighborhood.size());
   
   for (unsigned int i = 0; i < neighborhood.size(); i++)
@@ -170,11 +171,11 @@ ParticleEntropyGradientFunction<TGradientNumericType, VDimension>
   
   // Get the neighborhood surrounding the point "pos".
   typename ParticleSystemType::PointVectorType neighborhood
-    = system->FindNeighborhoodPoints(pos, neighborhood_radius, d);
+    = system->FindNeighborhoodPoints(pos, idx, neighborhood_radius, d);
   
   // Compute the weights based on angle between the neighbors and the center.
   std::vector<double> weights;
-  this->ComputeAngularWeights(pos,neighborhood,domain,weights);
+  this->ComputeAngularWeights(pos,idx,neighborhood,domain,weights);
   
   // Estimate the best sigma for Parzen windowing.  In some cases, such as when
   // the neighborhood does not include enough points, the value will be bogus.
@@ -200,7 +201,7 @@ ParticleEntropyGradientFunction<TGradientNumericType, VDimension>
       }
     
     neighborhood = system->FindNeighborhoodPoints(pos, neighborhood_radius, d);
-    this->ComputeAngularWeights(pos,neighborhood,domain,weights);
+    this->ComputeAngularWeights(pos,idx,neighborhood,domain,weights);
     sigma = this->EstimateSigma(idx, neighborhood, domain, weights, pos, sigma, epsilon, err);
     } // done while err
   
@@ -211,7 +212,7 @@ ParticleEntropyGradientFunction<TGradientNumericType, VDimension>
     sigma = this->GetMaximumNeighborhoodRadius() / this->GetNeighborhoodToSigmaRatio();
     neighborhood_radius = this->GetMaximumNeighborhoodRadius();
     neighborhood = system->FindNeighborhoodPoints(pos, neighborhood_radius, d);
-    this->ComputeAngularWeights(pos,neighborhood,domain,weights);
+    this->ComputeAngularWeights(pos,idx,neighborhood,domain,weights);
     }
 
   //  std::cout << idx <<  "\t SIGMA = " << sigma << "\t NEIGHBORHOOD SIZE = " << neighborhood.size()

--- a/Libs/Optimize/ParticleSystem/itkParticleEntropyGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleEntropyGradientFunction.txx
@@ -47,13 +47,13 @@ ParticleEntropyGradientFunction<TGradientNumericType, VDimension>
                         const ParticleDomain *domain,
                         std::vector<double> &weights) const
 {
-  GradientVectorType posnormal = domain->SampleNormalAtPoint(pos);
+  GradientVectorType posnormal = domain->SampleNormalAtPoint(pos, -1); //TODO What index
   weights.resize(neighborhood.size());
   
   for (unsigned int i = 0; i < neighborhood.size(); i++)
     {
     weights[i] = this->AngleCoefficient(posnormal,
-                                        domain->SampleNormalAtPoint(neighborhood[i].Point));
+                                        domain->SampleNormalAtPoint(neighborhood[i].Point, neighborhood[i].Index));
     if (weights[i] < 1.0e-5) weights[i] = 0.0;
     }
 }

--- a/Libs/Optimize/ParticleSystem/itkParticleGeneralShapeGradientMatrix.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleGeneralShapeGradientMatrix.h
@@ -156,10 +156,10 @@ public:
             }
             else
             {
-                vnl_vector_fixed<float, DIMENSION> gradient = ps->GetDomain(d)->SampleGradientAtPoint(posLocal);
+                vnl_vector_fixed<float, DIMENSION> gradient = ps->GetDomain(d)->SampleGradientAtPoint(posLocal, idx);
                 vnl_vector_fixed<float, DIMENSION> normal = gradient.normalize();
                 float grad_mag = gradient.magnitude();
-                typename ParticleImageDomainWithHessians<float>::VnlMatrixType hessian = ps->GetDomain(d)->SampleHessianAtPoint(posLocal);
+                typename ParticleImageDomainWithHessians<float>::VnlMatrixType hessian = ps->GetDomain(d)->SampleHessianAtPoint(posLocal, idx);
 
                 typename ParticleImageDomainWithHessians<float>::VnlMatrixType mat1;
                 mat1.set_identity();

--- a/Libs/Optimize/ParticleSystem/itkParticleGeneralShapeMatrix.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleGeneralShapeMatrix.h
@@ -140,7 +140,7 @@ public:
         }
         if (m_use_normals[dom])
         {
-            vnl_vector_fixed<float, DIMENSION> pN = ps->GetDomain(d)->SampleNormalAtPoint(posLocal);
+            vnl_vector_fixed<float, DIMENSION> pN = ps->GetDomain(d)->SampleNormalAtPoint(posLocal, idx);
             typename ParticleSystemType::VectorType tmp;
             tmp[0] = pN[0]; tmp[1] = pN[1]; tmp[2] = pN[2];
             tmp = ps->TransformVector(tmp, ps->GetTransform(d) * ps->GetPrefixTransform(d));

--- a/Libs/Optimize/ParticleSystem/itkParticleGoodBadAssessment.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleGoodBadAssessment.txx
@@ -106,7 +106,7 @@ ParticleGoodBadAssessment<TGradientNumericType, VDimension>::computeParticlesNor
     for (int i = 0; i < num; i++)
     {
         PointType pt = m_ParticleSystem->GetPosition(i, d);
-        NormalType n = m_ParticleSystem->GetDomain(d)->SampleNormalAtPoint(pt, -1); //TODO WHAT
+        NormalType n = m_ParticleSystem->GetDomain(d)->SampleNormalAtPoint(pt, -1);
         for (int j = 0; j < VDimension; j++)
             normals[i][j] = n[j];
     }

--- a/Libs/Optimize/ParticleSystem/itkParticleGoodBadAssessment.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleGoodBadAssessment.txx
@@ -106,7 +106,7 @@ ParticleGoodBadAssessment<TGradientNumericType, VDimension>::computeParticlesNor
     for (int i = 0; i < num; i++)
     {
         PointType pt = m_ParticleSystem->GetPosition(i, d);
-        NormalType n = m_ParticleSystem->GetDomain(d)->SampleNormalAtPoint(pt);
+        NormalType n = m_ParticleSystem->GetDomain(d)->SampleNormalAtPoint(pt, -1); //TODO WHAT
         for (int j = 0; j < VDimension; j++)
             normals[i][j] = n[j];
     }

--- a/Libs/Optimize/ParticleSystem/itkParticleGradientDescentPositionOptimizer.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleGradientDescentPositionOptimizer.txx
@@ -159,7 +159,7 @@ namespace itk
             PointType pt = *it;
 
             // Step 1 Project the gradient vector onto the tangent plane
-            VectorType original_gradient_projectedOntoTangentSpace = domain->ProjectVectorToSurfaceTangent(original_gradient, pt);
+            VectorType original_gradient_projectedOntoTangentSpace = domain->ProjectVectorToSurfaceTangent(original_gradient, pt, k);
 
             double newenergy, gradmag;
             while (true) {
@@ -178,7 +178,7 @@ namespace itk
               }
 
               // Step D compute the new point position
-              PointType newpoint = domain->UpdateParticlePosition(pt, gradient);
+              PointType newpoint = domain->UpdateParticlePosition(pt, k, gradient);
 
               // Step F update the point position in the particle system
               m_ParticleSystem->SetPosition(newpoint, it.GetIndex(), dom);
@@ -196,7 +196,7 @@ namespace itk
               {// bad move, reset point position and back off on timestep
                 if (m_TimeSteps[dom][k] > minimumTimeStep)
                 {
-                  domain->ApplyConstraints(pt);
+                  domain->ApplyConstraints(pt, k);
                   m_ParticleSystem->SetPosition(pt, it.GetIndex(), dom);
 
                   m_TimeSteps[dom][k] /= factor;

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomain.h
@@ -131,9 +131,6 @@ public:
   inline PointType GetOrigin() const {
     return m_Origin;
   }
-  void PrintStats() {
-
-  }
 
   inline typename ImageType::SizeType GetSize() const
   {

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomain.h
@@ -131,6 +131,9 @@ public:
   inline PointType GetOrigin() const {
     return m_Origin;
   }
+  void PrintStats() {
+
+  }
 
   inline typename ImageType::SizeType GetSize() const
   {

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithCurvature.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithCurvature.h
@@ -86,7 +86,7 @@ public:
     this->ComputeSurfaceStatistics(I);
   } // end setimage
 
-  double GetCurvature(const PointType &p) const override
+  double GetCurvature(const PointType &p, int idx) const override
   {
     if (this->m_FixedDomain) {
       return 0;
@@ -121,7 +121,7 @@ protected:
     // Rendering..." for detailss
     
     // Get the normal vector associated with this position.
-    typename Superclass::VnlVectorType posnormal = this->SampleNormalAtPoint(pos);
+    typename Superclass::VnlVectorType posnormal = this->SampleNormalAtPoint(pos, -1); //TODO Wha
 
     // Sample the Hessian for this point and compute gradient of the normal.
     typename Superclass::VnlMatrixType I;
@@ -208,7 +208,7 @@ private:
 
         // Compute curvature at point.
 //      std::cout << "pos : " << pos[0] << ' ' << pos[1] << ' ' << pos[2] << std::endl;
-        double mc = this->GetCurvature(pos);
+        double mc = this->GetCurvature(pos, -1);
         m_SurfaceMeanCurvature += mc;
         datalist.push_back(mc);
       }

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithCurvature.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithCurvature.h
@@ -121,7 +121,7 @@ protected:
     // Rendering..." for detailss
     
     // Get the normal vector associated with this position.
-    typename Superclass::VnlVectorType posnormal = this->SampleNormalAtPoint(pos, -1); //TODO Wha
+    typename Superclass::VnlVectorType posnormal = this->SampleNormalAtPoint(pos, -1);
 
     // Sample the Hessian for this point and compute gradient of the normal.
     typename Superclass::VnlMatrixType I;

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithGradients.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithGradients.h
@@ -46,22 +46,22 @@ public:
     m_VDBGradient = openvdb::tools::gradient(*this->GetVDBImage());
   }
 
-  inline vnl_vector_fixed<float, DIMENSION> SampleGradientAtPoint(const PointType &p) const {
-    return this->SampleGradientVnl(p);
+  inline vnl_vector_fixed<float, DIMENSION> SampleGradientAtPoint(const PointType &p, int idx) const {
+    return this->SampleGradientVnl(p, idx);
   }
 
-  inline vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(const PointType &p) const {
-    vnl_vector_fixed<float, DIMENSION> grad = this->SampleGradientVnl(p);
+  inline vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(const PointType &p, int idx) const {
+    vnl_vector_fixed<float, DIMENSION> grad = this->SampleGradientVnl(p, idx);
     return grad.normalize();
   }
 
   /** This method is called by an optimizer after a call to Evaluate and may be
       used to apply any constraints the resulting vector, such as a projection
       to the surface tangent plane. Returns true if the gradient was modified.*/
-  vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos) const override
+  vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos, int idx) const override
   {
     double dotprod = 0.0;  
-    VnlVectorType normal =  this->SampleNormalAtPoint(pos);
+    VnlVectorType normal =  this->SampleNormalAtPoint(pos, idx);
     for (unsigned int i = 0; i < DIMENSION; i++) {   dotprod  += normal[i] * gradE[i]; }
     vnl_vector_fixed<double, DIMENSION> result;
     for (unsigned int i = 0; i < DIMENSION; i++) { result[i] = gradE[i] - normal[i] * dotprod; }
@@ -89,14 +89,14 @@ private:
 
 
 
-  inline VnlVectorType SampleGradientVnl(const PointType &p) const {
-    return VnlVectorType(this->SampleGradient(p).GetDataPointer());
+  inline VnlVectorType SampleGradientVnl(const PointType &p, int idx) const {
+    return VnlVectorType(this->SampleGradient(p, idx).GetDataPointer());
   }
   /** Sample the image at a point.  This method performs no bounds checking.
       To check bounds, use IsInsideBuffer.  SampleGradientsVnl returns a vnl
       vector of length VDimension instead of an itk::CovariantVector
       (itk::FixedArray). */
-  inline VectorType SampleGradient(const PointType &p) const {
+  inline VectorType SampleGradient(const PointType &p, int idx) const {
     if (this->IsInsideBuffer(p)) {
       const auto coord = this->ToVDBCoord(p);
       const auto _v = openvdb::tools::BoxSampler::sample(m_VDBGradient->tree(), coord);

--- a/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithHessians.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImageDomainWithHessians.h
@@ -157,7 +157,7 @@ public:
   }
 
 
-  inline vnl_matrix_fixed<float, DIMENSION, DIMENSION> SampleHessianAtPoint(const PointType &p) const override {
+  inline vnl_matrix_fixed<float, DIMENSION, DIMENSION> SampleHessianAtPoint(const PointType &p, int idx) const override {
     return SampleHessianVnl(p);
   }
   

--- a/Libs/Optimize/ParticleSystem/itkParticleImplicitSurfaceDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleImplicitSurfaceDomain.h
@@ -68,10 +68,10 @@ public:
       bounding box domain, since movement off the surface will be very
       common.  Consider subclassing this method to add a check for significant
       differences in the input and output points. */
-  virtual bool ApplyConstraints(PointType &p, bool dbg = false) const override;
+  virtual bool ApplyConstraints(PointType &p, int idx, bool dbg = false) const override;
 
 
-  inline PointType UpdateParticlePosition(const PointType &point, vnl_vector_fixed<double, DIMENSION> &update) const override {
+  inline PointType UpdateParticlePosition(const PointType &point, int idx, vnl_vector_fixed<double, DIMENSION> &update) const override {
     PointType newpoint;
 
     // Master merge conflict
@@ -86,7 +86,7 @@ public:
     //for (unsigned int i = 0; i < DIMENSION; i++) { newpoint[i] = point[i] - update[i]; }
 
     // debuggg
-    ApplyConstraints(newpoint);
+    ApplyConstraints(newpoint, idx);
 
     // debuggg
     /*

--- a/Libs/Optimize/ParticleSystem/itkParticleImplicitSurfaceDomain.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleImplicitSurfaceDomain.txx
@@ -74,7 +74,7 @@ SetFids(const char *fidsFile)
 
 template<class T>
 bool
-ParticleImplicitSurfaceDomain<T>::ApplyConstraints(PointType &p, bool dbg) const
+ParticleImplicitSurfaceDomain<T>::ApplyConstraints(PointType &p, int idx, bool dbg) const
 {
   // First apply and constraints imposed by superclasses.  This will
   // guarantee the point starts in the correct image domain.
@@ -92,7 +92,7 @@ ParticleImplicitSurfaceDomain<T>::ApplyConstraints(PointType &p, bool dbg) const
     {
     PointType p_old = p;
     //vnl_vector_fixed<T, DIMENSION> grad = -this->SampleGradientAtPoint(p);
-    vnl_vector_fixed<T, DIMENSION> gradf = this->SampleGradientAtPoint(p);
+    vnl_vector_fixed<T, DIMENSION> gradf = this->SampleGradientAtPoint(p, idx);
     vnl_vector_fixed<double, DIMENSION> grad;
     grad[0] = double(gradf[0]); grad[1] = double(gradf[1]); grad[2] = double(gradf[2]);
 

--- a/Libs/Optimize/ParticleSystem/itkParticleMeanCurvatureAttribute.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleMeanCurvatureAttribute.h
@@ -93,7 +93,7 @@ public:
   {
     //  Get the position and index.
     PointType pos = system->GetPosition(idx, dom);
-    this->operator[](dom)->operator[](idx) = system->GetDomain(dom)->GetCurvature(pos);
+    this->operator[](dom)->operator[](idx) = system->GetDomain(dom)->GetCurvature(pos, idx);
   }
   
   /** Compute the mean and std deviation of the curvature on the image

--- a/Libs/Optimize/ParticleSystem/itkParticleNeighborhood.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleNeighborhood.h
@@ -75,18 +75,18 @@ public:
 
   /** Compile a list of points that are within a specified radius of a given
       point.  The default implementation will throw an exception. */
-  virtual PointVectorType FindNeighborhoodPoints(const PointType &, double) const
+  virtual PointVectorType FindNeighborhoodPoints(const PointType &, int idx, double) const
   {
     itkExceptionMacro("No algorithm for finding neighbors has been specified.");
   }
   /** This method finds neighborhood points as in the previous method, but also
       computes a vector of weights associated with each of those points. */
-  virtual PointVectorType FindNeighborhoodPoints(const PointType &, std::vector<double> &,
+  virtual PointVectorType FindNeighborhoodPoints(const PointType &, int idx, std::vector<double> &,
                                                  double) const
   {
     itkExceptionMacro("No algorithm for finding neighbors has been specified.");
   }
-  virtual unsigned int  FindNeighborhoodPoints(const PointType &, double, PointVectorType &) const
+  virtual unsigned int  FindNeighborhoodPoints(const PointType &, int idx, double, PointVectorType &) const
   {
     itkExceptionMacro("No algorithm for finding neighbors has been specified.");
     return 0;

--- a/Libs/Optimize/ParticleSystem/itkParticleOmegaGradientFunction.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleOmegaGradientFunction.txx
@@ -237,7 +237,7 @@ ParticleOmegaGradientFunction<TGradientNumericType, VDimension>
     }
 
     // Get the neighborhood surrounding the point "pos".
-    m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, m_CurrentWeights, neighborhood_radius, d);
+    m_CurrentNeighborhood = system->FindNeighborhoodPoints(pos, idx, m_CurrentWeights, neighborhood_radius, d);
 
     // Add the closest point on the plane as another neighbor.
     // See http://mathworld.wolfram.com/Point-PlaneDistance.html, for example
@@ -299,7 +299,7 @@ ParticleOmegaGradientFunction<TGradientNumericType, VDimension>
             m_CurrentSigma = neighborhood_radius / this->GetNeighborhoodToSigmaRatio();
         }
 
-        m_CurrentNeighborhood = system->FindNeighborhoodPoints( pos, m_CurrentWeights, neighborhood_radius, d );
+        m_CurrentNeighborhood = system->FindNeighborhoodPoints( pos, idx, m_CurrentWeights, neighborhood_radius, d );
 
 
         for (unsigned int pidx = 0; pidx < domain->GetConstraints()->getPlaneConstraints()->size(); pidx++)
@@ -341,7 +341,7 @@ ParticleOmegaGradientFunction<TGradientNumericType, VDimension>
     {
         m_CurrentSigma = this->GetMaximumNeighborhoodRadius() / this->GetNeighborhoodToSigmaRatio();
         neighborhood_radius = this->GetMaximumNeighborhoodRadius();
-        m_CurrentNeighborhood = system->FindNeighborhoodPoints( pos, m_CurrentWeights,
+        m_CurrentNeighborhood = system->FindNeighborhoodPoints( pos, idx,m_CurrentWeights,
                                                                 neighborhood_radius, d );
 
 

--- a/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.h
@@ -60,7 +60,7 @@ public:
   /** Compile a list of points that are within a specified radius of a given
       point.  This implementation uses a PowerOfTwoTree to sort points
       according to location. */
-  virtual PointVectorType FindNeighborhoodPoints(const PointType &, double) const;
+  virtual PointVectorType FindNeighborhoodPoints(const PointType &, int idx, double) const;
   //  virtual unsigned int  FindNeighborhoodPoints(const PointType &, double, PointVectorType &) const;
 
   /** Override SetDomain so that we can grab the region extent info and

--- a/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.txx
@@ -72,7 +72,7 @@ void ParticleRegionNeighborhood<VDimension>::SetDomain(DomainType *d)
 template <unsigned int VDimension>
 typename ParticleRegionNeighborhood<VDimension>::PointVectorType
 ParticleRegionNeighborhood<VDimension>
-::FindNeighborhoodPoints(const PointType &center, double radius) const
+::FindNeighborhoodPoints(const PointType &center, int idx, double radius) const
 {
   // Compute bounding box of the given hypersphere.
   PointType l, u;

--- a/Libs/Optimize/ParticleSystem/itkParticleSurfaceNeighborhood.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleSurfaceNeighborhood.h
@@ -63,7 +63,7 @@ public:
   /** Compile a list of points that are within a specified radius of a given
       point.  This implementation uses a PowerOfTwoTree to sort points
       according to location. */
-  virtual PointVectorType FindNeighborhoodPoints(const PointType &, std::vector<double> &, double) const;
+  virtual PointVectorType FindNeighborhoodPoints(const PointType &, int idx, std::vector<double> &, double) const;
   //  virtual unsigned int  FindNeighborhoodPoints(const PointType &, double, PointVectorType &) const;
 
   void PrintSelf(std::ostream& os, Indent indent) const

--- a/Libs/Optimize/ParticleSystem/itkParticleSurfaceNeighborhood.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSurfaceNeighborhood.txx
@@ -21,11 +21,11 @@ namespace itk
 template <class TImage>
 typename ParticleSurfaceNeighborhood<TImage>::PointVectorType
 ParticleSurfaceNeighborhood<TImage>
-::FindNeighborhoodPoints(const PointType &center,
+::FindNeighborhoodPoints(const PointType &center, int idx,
                          std::vector<double> &weights, double radius) const
 {
   const auto *domain = this->GetDomain();
-  GradientVectorType posnormal = domain->SampleNormalAtPoint(center);
+  GradientVectorType posnormal = domain->SampleNormalAtPoint(center, idx);
   //  double posnormalmag = posnormal.magnitude();
   weights.clear();
 
@@ -59,7 +59,7 @@ ParticleSurfaceNeighborhood<TImage>
     
     if (distance < radius && distance > 0.0 )
       {
-      GradientVectorType pn = domain->SampleNormalAtPoint((*it)->Point);
+      GradientVectorType pn = domain->SampleNormalAtPoint((*it)->Point, idx);
       double cosine   = dot_product(posnormal,pn); // normals already normalized
       // double cosine = proj / (posnormalmag * pn.magnitude() + 1.0e-6);
 

--- a/Libs/Optimize/ParticleSystem/itkParticleSurfaceNeighborhood.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSurfaceNeighborhood.txx
@@ -59,7 +59,7 @@ ParticleSurfaceNeighborhood<TImage>
     
     if (distance < radius && distance > 0.0 )
       {
-      GradientVectorType pn = domain->SampleNormalAtPoint((*it)->Point, idx);
+      GradientVectorType pn = domain->SampleNormalAtPoint((*it)->Point, (*it)->Index);
       double cosine   = dot_product(posnormal,pn); // normals already normalized
       // double cosine = proj / (posnormalmag * pn.magnitude() + 1.0e-6);
 

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.h
@@ -185,20 +185,20 @@ public:
       Neighborhood objects. FindTransformedNeighborhoodPoints returns the list
       with all points transformed by the transform associated with the given
       domain.*/
-  inline PointVectorType FindNeighborhoodPoints(const PointType &p,
+  inline PointVectorType FindNeighborhoodPoints(const PointType &p, int idx,
                                                 double r, unsigned int d = 0) const
-  {  return m_Neighborhoods[d]->FindNeighborhoodPoints(p, r); }
-  inline PointVectorType FindNeighborhoodPoints(const PointType &p,
+  {  return m_Neighborhoods[d]->FindNeighborhoodPoints(p, idx, r); }
+  inline PointVectorType FindNeighborhoodPoints(const PointType &p, int idx,
                                                 std::vector<double> &w,
                                                 double r, unsigned int d = 0) const
-  {  return m_Neighborhoods[d]->FindNeighborhoodPoints(p,w,r); }
+  {  return m_Neighborhoods[d]->FindNeighborhoodPoints(p,idx,w,r); }
   inline PointVectorType FindNeighborhoodPoints(unsigned int idx,
                                                 double r, unsigned int d = 0) const
-  {  return m_Neighborhoods[d]->FindNeighborhoodPoints(this->GetPosition(idx,d), r); }
+  {  return m_Neighborhoods[d]->FindNeighborhoodPoints(this->GetPosition(idx,d),idx, r); }
   inline PointVectorType FindNeighborhoodPoints(unsigned int idx,
                                                 std::vector<double> &w,
                                                 double r, unsigned int d = 0) const
-  {  return m_Neighborhoods[d]->FindNeighborhoodPoints(this->GetPosition(idx,d),w, r); }
+  {  return m_Neighborhoods[d]->FindNeighborhoodPoints(this->GetPosition(idx,d),idx,w, r); }
 
   //  inline int FindNeighborhoodPoints(const PointType &p,  double r, PointVectorType &vec, unsigned int d = 0) const
   //  {  return m_Neighborhoods[d]->FindNeighborhoodPoints(p, r, vec); }

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
@@ -152,7 +152,7 @@ ParticleSystem<VDimension>
   if (m_DomainFlags[d] == false) {
       // debugg
       //std::cout << "d" << d << " before apply " << m_Positions[d]->operator[](m_IndexCounters[d]);
-    m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](m_IndexCounters[d]));
+    m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](m_IndexCounters[d]), -1);
       // debugg
       //std::cout << " after apply " << m_Positions[d]->operator[](m_IndexCounters[d]) << std::endl;
     m_Neighborhoods[d]->AddPosition( m_Positions[d]->operator[](m_IndexCounters[d]), m_IndexCounters[d], threadId);
@@ -189,7 +189,7 @@ ParticleSystem<VDimension>
 
       // Debuggg
       //std::cout << "SynchronizePositions Apply constraints " << m_Positions[d]->operator[](k);
-      m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](k));
+      m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](k), -1);
       // Debuggg
       //std::cout << " updated " << m_Positions[d]->operator[](k) << std::endl;
 
@@ -341,7 +341,7 @@ void ParticleSystem<VDimension>::AdvancedAllParticleSplitting(double epsilon)
           // Go to surface
           if (!this->m_DomainFlags[j] &&
               !this->GetDomain(j)->GetConstraints()->IsAnyViolated(newpos)) {
-            this->GetDomain(j)->ApplyConstraints(newpos);
+            this->GetDomain(j)->ApplyConstraints(newpos, -1); // TODO WHAT
           }
           newposs_good.push_back(newpos);
           // Check for plane constraint violations

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
@@ -152,10 +152,11 @@ ParticleSystem<VDimension>
   if (m_DomainFlags[d] == false) {
       // debugg
       //std::cout << "d" << d << " before apply " << m_Positions[d]->operator[](m_IndexCounters[d]);
-    m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](m_IndexCounters[d]), -1);
+    const auto idx = m_IndexCounters[d];
+    m_Domains[d]->ApplyConstraints( m_Positions[d]->operator[](idx), idx);
       // debugg
       //std::cout << " after apply " << m_Positions[d]->operator[](m_IndexCounters[d]) << std::endl;
-    m_Neighborhoods[d]->AddPosition( m_Positions[d]->operator[](m_IndexCounters[d]), m_IndexCounters[d], threadId);
+    m_Neighborhoods[d]->AddPosition( m_Positions[d]->operator[](idx), idx, threadId);
   }
 
   // Increase the FixedParticleFlag list size if necessary.
@@ -341,7 +342,7 @@ void ParticleSystem<VDimension>::AdvancedAllParticleSplitting(double epsilon)
           // Go to surface
           if (!this->m_DomainFlags[j] &&
               !this->GetDomain(j)->GetConstraints()->IsAnyViolated(newpos)) {
-            this->GetDomain(j)->ApplyConstraints(newpos, -1); // TODO WHAT
+            this->GetDomain(j)->ApplyConstraints(newpos, -1);
           }
           newposs_good.push_back(newpos);
           // Check for plane constraint violations


### PR DESCRIPTION
This PR modifies many APIs to pass around particle index along with position. This is only useful for the mesh domain right now: to store a cache of particle index -> triangle index. This prevents many expensive KDtree lookups, resulting in a speedup(1:35 hours to 0:50 hours in femur_mesh use case)