### PR TITLE
Warp landmarks[WIP]

### DIFF
--- a/Libs/Mesh/CMakeLists.txt
+++ b/Libs/Mesh/CMakeLists.txt
@@ -118,3 +118,7 @@ INSTALL(TARGETS ReconstructSamplesAlongPCAModes RUNTIME DESTINATION bin)
 ADD_EXECUTABLE(RemoveFidsDTLeakage RemoveFidsDTLeakage.cxx)
 TARGET_LINK_LIBRARIES(RemoveFidsDTLeakage ${ITK_LIBRARIES} Mesh tinyxml)
 INSTALL(TARGETS RemoveFidsDTLeakage RUNTIME DESTINATION bin)
+
+ADD_EXECUTABLE(WarpLandmarks WarpLandmarks.cxx)
+TARGET_LINK_LIBRARIES(WarpLandmarks ${ITK_LIBRARIES} Mesh tinyxml)
+INSTALL(TARGETS WarpLandmarks RUNTIME DESTINATION bin)

--- a/Libs/Mesh/MeshUtils.cpp
+++ b/Libs/Mesh/MeshUtils.cpp
@@ -112,7 +112,6 @@ Eigen::MatrixXd MeshUtils::generateWarpMatrix(Eigen::MatrixXd TV, Eigen::MatrixX
   // list of points --> list of singleton lists
   std::vector<std::vector<int> > S;
   igl::matrix_to_list(b,S);
-
   // Technically k should equal 3 for smooth interpolation in 3d, but 2 is
   // faster and looks OK
   const int k = 2;

--- a/Libs/Mesh/WarpLandmarks.cxx
+++ b/Libs/Mesh/WarpLandmarks.cxx
@@ -1,0 +1,48 @@
+// #include "TriMesh.h"
+// #include "meshFIM.h"
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <string>
+#include "Mesh.h"
+#include "MeshUtils.h"
+#include "ParticleSystem.h"
+using namespace shapeworks;
+
+int main(int argc, char *argv[])
+{
+    if (argc != 6)
+    {
+        std::cout << "Usage: " << argv[0] << " plyMeshFilePath inPointsPath  outMeshFilePath outPointsPath numParticles" << std::endl;
+        return EXIT_FAILURE;
+    }
+    std::string inMesh  = std::string(argv[1]);
+    std::string inPoint   = std::string(argv[2]);
+	std::string outMesh  = std::string(argv[3]);
+    std::string outPoint   = std::string(argv[4]);
+	int numP = atoi(argv[5]);
+
+	// read the points
+	Eigen::MatrixXd Vcontrol_static;
+	Eigen::MatrixXd Vcontrol_moving;
+
+  Mesh ellipsoid( inMesh );
+  Eigen::MatrixXd Vref = MeshUtils::distilVertexInfo(ellipsoid);
+  Eigen::MatrixXi Fref = MeshUtils::distilFaceInfo(ellipsoid);
+  std::string staticPath = inPoint;
+  std::string movingPath = outPoint;
+  std::vector<std::string> paths;
+  paths.push_back(staticPath);
+  paths.push_back(movingPath);
+  ParticleSystem particlesystem(paths);
+  Eigen::MatrixXd allPts = particlesystem.Particles();
+  Eigen::MatrixXd staticPoints = allPts.col(0);
+  Eigen::MatrixXd movingPoints = allPts.col(1);
+  staticPoints.resize(3, numP);
+  movingPoints.resize(3, numP);
+  std::cout << Fref.rows() << " " << staticPoints.rows() << " " << Vref.size() << std::endl;
+  Eigen::MatrixXd W = MeshUtils::generateWarpMatrix(Vref, Fref, staticPoints.transpose());
+  Mesh output = MeshUtils::warpMesh(movingPoints.transpose(), W, Fref);
+  output.write(outMesh);
+  return 0;
+}


### PR DESCRIPTION
This is a standalone tool for performing mesh reconstruction using mesh warping. 
The reason for the WIP tag is due to a mesh/particle data I have that is causing a seg fault in the reconstruction code. It works well with other datasets.

@akenmorris @medakk Can you guys test this and see if it is causing the same problems on your end?

The data is here
[data.zip](https://github.com/SCIInstitute/ShapeWorks/files/6329992/data.zip)

The way to run this is 
```
./WarpLandmarks templatemeshpath templatepointpath outputmeshpath outputpointpath
```
