### PR TITLE
Install Miniconda in non-interactive mode

### DIFF
--- a/conda_installs.sh
+++ b/conda_installs.sh
@@ -44,11 +44,11 @@ function install_conda() {
     echo "installing anaconda..."
     if [[ "$(uname)" == "Darwin" ]]; then
       curl -o /tmp/Miniconda3-latest-MacOSX-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
-      bash /tmp/Miniconda3-latest-MacOSX-x86_64.sh
+      bash /tmp/Miniconda3-latest-MacOSX-x86_64.sh -b
       rm /tmp/Miniconda3-latest-MacOSX-x86_64.sh
     elif [[ "$(uname)" == "Linux" ]]; then
       curl -o ./Miniconda3-latest-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-      bash ./Miniconda3-latest-Linux-x86_64.sh
+      bash ./Miniconda3-latest-Linux-x86_64.sh -b
       rm ./Miniconda3-latest-Linux-x86_64.sh
     else
       echo "ERROR: unknown OS $(uname)"


### PR DESCRIPTION
This should be in line with the rest of the script using the analogous `--yes` flags.

https://docs.anaconda.com/anaconda/install/silent-mode/#linux-macos