### PR TITLE
Fix python deployment

### DIFF
--- a/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
@@ -69,9 +69,8 @@
     "\n",
     "- This notebook is located in `Examples/Python/notebooks/tutorials`\n",
     "- You have built shapeworks from source in `build` directory within the shapeworks code directory\n",
-    "- You have built shapeworks dependencies (using `build_dependencies.sh`) in the same parent directory of shapeworks code\n",
     "\n",
-    "**Note:** If you run from a ShapeWorks installation, you don't need to set the dependencies path and the `shapeworks_bin_dir` would be set as `../../../../bin`."
+    "**Note:** If you run from a ShapeWorks installation, you don't need to set the `shapeworks_bin_dir`"
    ]
   },
   {
@@ -90,12 +89,11 @@
     "import setupenv\n",
     "\n",
     "# indicate the bin directories for shapeworks and its dependencies\n",
-    "shapeworks_bin_dir   = \"../../../../build/bin\"\n",
-    "dependencies_bin_dir = \"../../../../../shapeworks-dependencies/bin\"\n",
+    "shapeworks_bin_dir = None # default\n",
+    "#shapeworks_bin_dir = \"../../../../build/bin\"\n",
     "\n",
     "# set up shapeworks environment\n",
     "setupenv.setup_shapeworks_env(shapeworks_bin_dir,  \n",
-    "                              dependencies_bin_dir, \n",
     "                              verbose = False)"
    ]
   },

--- a/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
@@ -338,7 +338,7 @@
    "outputs": [],
    "source": [
     "import glob # for paths and file-directory search\n",
-    "\n",
+    "from pathlib import Path # for generating robust paths irrespective of the platform:Win/Linux/Mac\n",
     "# file extension for the shape data\n",
     "shapeExtention = '.nrrd'\n",
     "\n",
@@ -350,7 +350,8 @@
     "print ('Number of shapes: ' + str(len(shapeFilenames)))\n",
     "print('Shape files found:')\n",
     "for shapeFilename in shapeFilenames:\n",
-    "    print('\\t' + shapeFilename)"
+    "    shapeFilenames = Path(shapeFilenames)\n",
+    "    print(shapeFilename)"
    ]
   },
   {
@@ -1071,7 +1072,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.6.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
@@ -1072,7 +1072,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.7.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
@@ -350,7 +350,7 @@
     "print ('Number of shapes: ' + str(len(shapeFilenames)))\n",
     "print('Shape files found:')\n",
     "for shapeFilename in shapeFilenames:\n",
-    "    shapeFilenames = Path(shapeFilenames)\n",
+    "    shapeFilename = Path(shapeFilename)\n",
     "    print(shapeFilename)"
    ]
   },

--- a/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
@@ -75,9 +75,8 @@
     "\n",
     "- This notebook is located in `Examples/Python/notebooks/tutorials`\n",
     "- You have built shapeworks from source in `build` directory within the shapeworks code directory\n",
-    "- You have built shapeworks dependencies (using `build_dependencies.sh`) in the same parent directory of shapeworks code\n",
     "\n",
-    "**Note:** If you run from a ShapeWorks installation, you don't need to set the dependencies path and the `shapeworks_bin_dir` would be set as `../../../../bin`."
+    "**Note:** If you run from a ShapeWorks installation, you don't need to set the `shapeworks_bin_dir`"
    ]
   },
   {
@@ -96,12 +95,11 @@
     "import setupenv\n",
     "\n",
     "# indicate the bin directories for shapeworks and its dependencies\n",
-    "shapeworks_bin_dir   = \"../../../../build/bin\"\n",
-    "dependencies_bin_dir = \"../../../../../shapeworks-dependencies/bin\"\n",
+    "shapeworks_bin_dir = None # default\n",
+    "#shapeworks_bin_dir = \"../../../../build/bin\"\n",
     "\n",
     "# set up shapeworks environment\n",
     "setupenv.setup_shapeworks_env(shapeworks_bin_dir,  \n",
-    "                              dependencies_bin_dir, \n",
     "                              verbose = False)"
    ]
   },
@@ -2242,7 +2240,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
@@ -672,7 +672,7 @@
     "print('Number of shapes: ' + str(len(shapeFilenames)))\n",
     "print('Shape files found:')\n",
     "for shapeFilename in shapeFilenames:\n",
-    "    shapeFilenames = Path(shapeFilenames)\n",
+    "    shapeFilename = Path(shapeFilename)\n",
     "    print(shapeFilename)"
    ]
   },
@@ -2883,7 +2883,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.7.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
@@ -640,7 +640,7 @@
    "outputs": [],
    "source": [
     "import glob # for paths and file-directory search\n",
-    "\n",
+    "from pathlib import Path # for generating robust paths irrespective of the platform:Win/Linux/Mac\n",
     "# dataset name is the folder name for your dataset\n",
     "datasetName  = 'ellipsoid-v2'\n",
     "\n",
@@ -672,7 +672,8 @@
     "print('Number of shapes: ' + str(len(shapeFilenames)))\n",
     "print('Shape files found:')\n",
     "for shapeFilename in shapeFilenames:\n",
-    "    print('\\t' + shapeFilename)"
+    "    shapeFilenames = Path(shapeFilenames)\n",
+    "    print(shapeFilename)"
    ]
   },
   {
@@ -2882,7 +2883,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.6.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
@@ -66,9 +66,8 @@
     "\n",
     "- This notebook is located in `Examples/Python/notebooks/tutorials`\n",
     "- You have built shapeworks from source in `build` directory within the shapeworks code directory\n",
-    "- You have built shapeworks dependencies (using `build_dependencies.sh`) in the same parent directory of shapeworks code\n",
     "\n",
-    "**Note:** If you run from a ShapeWorks installation, you don't need to set the dependencies path and the `shapeworks_bin_dir` would be set as `../../../../bin`."
+    "**Note:** If you run from a ShapeWorks installation, you don't need to set the `shapeworks_bin_dir`"
    ]
   },
   {
@@ -87,12 +86,11 @@
     "import setupenv\n",
     "\n",
     "# indicate the bin directories for shapeworks and its dependencies\n",
-    "shapeworks_bin_dir   = \"../../../../build/bin\"\n",
-    "dependencies_bin_dir = \"../../../../../shapeworks-dependencies/bin\"\n",
+    "shapeworks_bin_dir = None # default\n",
+    "#shapeworks_bin_dir = \"../../../../build/bin\"\n",
     "\n",
     "# set up shapeworks environment\n",
     "setupenv.setup_shapeworks_env(shapeworks_bin_dir,  \n",
-    "                              dependencies_bin_dir, \n",
     "                              verbose = False)"
    ]
   },

--- a/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
@@ -184,7 +184,7 @@
     "print ('Number of shapes: ' + str(len(shapeFilenames)))\n",
     "print('Shape files found:')\n",
     "for shapeFilename in shapeFilenames:\n",
-    "    shapeFilenames = Path(shapeFilenames)\n",
+    "    shapeFilename = Path(shapeFilename)\n",
     "    print(shapeFilename)"
    ]
   },
@@ -802,7 +802,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.7.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
@@ -172,7 +172,7 @@
    "outputs": [],
    "source": [
     "import glob # for paths and file-directory search\n",
-    "\n",
+    "from pathlib import Path # for generating robust paths irrespective of the platform:Win/Linux/Mac\n",
     "# file extension for the shape data\n",
     "shapeExtention = '.vtk'\n",
     "\n",
@@ -184,7 +184,8 @@
     "print ('Number of shapes: ' + str(len(shapeFilenames)))\n",
     "print('Shape files found:')\n",
     "for shapeFilename in shapeFilenames:\n",
-    "    print('\\t' + shapeFilename)"
+    "    shapeFilenames = Path(shapeFilenames)\n",
+    "    print(shapeFilename)"
    ]
   },
   {
@@ -801,7 +802,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.6.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
@@ -172,7 +172,7 @@
    "outputs": [],
    "source": [
     "import glob # for paths and file-directory search\n",
-    "\n",
+    "from pathlib import Path # for generating robust paths irrespective of the platform:Win/Linux/Mac\n",
     "# file extension for the shape data\n",
     "shapeExtention = '.nrrd'\n",
     "\n",
@@ -184,7 +184,8 @@
     "print ('Number of shapes: ' + str(len(shapeFilenames)))\n",
     "print('Shape files found:')\n",
     "for shapeFilename in shapeFilenames:\n",
-    "    print('\\t' + shapeFilename)"
+    "    shapeFilenames = Path(shapeFilenames)\n",
+    "    print(shapeFilename)"
    ]
   },
   {
@@ -851,7 +852,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.6.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
@@ -184,7 +184,7 @@
     "print ('Number of shapes: ' + str(len(shapeFilenames)))\n",
     "print('Shape files found:')\n",
     "for shapeFilename in shapeFilenames:\n",
-    "    shapeFilenames = Path(shapeFilenames)\n",
+    "    shapeFilename = Path(shapeFilename)\n",
     "    print(shapeFilename)"
    ]
   },
@@ -852,7 +852,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.7.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
@@ -67,9 +67,8 @@
     "\n",
     "- This notebook is located in `Examples/Python/notebooks/tutorials`\n",
     "- You have built shapeworks from source in `build` directory within the shapeworks code directory\n",
-    "- You have built shapeworks dependencies (using `build_dependencies.sh`) in the same parent directory of shapeworks code\n",
     "\n",
-    "**Note:** If you run from a ShapeWorks installation, you don't need to set the dependencies path and the `shapeworks_bin_dir` would be set as `../../../../bin`."
+    "**Note:** If you run from a ShapeWorks installation, you don't need to set the `shapeworks_bin_dir`"
    ]
   },
   {
@@ -88,12 +87,11 @@
     "import setupenv\n",
     "\n",
     "# indicate the bin directories for shapeworks and its dependencies\n",
-    "shapeworks_bin_dir   = \"../../../../build/bin\"\n",
-    "dependencies_bin_dir = \"../../../../../shapeworks-dependencies/bin\"\n",
+    "shapeworks_bin_dir = None # default\n",
+    "#shapeworks_bin_dir = \"../../../../build/bin\"\n",
     "\n",
     "# set up shapeworks environment\n",
     "setupenv.setup_shapeworks_env(shapeworks_bin_dir,  \n",
-    "                              dependencies_bin_dir, \n",
     "                              verbose = False)"
    ]
   },

--- a/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
+++ b/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
@@ -117,7 +117,7 @@
     "        elif platform.system() == \"Darwin\": # MacOS\n",
     "            shapeworks_bin_dir = \"/Applications/ShapeWorks/bin\"\n",
     "        else: # Linux\n",
-    "            shapeworks_bin_dir   = \"../../../../build/bin\"\n",
+    "            shapeworks_bin_dir   = \"../../../../bin\"\n",
     "    # add shapeworks (and studio on mac) directory to python path \n",
     "    sys.path.append(shapeworks_bin_dir)\n",
     "    if platform.system() == \"Darwin\": # MacOS\n",

--- a/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
+++ b/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
@@ -87,8 +87,15 @@
     "import sys\n",
     "import platform\n",
     "\n",
-    "# paths to be set\n",
-    "shapeworks_bin_dir   = \"../../../../build/bin\"\n",
+    "if platform.system() == \"Windows\":\n",
+    "    shapeworks_bin_dir = \"C:\\\\Program Files\\\\ShapeWorks\\\\bin\"\n",
+    "elif platform.system() == \"Darwin\": # MacOS\n",
+    "    shapeworks_bin_dir = \"/Applications/ShapeWorks/bin\"\n",
+    "else: # Linux\n",
+    "    shapeworks_bin_dir   = \"../../../../build/bin\"\n",
+    "    \n",
+    "# To override, uncomment and set paths here\n",
+    "#shapeworks_bin_dir   = \"../../../../build/bin\"\n",
     "dependencies_bin_dir = \"../../../../../shapeworks-dependencies/bin\""
    ]
   },
@@ -191,6 +198,13 @@
     "else:\n",
     "    print('SUCCESS: shapeworks library is successfully imported!!!')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -209,7 +223,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.9"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
+++ b/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
@@ -212,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.12"
+   "version": "3.7.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
+++ b/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
@@ -44,10 +44,9 @@
    "source": [
     "## 1. Setting up `shapeworks` environment \n",
     "\n",
-    "To setup shapeworks environement, please make sure to add the following paths to both your `PYTHONPATH` and your system `PATH`.\n",
+    "To setup shapeworks environement, please make sure to add the following path to both your `PYTHONPATH` and your system `PATH`.\n",
     "\n",
     "- shapeworks bin directory\n",
-    "- shapeworks dependencies bin directory\n",
     "\n",
     "This can be done either by running the following commands on the terminal \n",
     "\n",
@@ -69,34 +68,8 @@
     "\n",
     "- This notebook is located in `Examples/Python/notebooks/tutorials`\n",
     "- You have built shapeworks from source in `build` directory within the shapeworks code directory\n",
-    "- You have built shapeworks dependencies (using `build_dependencies.sh`) in the same parent directory of shapeworks code\n",
     "\n",
-    "**Note:** If you run from a ShapeWorks installation, you don't need to set the dependencies path and the `shapeworks_bin_dir` would be set as `../../../../bin`.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# import relevant libraries \n",
-    "# and indicate the bin directories for shapeworks and its dependencies\n",
-    "\n",
-    "import os\n",
-    "import sys\n",
-    "import platform\n",
-    "\n",
-    "if platform.system() == \"Windows\":\n",
-    "    shapeworks_bin_dir = \"C:\\\\Program Files\\\\ShapeWorks\\\\bin\"\n",
-    "elif platform.system() == \"Darwin\": # MacOS\n",
-    "    shapeworks_bin_dir = \"/Applications/ShapeWorks/bin\"\n",
-    "else: # Linux\n",
-    "    shapeworks_bin_dir   = \"../../../../build/bin\"\n",
-    "    \n",
-    "# To override, uncomment and set paths here\n",
-    "#shapeworks_bin_dir   = \"../../../../build/bin\"\n",
-    "dependencies_bin_dir = \"../../../../../shapeworks-dependencies/bin\""
+    "**Note:** If you run from a ShapeWorks installation, you don't need to set the `shapeworks_bin_dir`\n"
    ]
   },
   {
@@ -134,10 +107,17 @@
     "            print(curpath)\n",
     "        \n",
     "# helper function to add shapeworks bin directory to the path\n",
-    "def setup_shapeworks_env(shapeworks_bin_dir,   # path to the binary directory of shapeworks\n",
-    "                         dependencies_bin_dir, # path to the binary directory of shapeworks dependencies used when running build_dependencies.sh\n",
+    "def setup_shapeworks_env(shapeworks_bin_dir = None,   # path to the binary directory of shapeworks\n",
     "                         verbose = True):\n",
     "    \n",
+    "    # if not set, assume a binary deployment and guess at location\n",
+    "    if shapeworks_bin_dir is None:\n",
+    "        if platform.system() == \"Windows\":\n",
+    "            shapeworks_bin_dir = \"C:\\\\Program Files\\\\ShapeWorks\\\\bin\"\n",
+    "        elif platform.system() == \"Darwin\": # MacOS\n",
+    "            shapeworks_bin_dir = \"/Applications/ShapeWorks/bin\"\n",
+    "        else: # Linux\n",
+    "            shapeworks_bin_dir   = \"../../../../build/bin\"\n",
     "    # add shapeworks (and studio on mac) directory to python path \n",
     "    sys.path.append(shapeworks_bin_dir)\n",
     "    if platform.system() == \"Darwin\": # MacOS\n",
@@ -145,7 +125,6 @@
     "    \n",
     "    # add shapeworks and studio to the system path\n",
     "    os.environ[\"PATH\"] = shapeworks_bin_dir   + os.pathsep + os.environ[\"PATH\"]\n",
-    "    os.environ[\"PATH\"] = dependencies_bin_dir + os.pathsep + os.environ[\"PATH\"]\n",
     "    if platform.system() == \"Darwin\": # MacOS\n",
     "        os.environ[\"PATH\"] = shapeworks_bin_dir + \"/ShapeWorksStudio.app/Contents/MacOS\" + os.pathsep + os.environ[\"PATH\"]\n",
     "    \n",
@@ -169,10 +148,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# import relevant libraries \n",
+    "# and indicate the bin directories for shapeworks and its dependencies\n",
+    "\n",
+    "import os\n",
+    "import sys\n",
+    "import platform\n",
+    "\n",
+    "shapeworks_bin_dir = None  # use default\n",
+    "\n",
+    "# To override, uncomment and set paths here\n",
+    "# shapeworks_bin_dir   = \"../../../../build/bin\"\n",
+    "\n",
     "# set up shapeworks environment\n",
-    "setup_shapeworks_env(shapeworks_bin_dir,  \n",
-    "                     dependencies_bin_dir, \n",
-    "                     verbose = False)"
+    "setup_shapeworks_env(shapeworks_bin_dir, verbose = False)\n"
    ]
   },
   {
@@ -196,7 +185,7 @@
     "except ImportError:\n",
     "    print('ERROR: shapeworks library failed to import')\n",
     "else:\n",
-    "    print('SUCCESS: shapeworks library is successfully imported!!!')"
+    "    print('SUCCESS: shapeworks library is successfully imported!!!')    "
    ]
   },
   {
@@ -223,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.8"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
+++ b/Examples/Python/notebooks/tutorials/setting-up-shapeworks-environment.ipynb
@@ -212,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.6.12"
   },
   "toc": {
    "base_numbering": 1,

--- a/Examples/Python/setupenv.py
+++ b/Examples/Python/setupenv.py
@@ -30,7 +30,7 @@ def setup_shapeworks_env(shapeworks_bin_dir = None,   # path to the binary direc
         elif platform.system() == "Darwin": # MacOS
             shapeworks_bin_dir = "/Applications/ShapeWorks/bin"
         else: # Linux
-            shapeworks_bin_dir   = "../../../../build/bin"
+            shapeworks_bin_dir   = "../../../../bin"
         
     # add shapeworks (and studio on mac) directory to python path 
     sys.path.append(shapeworks_bin_dir)

--- a/Examples/Python/setupenv.py
+++ b/Examples/Python/setupenv.py
@@ -19,10 +19,19 @@ def print_env_path():
             print(curpath)
         
 # helper function to add shapeworks bin directory to the path
-def setup_shapeworks_env(shapeworks_bin_dir,   # path to the binary directory of shapeworks
+def setup_shapeworks_env(shapeworks_bin_dir = None,   # path to the binary directory of shapeworks
                          dependencies_bin_dir = None, # only needed if shapeworks is built from source: path to the binary directory of shapeworks dependencies used when running build_dependencies.sh
                          verbose = True):
-    
+
+    # if not set, assume a binary deployment and guess at location
+    if shapeworks_bin_dir is None:
+        if platform.system() == "Windows":
+            shapeworks_bin_dir = "C:\\Program Files\\ShapeWorks\\bin"
+        elif platform.system() == "Darwin": # MacOS
+            shapeworks_bin_dir = "/Applications/ShapeWorks/bin"
+        else: # Linux
+            shapeworks_bin_dir   = "../../../../build/bin"
+        
     # add shapeworks (and studio on mac) directory to python path 
     sys.path.append(shapeworks_bin_dir)
     if platform.system() == "Darwin": # MacOS

--- a/Support/package.sh
+++ b/Support/package.sh
@@ -82,15 +82,15 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     # copy platform plugins for View2
     cp -a ShapeWorksStudio.app/Contents/PlugIns .
 
+    for i in *.so ; do
+	install_name_tool -add_rpath "@loader_path/../lib" $i
+	install_name_tool -add_rpath $QT_LOADER_LIB_LOCATION $i
+    done
+
     for i in * ; do
 	install_name_tool -add_rpath $QT_LIB_LOCATION $i
     done
 
-    for i in *.so ; do
-	install_name_tool -add_rpath $QT_LOADER_LIB_LOCATION $i
-	install_name_tool -add_rpath "@loader_path/../lib" $i
-    done
-	
     cd ../lib
     # Copy libraries from anaconda
     conda_libs="libpython"
@@ -101,9 +101,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     for i in *.dylib ; do
 	install_name_tool -change ${BASE_LIB}/libitkgdcmopenjp2-5.0.1.dylib @rpath/libitkgdcmopenjp2-5.0.1.dylib $i
     done
-
     install_name_tool -id @rpath/libitkgdcmopenjp2-5.0.1.dylib libitkgdcmopenjp2-5.0.1.dylib
-    
+
     cd ..
 else
     # Copy libraries from anaconda

--- a/Support/package.sh
+++ b/Support/package.sh
@@ -76,6 +76,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     install_name_tool -add_rpath @executable_path/../Frameworks ShapeWorksStudio.app/Contents/MacOS/ShapeWorksStudio
     install_name_tool -add_rpath @executable_path/../../../../lib ShapeWorksStudio.app/Contents/MacOS/ShapeWorksStudio
     QT_LIB_LOCATION="@executable_path/ShapeWorksStudio.app/Contents/Frameworks"
+    QT_LOADER_LIB_LOCATION="@loader_path/ShapeWorksStudio.app/Contents/Frameworks"
 
 
     # copy platform plugins for View2
@@ -85,6 +86,11 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 	install_name_tool -add_rpath $QT_LIB_LOCATION $i
     done
 
+    for i in *.so ; do
+	install_name_tool -add_rpath $QT_LOADER_LIB_LOCATION $i
+	install_name_tool -add_rpath "@loader_path/../lib" $i
+    done
+	
     cd ../lib
     # Copy libraries from anaconda
     conda_libs="libpython"

--- a/conda_installs.sh
+++ b/conda_installs.sh
@@ -36,9 +36,9 @@ function install_conda() {
   if ! command -v conda 2>/dev/null 1>&2; then
     echo "installing anaconda..."
     if [[ "$(uname)" == "Darwin" ]]; then
-      curl -o ./Miniconda3-latest-MacOSX-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-      bash ./Miniconda3-latest-MacOSX-x86_64.sh
-      rm ./Miniconda3-latest-MacOSX-x86_64.sh
+      curl -o /tmp/Miniconda3-latest-MacOSX-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
+      bash /tmp/Miniconda3-latest-MacOSX-x86_64.sh
+      rm /tmp/Miniconda3-latest-MacOSX-x86_64.sh
     elif [[ "$(uname)" == "Linux" ]]; then
       curl -o ./Miniconda3-latest-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
       bash ./Miniconda3-latest-Linux-x86_64.sh

--- a/conda_installs.sh
+++ b/conda_installs.sh
@@ -3,6 +3,7 @@
 #
 echo ""
 echo "Note: this script only supports bash and zsh shells"
+echo "      It must be called using \"source ./conda_installs.sh\""
 echo ""
 
 (return 0 2>/dev/null) && sourced=1 || sourced=0


### PR DESCRIPTION
This PR fixes the loader path for the shapeworks python module on Mac OS.

It also fixes conda_installs.sh for the Mac binary deployment.

The change to the `setting-up-shapeworks-environment.ipynb` should fix this script to run on the binary deployments of Mac, Linux and Windows without the user needing to change the path variables.  If this works, I suppose we need to change the rest of the notebooks, although I would suggest that this logic be moved to the setupenv.py script, but it will require changing the behavior, so I have not done so yet.