### PR TITLE
Fix studio missing groom (#1045)

### DIFF
--- a/Studio/src/Application/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Application/Analysis/AnalysisTool.cpp
@@ -1034,6 +1034,10 @@ void AnalysisTool::initialize_mesh_warper()
     QSharedPointer<Shape> median_shape = this->session_->get_shapes()[median];
     vtkSmartPointer<vtkPolyData> poly_data = median_shape->get_groomed_mesh(true)->get_poly_data();
 
+    if (!poly_data) {
+      STUDIO_LOG_ERROR("Unable to set reference mesh, groomed mesh is unavailable");
+      return;
+    }
     this->session_->get_mesh_manager()->get_mesh_warper()->set_reference_mesh(poly_data,
                                                                               median_shape->get_local_correspondence_points());
   }

--- a/Studio/src/Application/Data/MeshManager.h
+++ b/Studio/src/Application/Data/MeshManager.h
@@ -67,6 +67,8 @@ Q_SIGNALS:
 
 private:
 
+  void check_error_status(MeshHandle mesh);
+
   Preferences& prefs_;
 
   // cache of shape meshes


### PR DESCRIPTION
Fix #1045 by adding an additional check and fall back when groomed mesh is missing while looking for reference mesh for mesh warping.