### PR TITLE
Studio scalar bar label precision

### DIFF
--- a/Studio/src/Application/Visualization/Viewer.cpp
+++ b/Studio/src/Application/Visualization/Viewer.cpp
@@ -174,9 +174,9 @@ Viewer::Viewer()
   this->scalar_bar_actor_->SetPosition(0.9, 0.1);
   this->scalar_bar_actor_->SetLabelFormat("%.1f");
   this->scalar_bar_actor_->GetTitleTextProperty()->SetFontFamilyToArial();
-  this->scalar_bar_actor_->GetTitleTextProperty()->SetFontSize(48);
+  this->scalar_bar_actor_->GetTitleTextProperty()->SetFontSize(4);
   this->scalar_bar_actor_->GetLabelTextProperty()->SetFontFamilyToArial();
-  this->scalar_bar_actor_->GetLabelTextProperty()->SetFontSize(48);
+  this->scalar_bar_actor_->GetLabelTextProperty()->SetFontSize(4);
   this->scalar_bar_actor_->GetLabelTextProperty()->SetJustificationToCentered();
   this->scalar_bar_actor_->GetLabelTextProperty()->SetColor(1, 1, 1);
 

--- a/Studio/src/Application/Visualization/Viewer.cpp
+++ b/Studio/src/Application/Visualization/Viewer.cpp
@@ -168,15 +168,15 @@ Viewer::Viewer()
   this->scalar_bar_actor_->SetOrientationToVertical();
   this->scalar_bar_actor_->SetMaximumNumberOfColors(1000);
   this->scalar_bar_actor_->GetPositionCoordinate()->SetCoordinateSystemToNormalizedViewport();
-  this->scalar_bar_actor_->GetPositionCoordinate()->SetValue(.2, .05);
-  this->scalar_bar_actor_->SetWidth(0.05);
+  this->scalar_bar_actor_->GetPositionCoordinate()->SetValue(.3, .2);
+  this->scalar_bar_actor_->SetWidth(0.10);
   this->scalar_bar_actor_->SetHeight(0.7);
-  this->scalar_bar_actor_->SetPosition(0.9, 0.05);
-  this->scalar_bar_actor_->SetLabelFormat("%.0f");
+  this->scalar_bar_actor_->SetPosition(0.9, 0.1);
+  this->scalar_bar_actor_->SetLabelFormat("%.1f");
   this->scalar_bar_actor_->GetTitleTextProperty()->SetFontFamilyToArial();
-  this->scalar_bar_actor_->GetTitleTextProperty()->SetFontSize(4);
+  this->scalar_bar_actor_->GetTitleTextProperty()->SetFontSize(48);
   this->scalar_bar_actor_->GetLabelTextProperty()->SetFontFamilyToArial();
-  this->scalar_bar_actor_->GetLabelTextProperty()->SetFontSize(4);
+  this->scalar_bar_actor_->GetLabelTextProperty()->SetFontSize(48);
   this->scalar_bar_actor_->GetLabelTextProperty()->SetJustificationToCentered();
   this->scalar_bar_actor_->GetLabelTextProperty()->SetColor(1, 1, 1);
 
@@ -886,6 +886,18 @@ void Viewer::update_difference_lut(float r0, float r1)
   this->arrow_glyph_mapper_->SetScalarRange(range);
   this->glyph_mapper_->SetScalarRange(range);
   this->scalar_bar_actor_->SetLookupTable(this->surface_lut_);
+  if (rd > 100) {
+    this->scalar_bar_actor_->SetLabelFormat("%.0f");
+  }
+  else if (rd > 1) {
+    this->scalar_bar_actor_->SetLabelFormat("%.1f");
+  }
+  else if (rd > 0.1) {
+    this->scalar_bar_actor_->SetLabelFormat("%.2f");
+  }
+  else {
+    this->scalar_bar_actor_->SetLabelFormat("%-#6.3g");
+  }
   this->scalar_bar_actor_->Modified();
 }
 


### PR DESCRIPTION
Address #1221 

Now:

<img width="49" alt="Screen Shot 2021-04-26 at 2 02 36 PM" src="https://user-images.githubusercontent.com/1693349/116143220-19061180-a698-11eb-8ae2-3bcde5a56aae.png">
<img width="45" alt="Screen Shot 2021-04-26 at 2 02 30 PM" src="https://user-images.githubusercontent.com/1693349/116143221-199ea800-a698-11eb-811d-d8de7abc1590.png">
<img width="46" alt="Screen Shot 2021-04-26 at 2 02 23 PM" src="https://user-images.githubusercontent.com/1693349/116143222-199ea800-a698-11eb-978a-135a2ab43bbd.png">
