### PR TITLE
Tuned parameters to fix the ellipsoid_cut use case

### DIFF
--- a/Examples/Python/ellipsoid_cut.py
+++ b/Examples/Python/ellipsoid_cut.py
@@ -87,13 +87,13 @@ def Run_Pipeline(args):
         cutting_plane_counts.append(2)
 
     parameterDictionary = {
-        "number_of_particles": 128,
+        "number_of_particles": 32,
         "use_normals": 1,
         "normal_weight": 15.0,
         "checkpointing_interval": 200,
         "keep_checkpoints": 0,
-        "iterations_per_split": 2000,
-        "optimization_iterations": 1000,
+        "iterations_per_split": 3000,
+        "optimization_iterations": 3000,
         "starting_regularization": 100,
         "ending_regularization": 10,
         "recompute_regularization_interval": 2,
@@ -111,11 +111,11 @@ def Run_Pipeline(args):
     }
 
     if args.tiny_test:
-        parameterDictionary["number_of_particles"] = 32
+        parameterDictionary["number_of_particles"] = 16
         parameterDictionary["optimization_iterations"] = 25
 
     if not args.use_single_scale:
-        parameterDictionary["use_shape_statistics_after"] = 32
+        parameterDictionary["use_shape_statistics_after"] = 16
 
     """
     Now we execute a single scale particle optimization function.


### PR DESCRIPTION
This PR fixes the parameters of the ellipsoid_cut use case so that the correspondence is reasonable. I decreased the number of particles because the clipped ellipsoid, which had less than 1/4 of the surface area of the whole ellipsoid was using the same number of particles (128 -> 32). I also increased the number of iterations so that the particles have the chance to swap in the cramped space of particles. This fixes issue #1104. The results are shown in fig 1

![Screenshot from 2021-03-16 14-24-13](https://user-images.githubusercontent.com/11202328/111375815-51134100-8664-11eb-8d76-97f51dca2c09.png)
Fig. 1 Shows the result of running the use case with the new parameters

To run this use case
1. cd into ShapeWorks/Examples/Python
2. `python RunUseCase.py --use_case ellipsoid_cut`
