### PR TITLE
Remove std::map from ParticleContainer

### DIFF
--- a/Libs/Optimize/ParticleSystem/itkParticleContainer.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleContainer.h
@@ -46,91 +46,24 @@ public:
   //  itkTypeMacro(ParticleContainer, ParticleAttribute);
   itkTypeMacro(ParticleContainer, DataObject);
   
-  /** Define a map container type.  A map is used because elements will be
-      frequently deleted and added.  Map has the property that addition and
-      deletion operations do not invalidate existing pointers. */
-  struct ltcmp
-  {
-    inline bool operator()(unsigned int a, unsigned int b) const
-    { return a < b; }
-  };
-  typedef std::map<unsigned int, T, ltcmp> MapType;  
-  
-  /** Define a const iterator type for this container.  This class is just a wrapper
-      around the stl::map iterator which provides a simpler API. */
-  class ConstIterator : public MapType::const_iterator
-  {
-  public:
-    typedef typename MapType::const_iterator Superclass;
-    ConstIterator( const typename MapType::const_iterator &o) : Superclass(o) {}
-    ConstIterator() : Superclass() {}
-    
-    inline const T &operator*() const
-    { return Superclass::operator*().second;  } 
-    inline unsigned long int GetIndex() const
-    { return Superclass::operator*().first; }
-  }; 
-
-  /** Define an iterator type for this container.  This class is just a wrapper
-      around the stl::map iterator which provides a simpler API. */
-  class Iterator : public MapType::iterator
-  {
-  public:
-    typedef typename MapType::iterator Superclass;
-    Iterator( const typename MapType::iterator &o) : Superclass(o) {}
-    Iterator() : Superclass() {}
-    
-    inline T &operator*() const
-    { return Superclass::operator*().second;  }
-    
-    inline unsigned long int GetIndex() const
-    { return Superclass::operator*().first; } 
-  }; 
-  
-  /** Return iterators for container values. */
-  inline ConstIterator GetBegin() const
-  { return ConstIterator( m_Map.begin()); }
-  inline ConstIterator GetEnd() const
-  { return ConstIterator( m_Map.end()); }
-
-  //
-  // Not sure whether we want non const iterators.
-  //
-  //    inline Iterator GetBegin() 
-  //    { return Iterator( m_Map.begin()); }
-  //    inline Iterator GetEnd()
-  //    { return Iterator( m_Map.end()); }
-
-  /** Return iterators for the underlying map container.  */
-  inline typename MapType::const_iterator GetMapBegin() const
-  { return m_Map.begin(); }
-  inline typename MapType::const_iterator GetMapEnd() const
-  { return m_Map.end(); }
-  inline typename MapType::iterator GetMapBegin() 
-  { return m_Map.begin(); }
-  inline typename MapType::iterator GetMapEnd()
-  { return m_Map.end(); }
-
   /** Returns a reference to the object associated with index k.  If the index
       k does not already exist, this method inserts a new entry for k. */
-  inline T &operator[](const unsigned long int &k)  { return m_Map[k]; }
-  inline const T&operator[](const unsigned long int &k) const { return m_Map[k]; }
+  inline T &operator[](size_t k)  {
+    if(k >= data.size()) {
+      data.resize(k + 1);
+    }
+    return data[k];
+  }
 
-  /** Returns true if index k is in the container and false otherwise. */
-  bool HasIndex(unsigned long int k) const
-  {
-    if ( m_Map.find(k) != m_Map.end()) return true;
-    else return false;
+  /** Convenience method since all usage of this function is via a pointer, leading
+      ugly syntax like ->operator[](k) */
+  inline T& Get(size_t k) {
+    return (*this)[k];
   }
 
   /** Number of objects in the container. */
-  unsigned long int GetSize() const  { return m_Map.size(); }
+  unsigned long int GetSize() const  { return data.size(); }
 
-  /**  Erase the element in the container with index k.  Return value is 1 on
-       success. */
-  typename MapType::size_type Erase( const unsigned int &k )
-  { return m_Map.erase(k); }
-  
 protected:
   ParticleContainer() { }
   void PrintSelf(std::ostream& os, Indent indent) const
@@ -138,9 +71,6 @@ protected:
     Superclass::PrintSelf(os,indent);
   
     os << indent << "ParticleContainer: " << std::endl;
-    //    for (typename MapType::const_iterator it= this->GetMapBegin();
-    //         it != this->GetMapEnd();  it++)
-    //      {      os <<  it->first << " " << it->second << std::endl;      }
   }
   virtual ~ParticleContainer() {};
 
@@ -148,7 +78,7 @@ protected:
   ParticleContainer(const Self&); //purposely not implemented
   void operator=(const Self&); //purposely not implemented
 
-  MapType m_Map;
+  std::vector<T> data;
   
 };
 

--- a/Libs/Optimize/ParticleSystem/itkParticleGradientDescentPositionOptimizer.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleGradientDescentPositionOptimizer.txx
@@ -138,25 +138,20 @@ namespace itk
           localGradientFunction->SetDomainNumber(dom);
 
           // Iterate over each particle position
-          unsigned int k = 0;
-          typename ParticleSystemType::PointContainerType::ConstIterator endit =
-            m_ParticleSystem->GetPositions(dom)->GetEnd();
-          for (typename ParticleSystemType::PointContainerType::ConstIterator it
-            = m_ParticleSystem->GetPositions(dom)->GetBegin(); it != endit; it++, k++)
+          for (auto k=0; k<m_ParticleSystem->GetPositions(dom)->GetSize(); k++)
           {
             if (m_TimeSteps[dom][k] < minimumTimeStep) {
               m_TimeSteps[dom][k] = minimumTimeStep;
             }
             // Compute gradient update.
             double energy = 0.0;
-            localGradientFunction->BeforeEvaluate(it.GetIndex(), dom, m_ParticleSystem);
+            localGradientFunction->BeforeEvaluate(k, dom, m_ParticleSystem);
             // maximumUpdateAllowed is set based on some fraction of the distance between particles
             // This is to avoid particles shooting past their neighbors
             double maximumUpdateAllowed;
-            VectorType original_gradient = localGradientFunction->Evaluate(it.GetIndex(), dom, m_ParticleSystem, maximumUpdateAllowed, energy);
+            VectorType original_gradient = localGradientFunction->Evaluate(k, dom, m_ParticleSystem, maximumUpdateAllowed, energy);
 
-            unsigned int idx = it.GetIndex();
-            PointType pt = *it;
+            PointType pt = m_ParticleSystem->GetPositions(dom)->Get(k);
 
             // Step 1 Project the gradient vector onto the tangent plane
             VectorType original_gradient_projectedOntoTangentSpace = domain->ProjectVectorToSurfaceTangent(original_gradient, pt, k);
@@ -167,7 +162,7 @@ namespace itk
               VectorType gradient = original_gradient_projectedOntoTangentSpace * m_TimeSteps[dom][k];
 
               // Step B Constrain the gradient so that the resulting position will not violate any domain constraints
-              m_ParticleSystem->GetDomain(dom)->GetConstraints()->applyBoundaryConstraints(gradient, m_ParticleSystem->GetPosition(it.GetIndex(), dom));
+              m_ParticleSystem->GetDomain(dom)->GetConstraints()->applyBoundaryConstraints(gradient, m_ParticleSystem->GetPosition(k, dom));
 
               gradmag = gradient.magnitude();
 
@@ -181,10 +176,10 @@ namespace itk
               PointType newpoint = domain->UpdateParticlePosition(pt, k, gradient);
 
               // Step F update the point position in the particle system
-              m_ParticleSystem->SetPosition(newpoint, it.GetIndex(), dom);
+              m_ParticleSystem->SetPosition(newpoint, k, dom);
 
               // Step G compute the new energy of the particle system
-              newenergy = localGradientFunction->Energy(it.GetIndex(), dom, m_ParticleSystem);
+              newenergy = localGradientFunction->Energy(k, dom, m_ParticleSystem);
 
               if (newenergy < energy) // good move, increase timestep for next time
               {
@@ -197,7 +192,7 @@ namespace itk
                 if (m_TimeSteps[dom][k] > minimumTimeStep)
                 {
                   domain->ApplyConstraints(pt, k);
-                  m_ParticleSystem->SetPosition(pt, it.GetIndex(), dom);
+                  m_ParticleSystem->SetPosition(pt, k, dom);
 
                   m_TimeSteps[dom][k] /= factor;
                 }

--- a/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.h
@@ -85,6 +85,7 @@ public:
       RemovePosition is called when a particle location is removed.*/
   virtual void AddPosition(const PointType &p, unsigned int idx, int threadId = 0);
   virtual void SetPosition(const PointType &p, unsigned int idx, int threadId = 0);
+  virtual void RemovePosition(unsigned int idx, int threadId = 0);
 
 protected:
   ParticleRegionNeighborhood() : m_TreeLevels(3)

--- a/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.h
@@ -85,7 +85,6 @@ public:
       RemovePosition is called when a particle location is removed.*/
   virtual void AddPosition(const PointType &p, unsigned int idx, int threadId = 0);
   virtual void SetPosition(const PointType &p, unsigned int idx, int threadId = 0);
-  virtual void RemovePosition(unsigned int idx, int threadId = 0);
 
 protected:
   ParticleRegionNeighborhood() : m_TreeLevels(3)

--- a/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.txx
@@ -141,15 +141,6 @@ void ParticleRegionNeighborhood<VDimension>
   pr.Iterator->Point = p;
 }
 
-template <unsigned int VDimension>
-void ParticleRegionNeighborhood<VDimension>
-::RemovePosition(unsigned int idx, int)
-{
-  IteratorNodePair pr = m_IteratorMap->operator[](idx);
-  m_IteratorMap->Erase(idx);
-  pr.NodePointer->GetList().erase(pr.Iterator); 
-}
-
 
 
 }

--- a/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleRegionNeighborhood.txx
@@ -141,6 +141,15 @@ void ParticleRegionNeighborhood<VDimension>
   pr.Iterator->Point = p;
 }
 
+template <unsigned int VDimension>
+void ParticleRegionNeighborhood<VDimension>
+::RemovePosition(unsigned int idx, int)
+{
+  IteratorNodePair pr = m_IteratorMap->operator[](idx);
+  pr.NodePointer->GetList().erase(pr.Iterator);
+}
+
+
 
 
 }

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.txx
@@ -285,9 +285,9 @@ void ParticleSystem<VDimension>::AdvancedAllParticleSplitting(double epsilon)
 
   for (size_t domain = 0; domain < num_doms; domain++) {
     std::vector<PointType> list;
-    typename PointContainerType::ConstIterator endIt = GetPositions(domain)->GetEnd();
-    for (typename PointContainerType::ConstIterator it = GetPositions(domain)->GetBegin();
-         it != endIt; it++) { list.push_back(*it); }
+    for (auto k=0; k<GetPositions(domain)->GetSize(); k++) {
+      list.push_back(GetPositions(domain)->Get(k));
+    }
     lists.push_back(list);
     // Debuggg
     /*


### PR DESCRIPTION
Replaces std::map in ParticleContainer with std::vector, results in faster optimization(femur_mesh in 38 minutes vs 50 minutes). Tested on ellipsoid(image domain), works correctly there.

Note that this builds on the cachewhichtri branch, so the PR diff looks huger than it really is. See https://github.com/SCIInstitute/ShapeWorks/compare/cachewhichtri...particlecontainer for the changes

Specifically, note the [removal of the Erase function](https://github.com/SCIInstitute/ShapeWorks/compare/cachewhichtri...particlecontainer#diff-f16703aff672f1a54739e4c2cedc11271f53075609dea00ba557574b64e03bbfL131) and the [removal of its usage in ParticleNeighborhood](https://github.com/SCIInstitute/ShapeWorks/compare/cachewhichtri...particlecontainer#diff-0b01cf01f36bdccbd15ce6edc67286dc3fe97f6e161f75d9cfca4311909f32beL150). This has not caused any problems in the testing I've done so far, but please let me know if there is some unintended consequence of that.