### PR TITLE
fix osx Big Sur dependencies xlnt build and upgrade it to version 1.5.0

### DIFF
--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -18,7 +18,7 @@ ITK_VER="v5.0.1-fix"
 ITK_VER_STR="5.0"
 EIGEN_VER="3.3.7"
 QT_MIN_VER="5.9.8"  # NOTE: 5.x is required, but this restriction is a clever way to ensure the anaconda version of Qt (5.9.6 or 5.9.7) isn't used since it won't work on most systems.
-XLNT_VER="v1.4.0"
+XLNT_VER="v1.5.0"
 OpenVDB_VER="v7.0.0"
 libigl_VER="v2.2.0-fix"
 geometry_central_VER="8b20898f6c7be1eab827a9f720c8fd45e58ae63c" # This library isn't using tagged versions
@@ -228,6 +228,9 @@ build_xlnt()
   cd xlnt
   git checkout -f tags/${XLNT_VER}
 
+  # move conflicting file out of the way so it builds on osx
+  mv third-party/libstudxml/version third-party/libstudxml/version.bak
+
   if [[ $BUILD_CLEAN = 1 ]]; then rm -rf build; fi
   mkdir -p build && cd build
 
@@ -239,6 +242,9 @@ build_xlnt()
       cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -DSTATIC=ON -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ..
       make -j${NUM_PROCS} install || exit 1
   fi
+
+  # move conflicting file back to where it was
+  mv third-party/libstudxml/version.bak third-party/libstudxml/version
 
   XLNT_DIR=${INSTALL_DIR}
 }


### PR DESCRIPTION
Failed due to a file called `version` in one of the xlnt third party libs. Fixed by temporarily moving that file out of the way to build the library then back afterwards (in case it's needed for anything, which seems unlikely.