### PR TITLE
Added ignore-back-intersection flag to FEAreaCoverage

### DIFF
--- a/Libs/Mesh/PreviewMeshQC/FEAreaCoverage.cpp
+++ b/Libs/Mesh/PreviewMeshQC/FEAreaCoverage.cpp
@@ -75,7 +75,21 @@ void FEAreaCoverage::Surface::Create(FEMesh& mesh)
 
 //-----------------------------------------------------------------------------
 FEAreaCoverage::FEAreaCoverage()
-{}
+{
+  	m_bignoreBackIntersections = true;
+}
+
+//-----------------------------------------------------------------------------
+void FEAreaCoverage::IgnoreBackIntersection(bool b)
+{
+	m_bignoreBackIntersections = b;
+}
+
+//-----------------------------------------------------------------------------
+bool FEAreaCoverage::IgnoreBackIntersection() const
+{
+	return m_bignoreBackIntersections;
+}
 
 //-----------------------------------------------------------------------------
 vector<double> FEAreaCoverage::Apply(FEMesh& mesh1, FEMesh& mesh2)
@@ -201,7 +215,8 @@ bool FEAreaCoverage::faceIntersect(FEAreaCoverage::Surface& surf, const Ray& ray
   break;
   }
 
-  if (bfound) {
+  if (bfound && (m_bignoreBackIntersections))  
+  {
     // make sure the projection is in the direction of the ray
     bfound = (ray.direction * (q.point - ray.origin) > 0.f);
   }

--- a/Libs/Mesh/PreviewMeshQC/FEAreaCoverage.h
+++ b/Libs/Mesh/PreviewMeshQC/FEAreaCoverage.h
@@ -42,6 +42,10 @@ public:
   // returns one value per node
   vector<double> Apply(FEMesh& mesh1, FEMesh& mesh2);
 
+  // set/get back intersection flag
+	void IgnoreBackIntersection(bool b);
+	bool IgnoreBackIntersection() const;
+
 protected:
   // build node normal list
   void UpdateSurface(FEAreaCoverage::Surface& s);
@@ -53,4 +57,5 @@ protected:
 protected:
   Surface m_surf1;
   Surface m_surf2;
+	bool		m_bignoreBackIntersections;
 };


### PR DESCRIPTION
The ignore-back-intersection flag decides whether or not to include back-intersections in coverage calculation.