### PR TITLE
Path class must be explicitly converted to string when used as such (#1112)

### DIFF
--- a/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
@@ -158,10 +158,10 @@
     "    for curImg, curName in zip(swImageList, swImageNames):\n",
     "        filename = Path(outDir + curName + '.' + extension)\n",
     "        if verbose:\n",
-    "            print('Writing: ' + filename)\n",
+    "            print('Writing: ' + str(filename))\n",
     "        if not os.path.exists(os.path.dirname(filename)):\n",
     "            os.makedirs(os.path.dirname(filename))\n",
-    "        curImg.write(filename, compressed=compressed) "
+    "        curImg.write(str(filename), compressed=compressed) "
    ]
   },
   {


### PR DESCRIPTION
Very small fix of notebook on windows. Not enough to warrant creating the next RC yet.
Confirmed this works on Windows, but haven't checked other platforms.