### PR TITLE
Do not consider faces that result in NaN barycentric coordinates

### DIFF
--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.cpp
@@ -337,7 +337,7 @@ inline bool TriMeshWrapper::IsBarycentricCoordinateValid(const trimesh::vec3& ba
 
 bool TriMeshWrapper::IsBarycentricCoordinateNotNaN(const vec3& b)
 {
-  if (isnan(b[0]) || isnan(b[1]) || isnan(b[2])) {
+  if (std::isnan(b[0]) || std::isnan(b[1]) || std::isnan(b[2])) {
     return false;
   }
   return true;

--- a/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
+++ b/Libs/Optimize/ParticleSystem/TriMeshWrapper.h
@@ -76,6 +76,8 @@ private:
 
   static inline bool IsBarycentricCoordinateValid(const trimesh::vec3& b);
 
+  static inline bool IsBarycentricCoordinateNotNaN(const trimesh::vec3& b);
+
   // IGL Helper functions
   void GetIGLMesh(Eigen::MatrixXd& V, Eigen::MatrixXi& F);
 


### PR DESCRIPTION
This is a temporary fix until we either add a QC check (e.g. something
like vtkCleanPolyData) or make other changes.

The bug that this fixes is where the mesh contains degenerate faces
(such as two vertices of a triangle that land on the same location).
The current computation returns barycentric coordinates containing
NaNs which end up propagating to many other variables resulting in
either infinite loops or crashes.

See #936 - TriMeshWrapper::ComputeBarycentricCoordinates 
See #926 - Replace trimesh2 with VTK or other mesh library
See #910 - ShapeWorks Optimize needs some input verification