### PR TITLE
Improvements to FEAreaCoverage tool

### DIFF
--- a/Libs/Mesh/PreviewMeshQC/FEAreaCoverage.h
+++ b/Libs/Mesh/PreviewMeshQC/FEAreaCoverage.h
@@ -42,20 +42,31 @@ public:
   // returns one value per node
   vector<double> Apply(FEMesh& mesh1, FEMesh& mesh2);
 
-  // set/get back intersection flag
-	void IgnoreBackIntersection(bool b);
-	bool IgnoreBackIntersection() const;
+  // get/set back intersection flag
+	void AllowBackIntersection(bool b);
+	bool AllowBackIntersection() const;
+
+  // set/get the angle threshold (w between 0 and 1)
+	void SetAngleThreshold(double w);
+	double GetAngleThreshold() const;
+
+  // set/get back-intersection search radius (0 ignores the search radius)
+	void SetBackSearchRadius(double R);
+	double GetBackSearchRadius() const;
 
 protected:
   // build node normal list
   void UpdateSurface(FEAreaCoverage::Surface& s);
 
   // see if a ray intersects with a surface
-  bool intersect(const vec3d& r, const vec3d& N, FEAreaCoverage::Surface& surf);
-  bool faceIntersect(FEAreaCoverage::Surface& surf, const Ray& ray, int nface);
+  bool intersect(const vec3d& r, const vec3d& N, FEAreaCoverage::Surface& surf, Intersection& q);
+  bool faceIntersect(FEAreaCoverage::Surface& surf, const Ray& ray, int nface, Intersection& q);
 
 protected:
   Surface m_surf1;
   Surface m_surf2;
-	bool		m_bignoreBackIntersections;
+
+	bool		  m_ballowBackIntersections;	// include back intersections
+	double		m_angleThreshold;			      // angular threshold (between 0 and 1)
+	double		m_backSearchRadius;			    // search radius for back intersections (set to 0 to ignore)
 };


### PR DESCRIPTION
- Modified algorithm so it looks for closest intersection (previously, first intersection was chosen)

- Added angle threshold parameter: This is used to see if the normal at the intersection point does not deviate too far from the ray. (Value should be between 0 and 1, which represents negative cosine of angle)

- Added back search radius parameter: This limits back intersections to user specified value.