### PR TITLE
Rigid Alignment

### DIFF
--- a/Examples/Python/GroomUtils.py
+++ b/Examples/Python/GroomUtils.py
@@ -193,11 +193,11 @@ def applyRigidAlignment(outDir, refFile, inDataListSeg, inDataListImg=[]):
         # resize images to reference images
         img = Image(inDataListSeg[i])
         rigidTransform = ImageUtils.createRigidRegistrationTransform(Image(inDataListSeg[i]).antialias(antialias_iterations), refImg, isoValue, icp_iterations)
-        img.resample(rigidTransform, refImg.origin(), refImg.dims(), refImg.spacing(), refImg.coordsys(), InterpolationType.Linear).write(segoutname)
+        img.applyTransform(rigidTransform, refImg.origin(), refImg.dims(), refImg.spacing(), refImg.coordsys(), InterpolationType.Linear).write(segoutname)
 
         if inDataListImg:
             img = Image(inDataListImg[i])
-            img.resample(rigidTransform, refImg.origin(), refImg.dims(), refImg.spacing(), refImg.coordsys(), InterpolationType.Linear).write(rawoutname)
+            img.applyTransform(rigidTransform, refImg.origin(), refImg.dims(), refImg.spacing(), refImg.coordsys(), InterpolationType.Linear).write(rawoutname)
 
     return [outSegDataList, outRawDataList] if inDataListImg else outSegDataList
 

--- a/Examples/Python/GroomUtils.py
+++ b/Examples/Python/GroomUtils.py
@@ -85,6 +85,7 @@ def applyCOMAlignment(outDir, inDataListSeg, inDataListImg, processRaw=False):
     files in the appropriate directory.
     """
     print("\n############# COM Alignment ###############")
+    antialias_iterations = 30
     segDir = os.path.join(outDir, 'segmentations') if processRaw else outDir
     if not os.path.exists(segDir):
         os.makedirs(segDir)
@@ -103,14 +104,14 @@ def applyCOMAlignment(outDir, inDataListSeg, inDataListImg, processRaw=False):
         T = img.center() - img.centerOfMass()
 
         # binarize result since linear interpolation makes image blurry again
-        img.translate(T).binarize().recenter().write(outname)
+        img.antialias(antialias_iterations).translate(T).binarize().recenter().write(outname)
 
         if processRaw:
             innameImg = inDataListImg[i]
             outnameImg = rename(innameImg, imageDir, 'com')
             outDataListImg.append(outnameImg)
             rawImg = Image(innameImg)
-            rawImg.translate(T).write(outnameImg)
+            rawImg.translate(T).recenter().write(outnameImg)
 
     return [outDataListSeg, outDataListImg] if processRaw else outDataListSeg
 

--- a/Examples/Python/GroomUtils.py
+++ b/Examples/Python/GroomUtils.py
@@ -156,14 +156,13 @@ def FindReferenceImage(inDataList):
     print(" ")
     return inDataList[idx]
 
-def applyRigidAlignment(outDir, refFile, inDataListSeg, inDataListImg=[]):
+def applyRigidAlignment(outDir, refFile, inDataListSeg, inDataListImg=[], icp_iterations=200):
     """
     This function takes in a filelists(binary and raw) and makes the 
     size and spacing the same as the reference
     """
     isoValue       = 1e-20
-    icp_iterations = 200
-    antialias_iterations = 1 
+    antialias_iterations = 30
 
     print("\n############# Rigidly Align #############")
 

--- a/Examples/Python/GroomUtils.py
+++ b/Examples/Python/GroomUtils.py
@@ -192,8 +192,9 @@ def applyRigidAlignment(outDir, refFile, inDataListSeg, inDataListImg=[], icp_it
 
         # resize images to reference images
         img = Image(inDataListSeg[i])
-        rigidTransform = ImageUtils.createRigidRegistrationTransform(Image(inDataListSeg[i]).antialias(antialias_iterations), refImg, isoValue, icp_iterations)
-        img.applyTransform(rigidTransform, refImg.origin(), refImg.dims(), refImg.spacing(), refImg.coordsys(), InterpolationType.Linear).write(segoutname)
+        img.antialias(antialias_iterations)
+        rigidTransform = ImageUtils.createRigidRegistrationTransform(img, refImg, isoValue, icp_iterations)
+        img.applyTransform(rigidTransform, refImg.origin(), refImg.dims(), refImg.spacing(), refImg.coordsys(), InterpolationType.Linear).binarize().write(segoutname)
 
         if inDataListImg:
             img = Image(inDataListImg[i])

--- a/Examples/Python/ellipsoid.py
+++ b/Examples/Python/ellipsoid.py
@@ -50,7 +50,6 @@ def Run_Pipeline(args):
     For the unprepped data the first few steps are 
     -- Isotropic resampling
     -- Center
-    -- Padding
     -- Center of Mass Alignment
     -- Rigid Alignment
     -- Largest Bounding Box and Cropping 
@@ -80,11 +79,8 @@ def Run_Pipeline(args):
         """Apply centering"""
         centeredFiles = center(groomDir + "centered/segmentations", isoresampledFiles)
 
-        """Apply padding"""
-        paddedFiles = applyPadding(groomDir + "padded/segmentations", centeredFiles, 10)
-
         """Apply center of mass alignment"""
-        comFiles = applyCOMAlignment(groomDir + "com_aligned/segmentations", paddedFiles, None)
+        comFiles = applyCOMAlignment(groomDir + "com_aligned/segmentations", centeredFiles, None)
 
         """ Apply rigid alignment """
         ref = FindReferenceImage(comFiles)

--- a/Examples/Python/ellipsoid.py
+++ b/Examples/Python/ellipsoid.py
@@ -28,7 +28,7 @@ def Run_Pipeline(args):
     if int(args.interactive) != 0:
         input("Press Enter to continue")
     # Get data
-    datasetName = "ellipsoid-v0"
+    datasetName = "ellipsoid-v2"
     outputDirectory = "Output/ellipsoid/"
     if not os.path.exists(outputDirectory):
         os.makedirs(outputDirectory)
@@ -84,13 +84,14 @@ def Run_Pipeline(args):
         paddedFiles = applyPadding(groomDir + "padded/segmentations", centeredFiles, 10)
 
         """Apply center of mass alignment"""
-        comFiles = applyCOMAlignment(groomDir + "com_aligned/segmentations", centeredFiles, None)
+        comFiles = applyCOMAlignment(groomDir + "com_aligned/segmentations", paddedFiles, None)
 
-        """ Apply resmapling"""
-        resampledFiles = applyResampling(groomDir + "resized/segmentations", comFiles[0], comFiles)
+        """ Apply rigid alignment """
+        ref = FindReferenceImage(comFiles)
+        alignedFiles = applyRigidAlignment(groomDir + "aligned/segmentations", ref, comFiles)
 
         """Compute largest bounding box and apply cropping"""
-        croppedFiles = applyCropping(groomDir + "cropped/segmentations", resampledFiles, groomDir + "resized/segmentations/*.resized.nrrd")
+        croppedFiles = applyCropping(groomDir + "cropped/segmentations", alignedFiles, groomDir + "aligned/segmentations/*.aligned.nrrd")
 
         """
         We convert the scans to distance transforms, this step is common for both the 

--- a/Examples/Python/ellipsoid.py
+++ b/Examples/Python/ellipsoid.py
@@ -28,7 +28,7 @@ def Run_Pipeline(args):
     if int(args.interactive) != 0:
         input("Press Enter to continue")
     # Get data
-    datasetName = "ellipsoid-v2"
+    datasetName = "ellipsoid-v1"
     outputDirectory = "Output/ellipsoid/"
     if not os.path.exists(outputDirectory):
         os.makedirs(outputDirectory)

--- a/Examples/Python/ellipsoid_cut.py
+++ b/Examples/Python/ellipsoid_cut.py
@@ -26,7 +26,7 @@ def Run_Pipeline(args):
     if int(args.interactive) != 0:
         input("Press Enter to continue")
     # Get data
-    datasetName = "ellipsoid_aligned-v0"
+    datasetName = "ellipsoid_aligned-v1"
     outputDirectory = "Output/ellipsoid_cut/"
     if not os.path.exists(outputDirectory):
         os.makedirs(outputDirectory)

--- a/Examples/Python/ellipsoid_cut.py
+++ b/Examples/Python/ellipsoid_cut.py
@@ -84,11 +84,12 @@ def Run_Pipeline(args):
         """Apply center of mass alignment"""
         comFiles = applyCOMAlignment(groomDir + "com_aligned/segmentations", paddedFiles, None)
 
-        """ Apply resampling"""
-        resampledFiles = applyResampling(groomDir + "resized/segmentations", comFiles[0], comFiles)
+        """ Apply rigid alignment """
+        ref = FindReferenceImage(comFiles)
+        alignedFiles = applyRigidAlignment(groomDir + "aligned/segmentations", ref, comFiles)
 
         """Compute largest bounding box and apply cropping"""
-        croppedFiles = applyCropping(groomDir + "cropped/segmentations", resampledFiles, groomDir + "resized/segmentations/*.resized.nrrd")
+        croppedFiles = applyCropping(groomDir + "cropped/segmentations", alignedFiles, groomDir + "aligned/segmentations/*.aligned.nrrd")
 
         """
         We convert the scans to distance transforms, this step is common for both the

--- a/Examples/Python/ellipsoid_cut.py
+++ b/Examples/Python/ellipsoid_cut.py
@@ -18,7 +18,7 @@ import CommonUtils
 
 def Run_Pipeline(args):
     """
-    The data (ellipsoid.zip) is dowloaded to /Data folder and extracted to 
+    The data (ellipsoid-aligned.zip) is dowloaded to /Data folder and extracted to 
     /Output/ellpsoid_cut
     """
 
@@ -26,7 +26,7 @@ def Run_Pipeline(args):
     if int(args.interactive) != 0:
         input("Press Enter to continue")
     # Get data
-    datasetName = "ellipsoid-v0"
+    datasetName = "ellipsoid_aligned-v0"
     outputDirectory = "Output/ellipsoid_cut/"
     if not os.path.exists(outputDirectory):
         os.makedirs(outputDirectory)
@@ -43,64 +43,11 @@ def Run_Pipeline(args):
     else:
         sample_idx = []
 
-    """
-    ## GROOM : Data Pre-processing
-    For the unprepped data the first few steps are
-    -- Isotropic resampling
-    -- Center
-    -- Padding
-    -- Center of Mass Alignment
-    -- Rigid Alignment
-    -- Largest Bounding Box and Cropping
-    For a detailed explanation of grooming steps see: /Documentation/Workflow/Groom.md
-    """
-    if args.skip_grooming:
-        print("Skipping grooming.")
-        dtDirecory = outputDirectory + datasetName + '/groomed/distance_transforms/'
-        indices = []
-        if args.tiny_test:
-            indices = [0,1,2]
-        elif args.use_subsample:
-            indices = sample_idx
-        dtFiles = CommonUtils.get_file_list(dtDirecory, ending=".nrrd", indices=indices)    
-    else:
-        print("\nStep 2. Groom - Data Pre-processing\n")
-        if int(args.interactive) != 0:
-            input("Press Enter to continue")
-
-        groomDir = outputDirectory + 'groomed/'
-        if not os.path.exists(groomDir):
-            os.makedirs(groomDir)
-            
-        """Apply isotropic resampling"""
-        resampledFiles = applyIsotropicResampling(groomDir + "resampled/segmentations", fileList)
-
-        """Apply centering"""
-        centeredFiles = center(groomDir + "centered/segmentations", resampledFiles)
-
-        """Apply padding"""
-        paddedFiles = applyPadding(groomDir + "padded/segmentations", centeredFiles, 10)
-
-        """Apply center of mass alignment"""
-        comFiles = applyCOMAlignment(groomDir + "com_aligned/segmentations", paddedFiles, None)
-
-        """ Apply rigid alignment """
-        ref = FindReferenceImage(comFiles)
-        alignedFiles = applyRigidAlignment(groomDir + "aligned/segmentations", ref, comFiles)
-
-        """Compute largest bounding box and apply cropping"""
-        croppedFiles = applyCropping(groomDir + "cropped/segmentations", alignedFiles, groomDir + "aligned/segmentations/*.aligned.nrrd")
-
-        """
-        We convert the scans to distance transforms, this step is common for both the
-        prepped as well as unprepped data, just provide correct filenames.
-        """
-
-        print("\nStep 3. Groom - Convert to distance transforms\n")
-        if int(args.interactive) != 0:
-            input("Press Enter to continue")
-
-        dtFiles = applyDistanceTransforms(groomDir, croppedFiles)
+    print("\nStep 2. Get distance transforms\n")
+    groomDir = outputDirectory + 'groomed/'
+    if not os.path.exists(groomDir):
+        os.makedirs(groomDir)
+    dtFiles = applyDistanceTransforms(groomDir, fileList)
 
     """
     ## OPTIMIZE : Particle Based Optimization

--- a/Examples/Python/femur.py
+++ b/Examples/Python/femur.py
@@ -179,18 +179,18 @@ def Run_Pipeline(args):
             medianFile = FindReferenceImage(centerFiles_segmentations)
             
             """
-            Apply resampling
+            Rigid alignment
             """
-            resized_segmentations, resized_images = applyResampling(groomDir + "resized", medianFile, centerFiles_segmentations, centerFiles_images)
+            aligned_segmentations, aligned_images = applyRigidAlignment(groomDir + "aligned", medianFile, centerFiles_segmentations, centerFiles_images)
 
             # If user chose option 2, define cutting plane on median sample
             if choice == 2:
-                input_file = medianFile.replace("centered", "resized").replace(".nrrd", ".resized.nrrd")
+                input_file = medianFile.replace("centered", "aligned").replace(".nrrd", ".aligned.nrrd")
                 cutting_plane_points = SelectCuttingPlane(input_file)
 
             elif choice == 1:
-                postfix = "_femur.isores.pad.com.center.resized.nrrd"
-                path = "resized/segmentations/"
+                postfix = "_femur.isores.pad.com.center.aligned.nrrd"
+                path = "aligned/segmentations/"
                 input_file = groomDir + path + cp_prefix + postfix
                 cutting_plane_points = SelectCuttingPlane(input_file)
 
@@ -206,11 +206,11 @@ def Run_Pipeline(args):
             """
             Clip Binary Volumes - We have femurs of different shaft length so we will clip them all using the defined cutting plane.
             """
-            clippedFiles_segmentations = ClipBinaryVolumes(groomDir + 'clipped_segmentations', resized_segmentations, cutting_plane_points.flatten())
+            clippedFiles_segmentations = ClipBinaryVolumes(groomDir + 'clipped_segmentations', aligned_segmentations, cutting_plane_points.flatten())
 
             """Compute largest bounding box and apply cropping"""
             croppedFiles_segmentations = applyCropping(groomDir + "cropped/segmentations", clippedFiles_segmentations, groomDir + "clipped_segmentations/*.nrrd")
-            croppedFiles_images = applyCropping(groomDir + "cropped/images", resized_images, groomDir + "clipped_segmentations/*.nrrd")
+            croppedFiles_images = applyCropping(groomDir + "cropped/images", aligned_images, groomDir + "clipped_segmentations/*.nrrd")
 
         # BEGIN GROOMING WITHOUT IMAGES
         else:
@@ -267,18 +267,18 @@ def Run_Pipeline(args):
             medianFile = FindReferenceImage(centerFiles_segmentations)
             
             """
-            Apply resampling
+            Apply rigid alignment
             """
-            resized_segmentations = applyResampling(groomDir + "resized", medianFile, centerFiles_segmentations)
+            aligned_segmentations = applyRigidAlignment(groomDir + "aligned", medianFile, centerFiles_segmentations)
 
             # If user chose option 2, define cutting plane on median sample
             if choice == 2:
-                input_file = medianFile.replace("centered/segmentations", "resized").replace(".nrrd", ".resized.nrrd")
+                input_file = medianFile.replace("centered/segmentations", "aligned").replace(".nrrd", ".aligned.nrrd")
                 cutting_plane_points = SelectCuttingPlane(input_file)
 
             elif choice == 1:
-                postfix = "_femur.isores.pad.com.center.resized.nrrd"
-                path = "resized/"
+                postfix = "_femur.isores.pad.com.center.aligned.nrrd"
+                path = "aligned/"
                 input_file = groomDir + path + cp_prefix + postfix
                 cutting_plane_points = SelectCuttingPlane(input_file)
 
@@ -294,7 +294,7 @@ def Run_Pipeline(args):
             """
             Clip Binary Volumes - We have femurs of different shaft length so we will clip them all using the defined cutting plane.
             """
-            clippedFiles_segmentations = ClipBinaryVolumes(groomDir + 'clipped_segmentations', resized_segmentations, cutting_plane_points.flatten())
+            clippedFiles_segmentations = ClipBinaryVolumes(groomDir + 'clipped_segmentations', aligned_segmentations, cutting_plane_points.flatten())
 
             """Compute largest bounding box and apply cropping"""
             croppedFiles_segmentations = applyCropping(groomDir + "cropped/segmentations", clippedFiles_segmentations, groomDir + "clipped_segmentations/*.nrrd")

--- a/Examples/Python/femur_cut.py
+++ b/Examples/Python/femur_cut.py
@@ -185,16 +185,16 @@ def Run_Pipeline(args):
             This function can handle both cases (processing only segmentation data or raw and segmentation data at the same time).
             This function uses the same transfrmation matrix for alignment of raw and segmentation files.
             """
-            [resampledFiles_segmentations, resampledFiles_images] = applyResampling(parentDir + "resized", medianFile,centerFiles_segmentations, centerFiles_images)
+            [alignedFiles_segmentations, alignedFiles_images] = applyRigidAlignment(parentDir + "aligned", medianFile,centerFiles_segmentations, centerFiles_images)
 
             # If user chose option 2, define cutting plane on median sample
             if choice == 2:
-                input_file = medianFile.replace("centered", "resized/segmentations").replace(".nrrd", ".resized.DT.nrrd")
+                input_file = medianFile.replace("centered", "aligned/segmentations").replace(".nrrd", ".aligned.DT.nrrd")
                 cutting_plane_points = SelectCuttingPlane(input_file)
 
             elif choice == 1:
-                postfix = "_femur.isores.pad.com.center.resized.DT.nrrd"
-                path = "resized/segmentations/"
+                postfix = "_femur.isores.pad.com.center.aligned.DT.nrrd"
+                path = "aligned/segmentations/"
                 input_file = parentDir + path + cp_prefix + postfix
                 cutting_plane_points = SelectCuttingPlane(input_file)
 
@@ -210,8 +210,8 @@ def Run_Pipeline(args):
             pickle.dump( [cutting_plane_points], open( outputDirectory + "groomed/groomed_pickle.p", "wb" ) )
 
             # Compute largest bounding box and apply cropping
-            croppedFiles_segmentations = applyCropping(parentDir + "cropped/segmentations", resampledFiles_segmentations, parentDir + "resized/*.resized.nrrd")
-            croppedFiles_images = applyCropping(parentDir + "cropped/images", resampledFiles_images, parentDir + "resized/*.resized.nrrd")
+            croppedFiles_segmentations = applyCropping(parentDir + "cropped/segmentations", alignedFiles_segmentations, parentDir + "aligned/*.aligned.nrrd")
+            croppedFiles_images = applyCropping(parentDir + "cropped/images", alignedFiles_images, parentDir + "aligned/*.aligned.nrrd")
 
 
         # BEGIN GROOMING WITHOUT IMAGES
@@ -274,16 +274,16 @@ def Run_Pipeline(args):
             This function can handle both cases (processing only segmentation data or raw and segmentation data at the same time).
             This function uses the same transfrmation matrix for alignment of raw and segmentation files.
             """
-            resampledFiles_segmentations = applyResampling(parentDir + "resized", medianFile,centerFiles_segmentations, None)
+            alignedFiles_segmentations = applyRigidAlignment(parentDir + "aligned", medianFile,centerFiles_segmentations, None)
 
             # If user chose option 2, define cutting plane on median sample
             if choice == 2:
-                input_file = medianFile.replace("centered/segmentations", "resized").replace(".nrrd", ".resized.DT.nrrd")
+                input_file = medianFile.replace("centered/segmentations", "aligned").replace(".nrrd", ".aligned.DT.nrrd")
                 cutting_plane_points = SelectCuttingPlane(input_file)
 
             elif choice == 1:
-                postfix = "_femur.isores.pad.com.center.resized.DT.nrrd"
-                path = "resized/"
+                postfix = "_femur.isores.pad.com.center.aligned.DT.nrrd"
+                path = "aligned/"
                 input_file = parentDir + path + cp_prefix + postfix
                 cutting_plane_points = SelectCuttingPlane(input_file)
 
@@ -299,7 +299,7 @@ def Run_Pipeline(args):
             pickle.dump( [cutting_plane_points], open( outputDirectory + "groomed/groomed_pickle.p", "wb" ) )
 
             # Compute largest bounding box and apply cropping
-            croppedFiles_segmentations = applyCropping(parentDir + "cropped/segmentations", resampledFiles_segmentations, parentDir + "resized/*.resized.nrrd")
+            croppedFiles_segmentations = applyCropping(parentDir + "cropped/segmentations", alignedFiles_segmentations, parentDir + "aligned/*.aligned.nrrd")
 
 
         print("\nStep 3. Groom - Convert to distance transforms\n")

--- a/Examples/Python/left_atrium.py
+++ b/Examples/Python/left_atrium.py
@@ -109,10 +109,10 @@ def Run_Pipeline(args):
             [comFiles_segmentations, comFiles_images] = applyCOMAlignment(groomDir + "com_aligned", paddedFiles_segmentations, paddedFiles_images, processRaw=True)
 
             """
-            Resample all images to be the same size and spacing as reference
+            Rigidly align to a reference
             """
             medianFile = FindReferenceImage(comFiles_segmentations)
-            [resampled_segmentations, resampled_images] = applyResampling(groomDir + "resized", medianFile, comFiles_segmentations, comFiles_images)
+            [aligned_segmentations, aligned_images] = applyRigidAlignment(groomDir + "aligned", medianFile, comFiles_segmentations, comFiles_images)
             
             """
             Compute largest bounding box and apply cropping
@@ -120,8 +120,8 @@ def Run_Pipeline(args):
             processRaw = False, applies the center of mass alignment only on segemnattion data.
             The function uses the same bounding box to crop the raw and segemnattion data.
             """
-            croppedFiles_segmentations = applyCropping(groomDir + "cropped/segmentations", resampled_segmentations, groomDir + "resized/segmentations/*.resized.nrrd")
-            croppedFiles_images = applyCropping(groomDir + "cropped/images", resampled_images, groomDir + "resized/images/*.resized.nrrd")
+            croppedFiles_segmentations = applyCropping(groomDir + "cropped/segmentations", aligned_segmentations, groomDir + "aligned/segmentations/*.aligned.nrrd")
+            croppedFiles_images = applyCropping(groomDir + "cropped/images", aligned_images, groomDir + "aligned/images/*.aligned.nrrd")
 
             print("\nStep 3. Groom - Convert to distance transforms\n")
             if args.interactive:
@@ -155,15 +155,15 @@ def Run_Pipeline(args):
             comFiles = applyCOMAlignment(groomDir + "com_aligned", paddedFiles, None)
 
             """
-            Resample all images to be the same size and spacing as reference
+            Rigidly alignment to a reference
             """
             medianFile = FindReferenceImage(comFiles)
-            resampledFiles = applyResampling(groomDir + "resized", medianFile, comFiles)
+            alignedFiles = applyRigidAlignment(groomDir + "aligned", medianFile, comFiles)
             
             """
             Compute largest bounding box and apply cropping
             """
-            croppedFiles = applyCropping(groomDir + "cropped", resampledFiles, groomDir + "resized/*.resized.nrrd")
+            croppedFiles = applyCropping(groomDir + "cropped", alignedFiles, groomDir + "aligned/*.aligned.nrrd")
 
             print("\nStep 3. Groom - Convert to distance transforms\n")
             if args.interactive:


### PR DESCRIPTION
This PR adds rigid alignment to the grooming pipeline in segmentation based use cases - issue #826 

This PR also changes the ellipsoid case to use ellipsoid-v2 data which is not already groomed to provide a better demonstration of grooming. It changes ellipsoid_cut to use ellipsoid-aligned-v0 which is already aligned. The grooming steps except creating distance transforms are removed so that the use case highlights the cutting plane and does not repeat the ellipsoid use case. 

To test run the following use cases:
- ellispoid
- ellipsoid_cut
- femur (with and without grooming images)
- femur_cut (with and without grooming images)
- left_atrium (with and without grooming images)