### PR TITLE
Removing nbstripout lines from conda_installs.bat that won't work on non-git repos.  

### DIFF
--- a/conda_installs.bat
+++ b/conda_installs.bat
@@ -60,10 +60,6 @@ call jupyter contrib nbextension install --user
 call jupyter nbextension enable spellchecker/main
 call jupyter nbextension enable toc2/main
 
-REM installing nbstripout to strip out notebooks cell outputs before committing 
-call nbstripout --install
-call nbstripout --install --attributes .gitattributes
-
 call conda info
 
 


### PR DESCRIPTION
See issue #1098.