### PR TITLE
Add test for shape evaluation shapeworks subcommand

### DIFF
--- a/Libs/Particles/ShapeEvaluation.cpp
+++ b/Libs/Particles/ShapeEvaluation.cpp
@@ -15,8 +15,6 @@ double ShapeEvaluation::ComputeCompactness(const ParticleSystem &particleSystem,
   const int N = particleSystem.N();
   const int D = particleSystem.D();
 
-  std::cerr << "N = " << N << "\n";
-  std::cerr << "D = " << D << "\n";
   Eigen::MatrixXd Y = particleSystem.Particles();
   const Eigen::VectorXd mu = Y.rowwise().mean();
   Y.colwise() -= mu;

--- a/Testing/data/shapeevaluation.txt
+++ b/Testing/data/shapeevaluation.txt
@@ -1,0 +1,3 @@
+Particle system compactness: 0.991787
+Particle system generalization: 0.198151
+Particle system specificity: 0.252149

--- a/Testing/shapeworksTests/shapeevaluation.sh
+++ b/Testing/shapeworksTests/shapeevaluation.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-truth=`cut -d' ' -f4 $DATA/shapeevaluation.txt | tr '\n' ' '`
+truth=`cut -d' ' -f4 $DATA/shapeevaluation.txt`
 
-if ! result=`shapeworks readparticlesystem --names $DATA/ellipsoid_particles/* -- compactness generalization specificity | cut -d' ' -f4 | tr '\n' ' '`; then
+if ! result=`shapeworks readparticlesystem --names $DATA/ellipsoid_particles/* -- compactness generalization specificity | cut -d' ' -f4`; then
     exit 1
 fi
 
 script="import sys
-lhs = [float(x) for x in \"$truth\".split()]
-rhs = [float(x) for x in \"$result\".split()]
+lhs = [float(x) for x in sys.argv[1].split()]
+rhs = [float(x) for x in sys.argv[2].split()]
 for a,b in zip(lhs, rhs):
     if abs(a-b) > 1e-1:
         sys.exit(1)
 "
-python -c "$script"
+python -c "$script" "$truth" "$result"

--- a/Testing/shapeworksTests/shapeevaluation.sh
+++ b/Testing/shapeworksTests/shapeevaluation.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+shapeworks readparticlesystem --names $DATA/ellipsoid_particles/* -- compactness generalization specificity | diff - $DATA/shapeevaluation.txt

--- a/Testing/shapeworksTests/shapeevaluation.sh
+++ b/Testing/shapeworksTests/shapeevaluation.sh
@@ -1,3 +1,16 @@
-#! /bin/bash
+#!/bin/bash
 
-shapeworks readparticlesystem --names $DATA/ellipsoid_particles/* -- compactness generalization specificity | diff - $DATA/shapeevaluation.txt
+truth=`cut -d' ' -f4 $DATA/shapeevaluation.txt | tr '\n' ' '`
+
+if ! result=`shapeworks readparticlesystem --names $DATA/ellipsoid_particles/* -- compactness generalization specificity | cut -d' ' -f4 | tr '\n' ' '`; then
+    exit 1
+fi
+
+script="import sys
+lhs = [float(x) for x in \"$truth\".split()]
+rhs = [float(x) for x in \"$result\".split()]
+for a,b in zip(lhs, rhs):
+    if abs(a-b) > 1e-1:
+        sys.exit(1)
+"
+python -c "$script"

--- a/Testing/shapeworksTests/shapeworksTests.cpp
+++ b/Testing/shapeworksTests/shapeworksTests.cpp
@@ -270,3 +270,9 @@ TEST(shapeworksTests, division)
 {
   ASSERT_FALSE(system("bash div.sh"));
 }
+
+//---------------------------------------------------------------------------
+TEST(shapeworksTests, shapeevaluation)
+{
+  ASSERT_FALSE(system("bash shapeevaluation.sh"));
+}


### PR DESCRIPTION
This PR adds a test for particle system subcommands in shapeworksTests.

Closes #602