### PR TITLE
Studio fixes

### DIFF
--- a/Studio/src/Application/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Application/Analysis/AnalysisTool.cpp
@@ -291,23 +291,20 @@ void AnalysisTool::handle_analysis_options()
 {
 
   if (this->ui_->tabWidget->currentWidget() == this->ui_->samples_tab) {
+    this->ui_->pcaAnimateCheckBox->setChecked(false);
+    this->ui_->pcaAnimateCheckBox->setEnabled(false);
+    this->ui_->pcaModeSpinBox->setEnabled(false);
+    this->pca_animate_timer_.stop();
+    this->ui_->pcaSlider->setEnabled(false);
     if (this->ui_->singleSamplesRadio->isChecked()) {
       //one sample mode
       this->ui_->sampleSpinBox->setEnabled(true);
       this->ui_->medianButton->setEnabled(true);
-      this->ui_->pcaSlider->setEnabled(false);
-      this->ui_->pcaAnimateCheckBox->setEnabled(false);
-      this->ui_->pcaModeSpinBox->setEnabled(false);
-      this->ui_->pcaAnimateCheckBox->setChecked(false);
     }
     else {
       //all samples mode
       this->ui_->sampleSpinBox->setEnabled(false);
       this->ui_->medianButton->setEnabled(false);
-      this->ui_->pcaSlider->setEnabled(false);
-      this->ui_->pcaAnimateCheckBox->setEnabled(false);
-      this->ui_->pcaModeSpinBox->setEnabled(false);
-      this->ui_->pcaAnimateCheckBox->setChecked(false);
     }
   }
   else if (this->ui_->tabWidget->currentWidget() == this->ui_->mean_tab) {
@@ -318,6 +315,7 @@ void AnalysisTool::handle_analysis_options()
     this->ui_->pcaAnimateCheckBox->setEnabled(false);
     this->ui_->pcaModeSpinBox->setEnabled(false);
     this->ui_->pcaAnimateCheckBox->setChecked(false);
+    this->pca_animate_timer_.stop();
   }
   else if (this->ui_->tabWidget->currentWidget() == this->ui_->pca_tab) {
     //pca mode
@@ -334,6 +332,7 @@ void AnalysisTool::handle_analysis_options()
     this->ui_->pcaSlider->setEnabled(false);
     this->ui_->pcaAnimateCheckBox->setEnabled(false);
     this->ui_->pcaModeSpinBox->setEnabled(false);
+    this->pca_animate_timer_.stop();
   }
 
   emit update_view();
@@ -609,7 +608,6 @@ void AnalysisTool::on_pcaModeSpinBox_valueChanged(int i)
 void AnalysisTool::handle_pca_animate_state_changed()
 {
   if (this->pcaAnimate()) {
-    //this->setPregenSteps();
     this->pca_animate_timer_.setInterval(10);
     this->pca_animate_timer_.start();
   }
@@ -621,6 +619,10 @@ void AnalysisTool::handle_pca_animate_state_changed()
 //---------------------------------------------------------------------------
 void AnalysisTool::handle_pca_timer()
 {
+  if (!this->pcaAnimate()) {
+    return;
+  }
+
   int value = this->ui_->pcaSlider->value();
   if (this->pca_animate_direction_) {
     value += this->ui_->pcaSlider->singleStep();
@@ -631,7 +633,6 @@ void AnalysisTool::handle_pca_timer()
 
   if (value >= this->ui_->pcaSlider->maximum() || value <= this->ui_->pcaSlider->minimum()) {
     this->pca_animate_direction_ = !this->pca_animate_direction_;
-    //this->setPregenSteps();
   }
 
   this->ui_->pcaSlider->setValue(value);
@@ -641,13 +642,10 @@ void AnalysisTool::handle_pca_timer()
 void AnalysisTool::handle_group_animate_state_changed()
 {
   if (this->ui_->group_animate_checkbox->isChecked()) {
-    //this->setPregenSteps();
-    std::cerr << "group animating\n";
     this->group_animate_timer_.setInterval(10);
     this->group_animate_timer_.start();
   }
   else {
-    std::cerr << "group NOT animating\n";
     this->group_animate_timer_.stop();
   }
 }

--- a/Studio/src/Application/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Application/Analysis/AnalysisTool.cpp
@@ -1060,4 +1060,20 @@ void AnalysisTool::reconstruction_method_changed()
   }
 }
 
+//---------------------------------------------------------------------------
+void AnalysisTool::set_active(bool active)
+{
+  if (!active) {
+    this->ui_->pcaAnimateCheckBox->setChecked(false);
+    this->pca_animate_timer_.stop();
+  }
+  this->active_ = active;
+}
+
+//---------------------------------------------------------------------------
+bool AnalysisTool::get_active()
+{
+  return this->active_;
+}
+
 }

--- a/Studio/src/Application/Analysis/AnalysisTool.h
+++ b/Studio/src/Application/Analysis/AnalysisTool.h
@@ -37,6 +37,12 @@ public:
   /// set the pointer to the application
   void set_app(ShapeWorksStudioApp* app);
 
+  //! Set if this tool is active
+  void set_active(bool active);
+
+  //! Return if this tool is active
+  bool get_active();
+
   bool get_group_difference_mode();
 
   std::vector<Shape::Point> get_group_difference_vectors();
@@ -145,6 +151,8 @@ signals:
   void reconstruction_complete();
 
 private:
+
+  bool active_ = false;
 
   void pca_labels_changed(QString value, QString eigen, QString lambda);
   void compute_mode_shape();

--- a/Studio/src/Application/Data/Shape.cpp
+++ b/Studio/src/Application/Data/Shape.cpp
@@ -73,7 +73,7 @@ void Shape::set_subject(std::shared_ptr<Subject> subject)
 
   if (this->subject_->get_segmentation_filenames().size() > 0) {
     std::string filename = this->subject_->get_segmentation_filenames()[0];
-    this->corner_annotations_[0] = QString::fromStdString(filename);
+    this->corner_annotations_[0] = QFileInfo(QString::fromStdString(filename)).fileName();
   }
 }
 
@@ -87,7 +87,7 @@ std::shared_ptr<Subject> Shape::get_subject()
 void Shape::import_original_image(std::string filename, float iso_value)
 {
   this->subject_->set_segmentation_filenames(std::vector<std::string>{filename});
-  this->corner_annotations_[0] = QString::fromStdString(filename);
+  this->corner_annotations_[0] = QFileInfo(QString::fromStdString(filename)).fileName();
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/src/Application/Optimize/OptimizeTool.cpp
+++ b/Studio/src/Application/Optimize/OptimizeTool.cpp
@@ -111,6 +111,8 @@ void OptimizeTool::on_run_optimize_button_clicked()
     this->optimization_is_running_ = false;
     this->enable_actions();
     emit progress(100);
+    emit message("Optimize Aborted");
+    emit optimize_complete();
     return;
   }
   this->optimization_is_running_ = true;

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
@@ -672,7 +672,9 @@ void ShapeWorksStudioApp::handle_slider_update()
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::handle_pca_update()
 {
-  this->compute_mode_shape();
+  if (this->analysis_tool_->get_analysis_mode() == AnalysisTool::MODE_PCA_C) {
+    this->compute_mode_shape();
+  }
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Application/Visualization/ShapeWorksStudioApp.cpp
@@ -672,7 +672,8 @@ void ShapeWorksStudioApp::handle_slider_update()
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::handle_pca_update()
 {
-  if (this->analysis_tool_->get_analysis_mode() == AnalysisTool::MODE_PCA_C) {
+  if (this->analysis_tool_->get_active() &&
+      this->analysis_tool_->get_analysis_mode() == AnalysisTool::MODE_PCA_C) {
     this->compute_mode_shape();
   }
 }
@@ -791,6 +792,8 @@ void ShapeWorksStudioApp::update_tool_mode()
 {
   std::string tool_state =
     this->session_->parameters().get("tool_state", Session::DATA_C);
+
+  this->analysis_tool_->set_active(tool_state == Session::ANALYSIS_C);
 
   if (tool_state == Session::ANALYSIS_C) {
     this->ui_->stacked_widget->setCurrentWidget(this->analysis_tool_.data());


### PR DESCRIPTION
Resolves the following issues:

#961 - Studio: Sample display bug
#960 - Studio: Only display basename of file name 
#959 - Studio: When optimization is aborted, the file menu does not re-enable
#963 - Studio: Bug when switching out of analysis while PCA animation is running