### PR TITLE
Studio variance mode

### DIFF
--- a/Studio/src/Application/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Application/Analysis/AnalysisTool.cpp
@@ -530,6 +530,20 @@ const vnl_vector<double>& AnalysisTool::get_shape_points(int mode, double value)
                            QString::number(this->stats_.Eigenvalues()[m]),
                            QString::number(value * lambda));
 
+
+  std::vector<double> vals;
+  for (int i = this->stats_.Eigenvalues().size() - 1; i > 0; i--) {
+    vals.push_back(this->stats_.Eigenvalues()[i]);
+  }
+  double sum = std::accumulate(vals.begin(), vals.end(), 0.0);
+  double cumulation = 0;
+  for (size_t i = 0; i < mode+1; ++i) {
+    cumulation += vals[i];
+  }
+  this->ui_->explained_variance->setText(QString::number(vals[mode] / sum * 100, 'f', 1) + "%");
+  this->ui_->cumulative_explained_variance->setText(
+    QString::number(cumulation / sum * 100, 'f', 1) + "%");
+
   this->temp_shape_ = this->stats_.Mean() + (e * (value * lambda));
 
   return this->temp_shape_;

--- a/Studio/src/Application/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Application/Analysis/AnalysisTool.cpp
@@ -530,19 +530,24 @@ const vnl_vector<double>& AnalysisTool::get_shape_points(int mode, double value)
                            QString::number(this->stats_.Eigenvalues()[m]),
                            QString::number(value * lambda));
 
-
   std::vector<double> vals;
   for (int i = this->stats_.Eigenvalues().size() - 1; i > 0; i--) {
     vals.push_back(this->stats_.Eigenvalues()[i]);
   }
   double sum = std::accumulate(vals.begin(), vals.end(), 0.0);
   double cumulation = 0;
-  for (size_t i = 0; i < mode+1; ++i) {
+  for (size_t i = 0; i < mode + 1; ++i) {
     cumulation += vals[i];
   }
-  this->ui_->explained_variance->setText(QString::number(vals[mode] / sum * 100, 'f', 1) + "%");
-  this->ui_->cumulative_explained_variance->setText(
-    QString::number(cumulation / sum * 100, 'f', 1) + "%");
+  if (sum > 0) {
+    this->ui_->explained_variance->setText(QString::number(vals[mode] / sum * 100, 'f', 1) + "%");
+    this->ui_->cumulative_explained_variance->setText(
+      QString::number(cumulation / sum * 100, 'f', 1) + "%");
+  }
+  else {
+    this->ui_->explained_variance->setText("");
+    this->ui_->cumulative_explained_variance->setText("");
+  }
 
   this->temp_shape_ = this->stats_.Mean() + (e * (value * lambda));
 

--- a/Studio/src/Application/Analysis/AnalysisTool.ui
+++ b/Studio/src/Application/Analysis/AnalysisTool.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>438</width>
-    <height>1252</height>
+    <height>1269</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -826,6 +826,19 @@ QWidget#metrics_panel {
                 <property name="rightMargin">
                  <number>3</number>
                 </property>
+                <item row="2" column="0">
+                 <spacer name="verticalSpacer_2">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>40</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
                 <item row="0" column="0">
                  <widget class="QWidget" name="pcaContent" native="true">
                   <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -989,26 +1002,6 @@ QWidget#metrics_panel {
                        </property>
                       </widget>
                      </item>
-                     <item row="0" column="0">
-                      <widget class="QLabel" name="label_9">
-                       <property name="minimumSize">
-                        <size>
-                         <width>0</width>
-                         <height>24</height>
-                        </size>
-                       </property>
-                       <property name="text">
-                        <string>Lambda</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QLabel" name="pcaEigenValueLabel">
-                       <property name="text">
-                        <string/>
-                       </property>
-                      </widget>
-                     </item>
                      <item row="1" column="1">
                       <widget class="QSpinBox" name="pcaModeSpinBox">
                        <property name="enabled">
@@ -1045,23 +1038,70 @@ QWidget#metrics_panel {
                        </property>
                       </widget>
                      </item>
+                     <item row="4" column="0">
+                      <widget class="QLabel" name="label_13">
+                       <property name="minimumSize">
+                        <size>
+                         <width>0</width>
+                         <height>24</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Cumulative Variance</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="0">
+                      <widget class="QLabel" name="label_9">
+                       <property name="minimumSize">
+                        <size>
+                         <width>0</width>
+                         <height>24</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Lambda</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="0">
+                      <widget class="QLabel" name="label_12">
+                       <property name="minimumSize">
+                        <size>
+                         <width>0</width>
+                         <height>24</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Explained Variance</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="1">
+                      <widget class="QLabel" name="pcaEigenValueLabel">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="1">
+                      <widget class="QLabel" name="explained_variance">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="4" column="1">
+                      <widget class="QLabel" name="cumulative_explained_variance">
+                       <property name="text">
+                        <string/>
+                       </property>
+                      </widget>
+                     </item>
                     </layout>
                    </item>
                   </layout>
                  </widget>
-                </item>
-                <item row="1" column="0">
-                 <spacer name="verticalSpacer_2">
-                  <property name="orientation">
-                   <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>40</height>
-                   </size>
-                  </property>
-                 </spacer>
                 </item>
                </layout>
               </widget>

--- a/Studio/src/Application/Visualization/BarGraph.cpp
+++ b/Studio/src/Application/Visualization/BarGraph.cpp
@@ -42,7 +42,7 @@ void BarGraph::hover_timer_event()
     double explained_variance = this->values_[bar];
     double accumulated_variance = this->accumulation_[bar];
 
-    QString message("Mode: " + QString::number(bar)
+    QString message("Mode: " + QString::number(bar+1)
                     + "\nExplained Variance: " + QString::number(explained_variance, 'f', 1)
                     + "\nCumulative Variance: " + QString::number(accumulated_variance, 'f', 1));
 
@@ -117,7 +117,7 @@ void BarGraph::paint_bar_graph(QPainter& painter)
       if (i < 99 || i % 4 == 0) {
         // after '9', there's not enough room to write each number, only write every other
         painter.drawText(45 + this->bar_width_ * (i + 0.5) + this->margin_ * (i + 1) - 3,
-                         this->height() - 20, QString::number(i));
+                         this->height() - 20, QString::number(i+1));
       }
     }
 


### PR DESCRIPTION
This PR fixes #1030, updating the 1 based instead of 0 based indexing for modes.

I also added the current mode's explained variance and cumulative explained variance under the lambda value:

<img width="397" alt="Screen Shot 2021-03-10 at 10 09 10 AM" src="https://user-images.githubusercontent.com/1693349/110668863-ff147c00-8188-11eb-8b40-b4da0cbc8d5e.png">

Docs updated!