### PR TITLE
Relax optimize input constraints in Studio

### DIFF
--- a/Studio/src/Application/Optimize/OptimizeTool.cpp
+++ b/Studio/src/Application/Optimize/OptimizeTool.cpp
@@ -4,6 +4,7 @@
 #include <QThread>
 #include <QMessageBox>
 #include <QTemporaryDir>
+#include <QIntValidator>
 
 #include <Optimize/OptimizeTool.h>
 #include <Libs/Optimize/OptimizeParameters.h>

--- a/Studio/src/Application/Optimize/OptimizeTool.cpp
+++ b/Studio/src/Application/Optimize/OptimizeTool.cpp
@@ -20,7 +20,7 @@
 
 #include <ui_OptimizeTool.h>
 
-namespace shapeworks {
+using namespace shapeworks;
 
 //---------------------------------------------------------------------------
 OptimizeTool::OptimizeTool()
@@ -46,11 +46,45 @@ OptimizeTool::OptimizeTool()
   this->ui_->use_normals->setToolTip("Use surface normals as part of optimization");
   this->ui_->normals_strength->setToolTip("Strength of surface normals relative to position");
   this->ui_->procrustes->setToolTip("Use procrustes registration during optimization");
-  this->ui_->procrustes_interval->setToolTip("How often to run procrustes during optimization (0 = disabled)");
+  this->ui_->procrustes_interval->setToolTip(
+    "How often to run procrustes during optimization (0 = disabled)");
   this->ui_->procrustes_scaling->setToolTip("Use procrustes scaling");
   this->ui_->multiscale->setToolTip("Use multiscale optimization mode");
   this->ui_->multiscale_particles->setToolTip(
     "Start multiscale optimization after this many particles");
+
+  QIntValidator* above_zero = new QIntValidator(1, std::numeric_limits<int>::max(), this);
+  QIntValidator* zero_and_up = new QIntValidator(0, std::numeric_limits<int>::max(), this);
+
+  QDoubleValidator* double_validator = new QDoubleValidator(0, std::numeric_limits<double>::max(),
+                                                            1000, this);
+
+  ui_->number_of_particles->setValidator(above_zero);
+  ui_->initial_relative_weighting->setValidator(double_validator);
+  ui_->relative_weighting->setValidator(double_validator);
+  ui_->starting_regularization->setValidator(double_validator);
+  ui_->ending_regularization->setValidator(double_validator);
+  ui_->iterations_per_split->setValidator(above_zero);
+  ui_->optimization_iterations->setValidator(zero_and_up);
+  ui_->normals_strength->setValidator(double_validator);
+  ui_->procrustes_interval->setValidator(above_zero);
+  ui_->multiscale_particles->setValidator(above_zero);
+
+  line_edits_.push_back(ui_->number_of_particles);
+  line_edits_.push_back(ui_->initial_relative_weighting);
+  line_edits_.push_back(ui_->relative_weighting);
+  line_edits_.push_back(ui_->starting_regularization);
+  line_edits_.push_back(ui_->ending_regularization);
+  line_edits_.push_back(ui_->iterations_per_split);
+  line_edits_.push_back(ui_->optimization_iterations);
+  line_edits_.push_back(ui_->normals_strength);
+  line_edits_.push_back(ui_->procrustes_interval);
+  line_edits_.push_back(ui_->multiscale_particles);
+
+  for (QLineEdit* line_edit : line_edits_) {
+    connect(line_edit, &QLineEdit::textChanged,
+            this, &OptimizeTool::update_run_button);
+  }
 }
 
 //---------------------------------------------------------------------------
@@ -61,7 +95,7 @@ OptimizeTool::~OptimizeTool()
 void OptimizeTool::handle_error(std::string msg)
 {
   emit error_message(msg);
-  this->ui_->run_optimize_button->setEnabled(true);
+  this->update_run_button();
 }
 
 //---------------------------------------------------------------------------
@@ -101,7 +135,7 @@ void OptimizeTool::handle_optimize_complete()
   emit progress(100);
   emit message("Optimize Complete");
   emit optimize_complete();
-  this->ui_->run_optimize_button->setEnabled(true);
+  this->update_run_button();
 }
 
 //---------------------------------------------------------------------------
@@ -185,23 +219,26 @@ void OptimizeTool::load_params()
 {
   auto params = OptimizeParameters(this->session_->get_project());
 
-  this->ui_->number_of_particles->setValue(params.get_number_of_particles()[0]);
-  this->ui_->initial_relative_weighting->setValue(params.get_initial_relative_weighting());
-  this->ui_->relative_weighting->setValue(params.get_relative_weighting());
-  this->ui_->starting_regularization->setValue(params.get_starting_regularization());
-  this->ui_->ending_regularization->setValue(params.get_ending_regularization());
-  this->ui_->iterations_per_split->setValue(params.get_iterations_per_split());
-  this->ui_->optimization_iterations->setValue(params.get_optimization_iterations());
+  this->ui_->number_of_particles->setText(QString::number(params.get_number_of_particles()[0]));
+  this->ui_->initial_relative_weighting->setText(
+    QString::number(params.get_initial_relative_weighting()));
+  this->ui_->relative_weighting->setText(QString::number(params.get_relative_weighting()));
+  this->ui_->starting_regularization->setText(
+    QString::number(params.get_starting_regularization()));
+  this->ui_->ending_regularization->setText(QString::number(params.get_ending_regularization()));
+  this->ui_->iterations_per_split->setText(QString::number(params.get_iterations_per_split()));
+  this->ui_->optimization_iterations->setText(
+    QString::number(params.get_optimization_iterations()));
 
   this->ui_->use_normals->setChecked(params.get_use_normals()[0]);
-  this->ui_->normals_strength->setValue(params.get_normals_strength());
+  this->ui_->normals_strength->setText(QString::number(params.get_normals_strength()));
 
   this->ui_->procrustes->setChecked(params.get_use_procrustes());
   this->ui_->procrustes_scaling->setChecked(params.get_use_procrustes_scaling());
-  this->ui_->procrustes_interval->setValue(params.get_procrustes_interval());
+  this->ui_->procrustes_interval->setText(QString::number(params.get_procrustes_interval()));
 
   this->ui_->multiscale->setChecked(params.get_use_multiscale());
-  this->ui_->multiscale_particles->setValue(params.get_multiscale_particles());
+  this->ui_->multiscale_particles->setText(QString::number(params.get_multiscale_particles()));
 
   this->update_ui_elements();
 
@@ -212,23 +249,23 @@ void OptimizeTool::store_params()
 {
   auto params = OptimizeParameters(this->session_->get_project());
 
-  params.set_number_of_particles({this->ui_->number_of_particles->value()});
-  params.set_initial_relative_weighting(this->ui_->initial_relative_weighting->value());
-  params.set_relative_weighting(this->ui_->relative_weighting->value());
-  params.set_starting_regularization(this->ui_->starting_regularization->value());
-  params.set_ending_regularization(this->ui_->ending_regularization->value());
-  params.set_iterations_per_split(this->ui_->iterations_per_split->value());
-  params.set_optimization_iterations(this->ui_->optimization_iterations->value());
+  params.set_number_of_particles({this->ui_->number_of_particles->text().toInt()});
+  params.set_initial_relative_weighting(this->ui_->initial_relative_weighting->text().toDouble());
+  params.set_relative_weighting(this->ui_->relative_weighting->text().toDouble());
+  params.set_starting_regularization(this->ui_->starting_regularization->text().toDouble());
+  params.set_ending_regularization(this->ui_->ending_regularization->text().toDouble());
+  params.set_iterations_per_split(this->ui_->iterations_per_split->text().toDouble());
+  params.set_optimization_iterations(this->ui_->optimization_iterations->text().toDouble());
 
   params.set_use_normals({this->ui_->use_normals->isChecked()});
-  params.set_normals_strength(this->ui_->normals_strength->value());
+  params.set_normals_strength(this->ui_->normals_strength->text().toDouble());
 
   params.set_use_procrustes(this->ui_->procrustes->isChecked());
   params.set_use_procrustes_scaling(this->ui_->procrustes_scaling->isChecked());
-  params.set_procrustes_interval(this->ui_->procrustes_interval->value());
+  params.set_procrustes_interval(this->ui_->procrustes_interval->text().toDouble());
 
   params.set_use_multiscale(this->ui_->multiscale->isChecked());
-  params.set_multiscale_particles(this->ui_->multiscale_particles->value());
+  params.set_multiscale_particles(this->ui_->multiscale_particles->text().toDouble());
 
   params.save_to_project();
 }
@@ -236,14 +273,7 @@ void OptimizeTool::store_params()
 //---------------------------------------------------------------------------
 void OptimizeTool::enable_actions()
 {
-  this->ui_->run_optimize_button->setEnabled(this->session_->get_groomed_present());
-
-  if (this->optimization_is_running_) {
-    this->ui_->run_optimize_button->setText("Abort Optimize");
-  }
-  else {
-    this->ui_->run_optimize_button->setText("Run Optimize");
-  }
+  this->update_run_button();
 }
 
 //---------------------------------------------------------------------------
@@ -302,4 +332,37 @@ void OptimizeTool::clear_particles()
   this->session_->update_points(lists, true);
   this->session_->update_points(lists, false);
 }
+
+//---------------------------------------------------------------------------
+bool OptimizeTool::validate_inputs()
+{
+  bool all_valid = true;
+  for (QLineEdit* line_edit : this->line_edits_) {
+    QString text = line_edit->text();
+    int pos;
+    QString ss;
+    if (QValidator::Acceptable != line_edit->validator()->validate(text, pos)) {
+      ss = "QLineEdit {background-color: rgb(255,204,203);}";
+      all_valid = false;
+    }
+    line_edit->setStyleSheet(ss);
+  }
+  return all_valid;
 }
+
+//---------------------------------------------------------------------------
+void OptimizeTool::update_run_button()
+{
+  bool inputs_valid = this->validate_inputs();
+
+  this->ui_->run_optimize_button->setEnabled(inputs_valid && this->session_->get_groomed_present());
+
+  if (this->optimization_is_running_) {
+    this->ui_->run_optimize_button->setText("Abort Optimize");
+  }
+  else {
+    this->ui_->run_optimize_button->setText("Run Optimize");
+  }
+
+}
+

--- a/Studio/src/Application/Optimize/OptimizeTool.cpp
+++ b/Studio/src/Application/Optimize/OptimizeTool.cpp
@@ -10,13 +10,9 @@
 
 #include <Visualization/ShapeWorksWorker.h>
 #include <Data/Session.h>
-#include <Data/StudioMesh.h>
 #include <Data/Shape.h>
-#include <Data/StudioLog.h>
 
 #include <Optimize/QOptimize.h>
-
-#include <vtkPLYWriter.h>
 
 #include <ui_OptimizeTool.h>
 

--- a/Studio/src/Application/Optimize/OptimizeTool.h
+++ b/Studio/src/Application/Optimize/OptimizeTool.h
@@ -10,10 +10,13 @@
 
 class Ui_OptimizeTool;
 
+class QLineEdit;
+
 namespace shapeworks {
 class QOptimize;
 class OptimizeParameters;
 class Session;
+
 
 class OptimizeTool : public QWidget {
 Q_OBJECT;
@@ -55,6 +58,8 @@ public Q_SLOTS:
 
   void update_ui_elements();
 
+  bool validate_inputs();
+
 signals:
   void optimize_start();
   void optimize_complete();
@@ -67,9 +72,13 @@ signals:
 
 private:
 
+  void update_run_button();
+
   void handle_load_progress(int count);
 
   void clear_particles();
+
+  std::vector<QLineEdit*> line_edits_;
 
   QList<QThread*> threads_;
   bool optimization_is_running_ = false;

--- a/Studio/src/Application/Optimize/OptimizeTool.ui
+++ b/Studio/src/Application/Optimize/OptimizeTool.ui
@@ -392,12 +392,18 @@ background: rgb(255, 255, 127)
         <property name="text">
          <string>128</string>
         </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
        </widget>
       </item>
       <item row="1" column="2">
        <widget class="QLineEdit" name="initial_relative_weighting">
         <property name="text">
          <string>0.05</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -406,12 +412,18 @@ background: rgb(255, 255, 127)
         <property name="text">
          <string>1.0</string>
         </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
        </widget>
       </item>
       <item row="3" column="2">
        <widget class="QLineEdit" name="starting_regularization">
         <property name="text">
          <string>10</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -420,12 +432,18 @@ background: rgb(255, 255, 127)
         <property name="text">
          <string>1.0</string>
         </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
        </widget>
       </item>
       <item row="5" column="2">
        <widget class="QLineEdit" name="iterations_per_split">
         <property name="text">
          <string>1000</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -434,12 +452,18 @@ background: rgb(255, 255, 127)
         <property name="text">
          <string>1000</string>
         </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
        </widget>
       </item>
       <item row="8" column="2">
        <widget class="QLineEdit" name="normals_strength">
         <property name="text">
          <string>10</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>
@@ -448,12 +472,18 @@ background: rgb(255, 255, 127)
         <property name="text">
          <string>32</string>
         </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
        </widget>
       </item>
       <item row="11" column="2">
        <widget class="QLineEdit" name="procrustes_interval">
         <property name="text">
          <string>10</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
        </widget>
       </item>

--- a/Studio/src/Application/Optimize/OptimizeTool.ui
+++ b/Studio/src/Application/Optimize/OptimizeTool.ui
@@ -59,62 +59,6 @@ background: rgb(255, 255, 127)
       <property name="bottomMargin">
        <number>1</number>
       </property>
-      <item row="3" column="2">
-       <widget class="QDoubleSpinBox" name="starting_regularization">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="decimals">
-         <number>2</number>
-        </property>
-        <property name="minimum">
-         <double>0.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>99999.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>10.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="11" column="2">
-       <widget class="QSpinBox" name="procrustes_interval">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="maximum">
-         <number>999999</number>
-        </property>
-        <property name="value">
-         <number>10</number>
-        </property>
-       </widget>
-      </item>
       <item row="8" column="0">
        <widget class="QLabel" name="label_21">
         <property name="text">
@@ -126,37 +70,6 @@ background: rgb(255, 255, 127)
        <widget class="QLabel" name="label_5">
         <property name="text">
          <string>Initial Relative Weighting</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QSpinBox" name="number_of_particles">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>999999</number>
-        </property>
-        <property name="value">
-         <number>128</number>
         </property>
        </widget>
       </item>
@@ -195,37 +108,6 @@ background: rgb(255, 255, 127)
         </property>
        </widget>
       </item>
-      <item row="6" column="2">
-       <widget class="QSpinBox" name="optimization_iterations">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>999999</number>
-        </property>
-        <property name="value">
-         <number>1000</number>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
@@ -237,37 +119,6 @@ background: rgb(255, 255, 127)
        <widget class="QLabel" name="label_13">
         <property name="text">
          <string>Multiscale Mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QDoubleSpinBox" name="initial_relative_weighting">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="maximum">
-         <double>99999.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.050000000000000</double>
         </property>
        </widget>
       </item>
@@ -346,37 +197,6 @@ background: rgb(255, 255, 127)
        <widget class="QLabel" name="label_20">
         <property name="text">
          <string>Normals</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QDoubleSpinBox" name="relative_weighting">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="maximum">
-         <double>99999.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -489,71 +309,6 @@ background: rgb(255, 255, 127)
         </property>
        </widget>
       </item>
-      <item row="5" column="2">
-       <widget class="QSpinBox" name="iterations_per_split">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>999999</number>
-        </property>
-        <property name="value">
-         <number>1000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="QDoubleSpinBox" name="ending_regularization">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="decimals">
-         <number>2</number>
-        </property>
-        <property name="minimum">
-         <double>0.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>99999.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>1.000000000000000</double>
-        </property>
-       </widget>
-      </item>
       <item row="4" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
@@ -619,28 +374,6 @@ background: rgb(255, 255, 127)
         </layout>
        </widget>
       </item>
-      <item row="13" column="2">
-       <widget class="QSpinBox" name="multiscale_particles">
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="maximum">
-         <number>999999</number>
-        </property>
-        <property name="value">
-         <number>32</number>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <spacer name="horizontalSpacer_10">
         <property name="orientation">
@@ -654,31 +387,73 @@ background: rgb(255, 255, 127)
         </property>
        </spacer>
       </item>
+      <item row="0" column="2">
+       <widget class="QLineEdit" name="number_of_particles">
+        <property name="text">
+         <string>128</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="initial_relative_weighting">
+        <property name="text">
+         <string>0.05</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QLineEdit" name="relative_weighting">
+        <property name="text">
+         <string>1.0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QLineEdit" name="starting_regularization">
+        <property name="text">
+         <string>10</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QLineEdit" name="ending_regularization">
+        <property name="text">
+         <string>1.0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="QLineEdit" name="iterations_per_split">
+        <property name="text">
+         <string>1000</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="QLineEdit" name="optimization_iterations">
+        <property name="text">
+         <string>1000</string>
+        </property>
+       </widget>
+      </item>
       <item row="8" column="2">
-       <widget class="QDoubleSpinBox" name="normals_strength">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
+       <widget class="QLineEdit" name="normals_strength">
+        <property name="text">
+         <string>10</string>
         </property>
-        <property name="minimumSize">
-         <size>
-          <width>100</width>
-          <height>0</height>
-         </size>
+       </widget>
+      </item>
+      <item row="13" column="2">
+       <widget class="QLineEdit" name="multiscale_particles">
+        <property name="text">
+         <string>32</string>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="maximum">
-         <double>999999999.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>10.000000000000000</double>
+       </widget>
+      </item>
+      <item row="11" column="2">
+       <widget class="QLineEdit" name="procrustes_interval">
+        <property name="text">
+         <string>10</string>
         </property>
        </widget>
       </item>
@@ -722,20 +497,10 @@ background: rgb(255, 255, 127)
   </layout>
  </widget>
  <tabstops>
-  <tabstop>number_of_particles</tabstop>
-  <tabstop>initial_relative_weighting</tabstop>
-  <tabstop>relative_weighting</tabstop>
-  <tabstop>starting_regularization</tabstop>
-  <tabstop>ending_regularization</tabstop>
-  <tabstop>iterations_per_split</tabstop>
-  <tabstop>optimization_iterations</tabstop>
   <tabstop>use_normals</tabstop>
-  <tabstop>normals_strength</tabstop>
   <tabstop>procrustes</tabstop>
   <tabstop>procrustes_scaling</tabstop>
-  <tabstop>procrustes_interval</tabstop>
   <tabstop>multiscale</tabstop>
-  <tabstop>multiscale_particles</tabstop>
   <tabstop>run_optimize_button</tabstop>
   <tabstop>restoreDefaults</tabstop>
  </tabstops>


### PR DESCRIPTION
Resolve #1031 

Rather than use QDoubleSpinBoxes for these values that must have a number of decimals set, I've switched to free response line edits with validators.  When a param is invalid, the background changes to red and the "run optimize" button disables.  This allows the user to easily type "1e9" for a value as they support scientific notation for the double parameters.