### PR TITLE
PR package naming

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - pr_package
     tags:
     - '*'
   pull_request:
@@ -106,6 +107,8 @@ jobs:
 
     - name: Build Binary Package
       shell: bash -l {0}
+      env:
+        PR_NUMBER: ${{ github.event.number }}
       run: conda activate shapeworks && PATH=$HOME:$PATH ./Support/package.sh tag ${GITHUB_WORKSPACE}/shapeworks-install $HOME/install
 
     - name: make test

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - pr_package
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -53,12 +53,6 @@ jobs:
     - name: Get tags
       run: git fetch --unshallow origin +refs/tags/*:refs/tags/*
 
-    - name: Temp check package Build Binary Package
-      shell: bash -l {0}
-      env:
-        PR_NUMBER: ${{ github.event.number }}
-      run: ./Support/package.sh tag ${GITHUB_WORKSPACE}/shapeworks-install $HOME/install
-    
     - name: conda installs
       shell: bash -l {0}
       run: source ./conda_installs.sh

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -53,6 +53,12 @@ jobs:
     - name: Get tags
       run: git fetch --unshallow origin +refs/tags/*:refs/tags/*
 
+    - name: Temp check package Build Binary Package
+      shell: bash -l {0}
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: ./Support/package.sh tag ${GITHUB_WORKSPACE}/shapeworks-install $HOME/install
+    
     - name: conda installs
       shell: bash -l {0}
       run: source ./conda_installs.sh

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - pr_package
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -49,7 +49,7 @@ jobs:
       run: git fetch --unshallow origin +refs/tags/*:refs/tags/*
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2.0.0
+      uses: conda-incubator/setup-miniconda@v2.0.1
       with:
           miniconda-version: 'latest'
           

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - pr_package
     tags:
     - '*'
   pull_request:
@@ -102,6 +103,8 @@ jobs:
 
     - name: Build Binary Package
       shell: bash -l {0}
+      env:
+        PR_NUMBER: ${{ github.event.number }}
       run: conda activate shapeworks && ./Support/package.sh tag ${GITHUB_WORKSPACE}/shapeworks-install $HOME/install
 
     - name: make test

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - pr_package
     tags:
     - '*'
   pull_request:
@@ -103,6 +104,8 @@ jobs:
 
     - name: Build Binary Package
       shell: bash -l {0}
+      env:
+        PR_NUMBER: ${{ github.event.number }}
       run: conda activate shapeworks && pwd ; ls ; cp docs/users/Windows_README.txt . ; cp Support/shapeworks.nsi . ; conda activate shapeworks && ./Support/package_windows.sh tag
       
     - name: Test

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - pr_package
     tags:
     - '*'
   pull_request:

--- a/Support/package.sh
+++ b/Support/package.sh
@@ -15,9 +15,13 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 else
     PLATFORM="linux"
 fi
-    
+
+echo "PR_NUMBER = $PR_NUMBER"
+echo "GITHUB_REF = $GITHUB_REF"
+
 if [[ "$VERSION" == "tag" ]]; then
     VERSION="ShapeWorks-$(git describe --tags)-${PLATFORM}"
+    VERSION="ShapeWorks-PR-${PR_NUMBER}-${PLATFORM}"
 fi
 
 # Special case for when we are on the master branch (dev releases)

--- a/Support/package.sh
+++ b/Support/package.sh
@@ -16,12 +16,17 @@ else
     PLATFORM="linux"
 fi
 
+echo "VERSION = $VERSION"
 echo "PR_NUMBER = $PR_NUMBER"
 echo "GITHUB_REF = $GITHUB_REF"
+echo "PLATFORM = $PLATFORM"
 
-if [[ "$VERSION" == "tag" ]]; then
-    VERSION="ShapeWorks-$(git describe --tags)-${PLATFORM}"
+if [[ "$PR_NUMBER" != "" ]]; then
     VERSION="ShapeWorks-PR-${PR_NUMBER}-${PLATFORM}"
+else
+    if [[ "$VERSION" == "tag" ]]; then
+	VERSION="ShapeWorks-$(git describe --tags)-${PLATFORM}"
+    fi
 fi
 
 # Special case for when we are on the master branch (dev releases)

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -8,8 +8,18 @@ fi
 VERSION=$1
 PLATFORM="windows"
 
-if [[ "$VERSION" == "tag" ]]; then
-    VERSION="ShapeWorks-$(git describe --tags)-${PLATFORM}"
+
+echo "VERSION = $VERSION"
+echo "PR_NUMBER = $PR_NUMBER"
+echo "GITHUB_REF = $GITHUB_REF"
+echo "PLATFORM = $PLATFORM"
+
+if [[ "$PR_NUMBER" != "" ]]; then
+    VERSION="ShapeWorks-PR-${PR_NUMBER}-${PLATFORM}"
+else
+    if [[ "$VERSION" == "tag" ]]; then
+	VERSION="ShapeWorks-$(git describe --tags)-${PLATFORM}"
+    fi
 fi
 
 # Special case for when we are on the master branch (dev releases)


### PR DESCRIPTION
This PR modifies the version naming for artifacts built from PR.  PRs will now have the form:

VERSION="ShapeWorks-PR-${PR_NUMBER}-${PLATFORM}"

They were previous using the tag mode, but this was typically just "dev-linux" (on any platform) and a not very useful git hash from the merge commit.