### PR TITLE
Fix broken conda installs on GitHub Actions (mac)

### DIFF
--- a/conda_installs.sh
+++ b/conda_installs.sh
@@ -108,11 +108,12 @@ function install_conda() {
 
   if [[ "$GITHUB_ACTION" != "" ]]; then
       echo "Running under GitHub Action"
-      cd $HOME/miniconda3/envs/shapeworks/lib
+      pushd $HOME/miniconda3/envs/shapeworks/lib
       ls libffi*
       if [ ! -f libffi.6.dylib ]; then
 	  ln -s libffi.7.dylib libffi.6.dylib
       fi
+      popd
   fi
   
   if ! pip install termcolor==1.1.0; then return 1; fi

--- a/conda_installs.sh
+++ b/conda_installs.sh
@@ -106,6 +106,14 @@ function install_conda() {
       then return 1; fi
   fi
 
+  if [[ "$GITHUB_ACTION" != "" ]]; then
+      echo "Running under GitHub Action"
+      cd $HOME/miniconda3/envs/shapeworks/lib
+      ls libffi*
+      if [ ! -f libffi.6.dylib ]; then
+	  ln -s libffi.7.dylib libffi.6.dylib
+      fi
+  fi
   
   if ! pip install termcolor==1.1.0; then return 1; fi
   if ! pip install grip==4.5.2; then return 1; fi


### PR DESCRIPTION
The only solutions I can find for this problem are to either re-install (not applicable) or do this ln operation in the env lib dir:

`ln -s libffi.7.dylib libffi.6.dylib`

I have no idea why, but sometimes we end up with 7 and other times with 6 and pip always needs 6.

Relevant links:

https://github.com/conda/conda/issues/9038
https://github.com/conda/conda/issues/9899

9038 was closed for some reason.  9899 is still open.