### PR TITLE
Invert normals test

### DIFF
--- a/Applications/shapeworks/Commands.cpp
+++ b/Applications/shapeworks/Commands.cpp
@@ -1737,7 +1737,7 @@ bool Decimate::execute(const optparse::Values &options, SharedCommandData &share
 void InvertNormals::buildParser()
 {
   const std::string prog = "invert-normals";
-  const std::string desc = "flips the normal";
+  const std::string desc = "flips the normals";
   parser.prog(prog).description(desc);
 
   Command::buildParser();

--- a/Applications/shapeworks/Commands.cpp
+++ b/Applications/shapeworks/Commands.cpp
@@ -1732,18 +1732,18 @@ bool Decimate::execute(const optparse::Values &options, SharedCommandData &share
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-// InvertNormal
+// InvertNormals
 ///////////////////////////////////////////////////////////////////////////////
-void InvertNormal::buildParser()
+void InvertNormals::buildParser()
 {
-  const std::string prog = "invert-normal";
+  const std::string prog = "invert-normals";
   const std::string desc = "flips the normal";
   parser.prog(prog).description(desc);
 
   Command::buildParser();
 }
 
-bool InvertNormal::execute(const optparse::Values &options, SharedCommandData &sharedData)
+bool InvertNormals::execute(const optparse::Values &options, SharedCommandData &sharedData)
 {
   if (!sharedData.validMesh())
   {
@@ -1751,7 +1751,7 @@ bool InvertNormal::execute(const optparse::Values &options, SharedCommandData &s
     return false;
   }
 
-  sharedData.mesh->invertNormal();
+  sharedData.mesh->invertNormals();
   return sharedData.validMesh();
 }
 

--- a/Applications/shapeworks/Commands.h
+++ b/Applications/shapeworks/Commands.h
@@ -56,7 +56,7 @@ COMMAND_DECLARE(MeshInfo, MeshCommand);
 COMMAND_DECLARE(Coverage, MeshCommand);
 COMMAND_DECLARE(Smooth, MeshCommand);
 COMMAND_DECLARE(Decimate, MeshCommand);
-COMMAND_DECLARE(InvertNormal, MeshCommand);
+COMMAND_DECLARE(InvertNormals, MeshCommand);
 COMMAND_DECLARE(ReflectMesh, MeshCommand);
 COMMAND_DECLARE(Transform, MeshCommand);
 COMMAND_DECLARE(FillHoles, MeshCommand);

--- a/Applications/shapeworks/shapeworks.cpp
+++ b/Applications/shapeworks/shapeworks.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
   shapeworks.addCommand(Coverage::getCommand());
   shapeworks.addCommand(Smooth::getCommand());
   shapeworks.addCommand(Decimate::getCommand());
-  shapeworks.addCommand(InvertNormal::getCommand());
+  shapeworks.addCommand(InvertNormals::getCommand());
   shapeworks.addCommand(ReflectMesh::getCommand());
   shapeworks.addCommand(Transform::getCommand());
   shapeworks.addCommand(FillHoles::getCommand());

--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -201,7 +201,7 @@ Mesh &Mesh::decimate(double reduction, double angle, bool preservetopology)
   return *this;
 }
 
-Mesh &Mesh::invertNormal()
+Mesh &Mesh::invertNormals()
 {
   vtkSmartPointer<vtkReverseSense> reverseSense = vtkSmartPointer<vtkReverseSense>::New();
 
@@ -224,7 +224,7 @@ Mesh &Mesh::reflect(const Axis &axis, const Vector3 &origin)
   transform->Scale(scale[0], scale[1], scale[2]);
   transform->Translate(origin[0], origin[1], origin[2]);
 
-  return invertNormal().applyTransform(transform);
+  return invertNormals().applyTransform(transform);
 }
 
 swTransform Mesh::createTransform(const Mesh &target, Mesh::TransformType type, Mesh::AlignmentType align, unsigned iterations)

--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -676,6 +676,58 @@ bool Mesh::compareAllPoints(const Mesh &other_mesh) const
   return true;
 }
 
+bool Mesh::compareAllFaces(const Mesh &other_mesh) const
+{
+  if (!this->mesh || !other_mesh.mesh)
+    throw std::invalid_argument("invalid meshes");
+
+  if (this->mesh->GetNumberOfCells() != other_mesh.mesh->GetNumberOfCells())
+  {
+    std::cerr << "meshes differ in number of faces";
+    return false;
+  }
+
+  // helper function to print out the cell indices
+  auto printCells = [](vtkCell* cell1, vtkCell* cell2){
+    printf("[ ");
+    for(int i = 0; i < cell1->GetNumberOfPoints(); i++) {
+      printf("%lld ", cell1->GetPointId(i));
+    }
+    printf("], [ ");
+    for(int i = 0; i < cell2->GetNumberOfPoints(); i++) {
+      printf("%lld ", cell2->GetPointId(i));
+    }
+    printf("]");
+  };
+
+  for (int i = 0; i < this->mesh->GetNumberOfCells(); i++)
+  {
+    vtkCell* cell1 = this->mesh->GetCell(i);
+    vtkCell* cell2 = other_mesh.mesh->GetCell(i);
+
+    if(cell1->GetNumberOfPoints() != cell2->GetNumberOfPoints())
+    {
+      printf("%ith face not equal (", i);
+      printCells(cell1, cell2);
+      printf(")\n");
+      return false;
+    }
+
+    for(int pi=0; pi<cell1->GetNumberOfPoints(); pi++)
+    {
+      if(cell1->GetPointId(pi) != cell2->GetPointId(pi))
+      {
+        printf("%ith face not equal (", i);
+        printCells(cell1, cell2);
+        printf(")\n");
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 bool Mesh::compareAllFields(const Mesh &other_mesh) const
 {
   if (!this->mesh || !other_mesh.mesh)
@@ -763,6 +815,7 @@ bool Mesh::compare(const Mesh& other) const
   if (numPoints() != other.numPoints())                    { std::cerr << "num pts differ\n"; return false; }
   if (numFaces() != other.numFaces())                      { std::cerr << "num faces differ\n"; return false; }
   if (!compareAllPoints(other))                            { std::cerr << "points differ\n"; return false; }
+  if (!compareAllFaces(other))                             { std::cerr << "faces differ\n"; return false; }
   if (!compareAllFields(other))                            { std::cerr << "fields differ\n"; return false; }
 
   return true;

--- a/Libs/Mesh/Mesh.h
+++ b/Libs/Mesh/Mesh.h
@@ -141,6 +141,9 @@ public:
   /// compare if values of the points in two (corresponding) meshes are (eps)equal
   bool compareAllPoints(const Mesh& other_mesh) const;
 
+  /// compare if face indices in two (corresponding) meshes are equal
+  bool compareAllFaces(const Mesh& other_mesh) const;
+
   /// compare if all fields in two meshes are (eps)equal
   bool compareAllFields(const Mesh& other_mesh) const;
 

--- a/Libs/Mesh/Mesh.h
+++ b/Libs/Mesh/Mesh.h
@@ -42,7 +42,7 @@ public:
   Mesh& decimate(double reduction = 0.0, double angle = 0.0, bool preservetopology = false);
 
   /// handle flipping normals
-  Mesh& invertNormal();
+  Mesh& invertNormals();
 
   /// reflect meshes with respect to a specified center and specific axis
   Mesh& reflect(const Axis &axis, const Vector3 &origin = makeVector({ 0.0, 0.0, 0.0 }));

--- a/Testing/MeshTests/MeshTests.cpp
+++ b/Testing/MeshTests/MeshTests.cpp
@@ -56,11 +56,14 @@ TEST(MeshTests, decimateTest2)
   ASSERT_TRUE(femur == ground_truth);
 }
 
-// https://github.com/SCIInstitute/ShapeWorks/issues/937
-// TEST(MeshTests, invertNormalTest1)
-// {
-//   // TODO
-// }
+TEST(MeshTests, invertNormalsTest)
+{
+  Mesh femur(std::string(TEST_DATA_DIR) + "/femur.vtk");
+  femur.invertNormals();
+  Mesh ground_truth(std::string(TEST_DATA_DIR) + "/invertnormals.vtk");
+
+  ASSERT_TRUE(femur == ground_truth);
+}
 
 TEST(MeshTests, reflectTest1)
 {

--- a/Testing/data/invertnormals.vtk
+++ b/Testing/data/invertnormals.vtk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d73a481f3ac1f6d52270bc7c144d3a9aaf9a975317b9b428796926ea073105d
+size 416267


### PR DESCRIPTION
This PR adds a test for the invert-normals command.

Additionally, this adds a check over the face indices for Mesh::operator== 

Closes #937 