### PR TITLE
fix memory leak in Sampler::AddMesh()

### DIFF
--- a/Libs/Optimize/ParticleSystem/MeshDomain.h
+++ b/Libs/Optimize/ParticleSystem/MeshDomain.h
@@ -11,6 +11,7 @@
 #include "itkParticleDomain.h"
 #include "MeshWrapper.h"
 #include "TriMeshWrapper.h"
+#include <itkObjectFactory.h>
 
 namespace itk
 {
@@ -19,6 +20,7 @@ class MeshDomain : public ParticleDomain
 public:
   /** Standard class typedefs */
   typedef SmartPointer<MeshDomain> Pointer;
+  itkSimpleNewMacro(MeshDomain);
 
   /** Point type used to store particle locations. */
   typedef typename ParticleDomain::PointType PointType;
@@ -114,10 +116,10 @@ public:
   void UpdateZeroCrossingPoint() override {
   }
 
+protected:
   MeshDomain() { }
   virtual ~MeshDomain() {}
 
-protected:
   void PrintSelf(std::ostream& os, Indent indent) const
   {
     DataObject::Superclass::PrintSelf(os, indent);

--- a/Libs/Optimize/ParticleSystem/Sampler.cpp
+++ b/Libs/Optimize/ParticleSystem/Sampler.cpp
@@ -284,12 +284,16 @@ void Sampler::ReInitialize()
 
 void Sampler::AddMesh(std::shared_ptr<shapeworks::MeshWrapper> mesh)
 {
-  itk::MeshDomain* domain = new itk::MeshDomain();
-  m_NeighborhoodList.push_back(itk::ParticleSurfaceNeighborhood<ImageType>::New());
-  if (mesh) {
-    this->m_Spacing = 1;
-    domain->SetMesh(mesh);
+  if(mesh == nullptr) {
+    throw std::runtime_error("Sampler::AddMesh received null mesh");
   }
+
+  auto domain = itk::MeshDomain::New();
+  domain->SetMesh(mesh);
+
+  m_NeighborhoodList.push_back(itk::ParticleSurfaceNeighborhood<ImageType>::New());
+
+  this->m_Spacing = 1;
   m_DomainList.push_back(domain);
 }
 


### PR DESCRIPTION
Make sure MeshDomain uses the itk Smart Pointer so there are no memory leaks

Closes #1044 