### PR TITLE
fix getting started with grooming segmentations notebook

### DIFF
--- a/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-grooming-segmentations.ipynb
@@ -2846,8 +2846,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# here is the list of groomed segmentations\n",
-    "!echo {outDir}dts/*.nrrd"
+    "# compose the list of groomed segmentations\n",
+    "filenames = ''\n",
+    "for curName in shapeNames:\n",
+    "    filename = Path(outDir + 'dts/' + curName + '.nrrd')\n",
+    "    filenames += ' ' + str(filename)\n",
+    "print(filenames)"
    ]
   },
   {
@@ -2859,7 +2863,7 @@
     "# let's launch studio to optimize our shape model \n",
     "# see the video in the next cell to an illustration\n",
     "\n",
-    "!ShapeWorksStudio {outDir}dts/*.nrrd"
+    "!ShapeWorksStudio {str(filenames)}"
    ]
   },
   {


### PR DESCRIPTION
launch studio using list of files since on windows it doesn't support wildcard arguments
- note that getting started notebook still fails on OS X, a recent discovery, but this is not related to this fix