### PR TITLE
Mesh Warping for Multiple Meshes

### DIFF
--- a/Applications/shapeworks/MeshCommands.cpp
+++ b/Applications/shapeworks/MeshCommands.cpp
@@ -1023,8 +1023,6 @@ bool CompareMesh::execute(const optparse::Values &options, SharedCommandData &sh
   }
 }
 
-
-
 ///////////////////////////////////////////////////////////////////////////////
 // WarpMesh
 ///////////////////////////////////////////////////////////////////////////////
@@ -1033,16 +1031,11 @@ void WarpMesh::buildParser()
   const std::string prog = "warp-mesh";
   const std::string desc = "warps a mesh given reference and target particles";
   parser.prog(prog).description(desc);
-
   parser.add_option("--reference_mesh").action("store").type("string").set_default("").help("Name of reference mesh.");
   parser.add_option("--reference_points").action("store").type("string").set_default("").help("Name of reference points.");
-  parser.add_option("--target_points").action("store").type("string").set_default("").help("Name of target points. If multiple--> list of target points");
-  parser.add_option("--target_mesh").action("store").type("string").set_default("").help("Name of output target mesh. If multiple--> list of target meshes");
-  parser.add_option("--multiple").action("store").type("bool").set_default(false).help("Flag true is multiple meshes are to be warped.");
-
+  parser.add_option("--target_points").action("store").type("multistring").set_default("").help("Names of target points (must be followed by `--`), ex: \"... --target_points *.particles -- ...");
   Command::buildParser();
 }
-
 bool WarpMesh::execute(const optparse::Values &options, SharedCommandData &sharedData)
 {
   std::string inputMeshFilename = options["reference_mesh"];
@@ -1050,86 +1043,39 @@ bool WarpMesh::execute(const optparse::Values &options, SharedCommandData &share
     std::cerr << "warpmesh error: no reference mesh specified, must pass `--reference_mesh <filename>`\n";
     return false;
   }
-
   std::string inputPointsFilename = options["reference_points"];
   if (inputPointsFilename.length() == 0) {
     std::cerr << "warpmesh error: no reference points specified, must pass `--reference_points <filename>`\n";
     return false;
   }
-
-  std::string targetMeshFilename = options["target_mesh"];
-  if (targetMeshFilename.length() == 0) {
-    std::cerr << "warpmesh error: no target mesh specified, must pass `--target_mesh <filename>`\n";
+  std::vector<std::string> targetPointsFilenames = options.get("target_points");
+  if (targetPointsFilenames.size() == 0) {
+    std::cerr << "warpmesh error: no target points specified, must pass `--target_points <filenames> --`\n";
     return false;
   }
-
-  std::string targetPointsFilename = options["target_points"];
-  if (targetPointsFilename.length() == 0) {
-    std::cerr << "warpmesh error: no target points specified, must pass `--target_points <filename>`\n";
-    return false;
-  }
-
-  bool multiple = static_cast<bool>(options.get("multiple"));
-
   try {
     Mesh inputMesh(inputMeshFilename);
-
-    std::vector<std::string> paths;
-    paths.push_back(inputPointsFilename);
-    if (multiple) {
-      std::vector<std::string> outMeshes;
-      std::ifstream inputFile(targetPointsFilename);
-      std::string line;
-      while (inputFile >> line) {
-          paths.push_back(line);
-      }
-      inputFile.close();
-
-      std::ifstream inputFileMeshes(targetMeshFilename);
-      while (inputFileMeshes >> line) {
-          outMeshes.push_back(line);
-      }
-      inputFileMeshes.close();
-      
-      if (paths.size() - 1 != outMeshes.size()) {
-        std::cerr << "warpmesh error: number of output point files should be equal to the number of output mesh files\n";
-        return false;
-      }
-
-      ParticleSystem particlesystem(paths);
-      Eigen::MatrixXd allPts = particlesystem.Particles();
-      Eigen::MatrixXd staticPoints = allPts.col(0);
-      int numParticles = staticPoints.rows() / 3;
-      staticPoints.resize(3, numParticles);
-      staticPoints.transposeInPlace();
-      MeshWarper warper;
-      warper.set_reference_mesh(inputMesh.getVTKMesh(), staticPoints);
-      for (int i = 0; i < outMeshes.size(); i++) {
-        Eigen::MatrixXd movingPoints = allPts.col(i+ 1);
-        movingPoints.resize(3, numParticles);
-        movingPoints.transposeInPlace();
-        Mesh output = warper.build_mesh(movingPoints);
-        output.write(outMeshes[i]);  
-      }
-    }
-    else {
-      paths.push_back(targetPointsFilename);
-      ParticleSystem particlesystem(paths);
-      Eigen::MatrixXd allPts = particlesystem.Particles();
-      Eigen::MatrixXd staticPoints = allPts.col(0);
-      Eigen::MatrixXd movingPoints = allPts.col(1);
-      int numParticles = staticPoints.rows() / 3;
-      staticPoints.resize(3, numParticles);
-      staticPoints.transposeInPlace();
+    // auto paths = inputPointsFilename + targetPointsFilenames;
+    targetPointsFilenames.push_back(inputPointsFilename);
+    ParticleSystem particlesystem(targetPointsFilenames);
+    Eigen::MatrixXd allPts = particlesystem.Particles();
+    Eigen::MatrixXd staticPoints = allPts.col(targetPointsFilenames.size() - 1);
+    int numParticles = staticPoints.rows() / 3;
+    staticPoints.resize(3, numParticles);
+    staticPoints.transposeInPlace();
+    MeshWarper warper;
+    warper.set_reference_mesh(inputMesh.getVTKMesh(), staticPoints);
+    std::string infnm;
+    for (int i = 0; i < targetPointsFilenames.size() - 1; i++) {
+      infnm = targetPointsFilenames[i];
+      // for now just replace .particles to .vtk
+      infnm.replace(infnm.end()-9, infnm.end(), "vtk");
+      Eigen::MatrixXd movingPoints = allPts.col(i);
       movingPoints.resize(3, numParticles);
       movingPoints.transposeInPlace();
-
-      MeshWarper warper;
-      warper.set_reference_mesh(inputMesh.getVTKMesh(), staticPoints);
       Mesh output = warper.build_mesh(movingPoints);
-      output.write(targetMeshFilename);
+      output.write(infnm);
     }
-
     return true;
   } catch (std::exception &e) {
     std::cerr << "exception during mesh warp: " << e.what() << std::endl;

--- a/Applications/shapeworks/MeshCommands.cpp
+++ b/Applications/shapeworks/MeshCommands.cpp
@@ -1053,6 +1053,7 @@ bool WarpMesh::execute(const optparse::Values &options, SharedCommandData &share
     std::cerr << "warpmesh error: no target points specified, must pass `--target_points <filenames> --`\n";
     return false;
   }
+
   try {
     Mesh inputMesh(inputMeshFilename);
     // auto paths = inputPointsFilename + targetPointsFilenames;

--- a/Applications/shapeworks/MeshCommands.cpp
+++ b/Applications/shapeworks/MeshCommands.cpp
@@ -1067,25 +1067,25 @@ bool WarpMesh::execute(const optparse::Values &options, SharedCommandData &share
     staticPoints.transposeInPlace();
     MeshWarper warper;
     warper.set_reference_mesh(inputMesh.getVTKMesh(), staticPoints);
-    std::string infnm;
-    
+    std::string filenm;
+
     if (saveDir.length() > 0) {
       boost::filesystem::create_directories(saveDir);
     }
 
     for (int i = 0; i < targetPointsFilenames.size() - 1; i++) {
-      infnm = targetPointsFilenames[i];
-      infnm.replace(infnm.end()-9, infnm.end(), "vtk");
+      filenm = targetPointsFilenames[i];
+      filenm.replace(static_cast<int>(filenm.rfind('.')) + 1, filenm.length(), "vtk");
       if (saveDir.length() > 0) {
-        int idx = static_cast<int>(infnm.rfind('/'));
-        infnm.replace(0, idx, saveDir);
+        int idx = static_cast<int>(filenm.rfind('/'));
+        filenm.replace(0, idx, saveDir);
       }
       
       Eigen::MatrixXd movingPoints = allPts.col(i);
       movingPoints.resize(3, numParticles);
       movingPoints.transposeInPlace();
       Mesh output = warper.build_mesh(movingPoints);
-      output.write(infnm);
+      output.write(filenm);
     }
     return true;
   } catch (std::exception &e) {

--- a/Applications/shapeworks/MeshCommands.cpp
+++ b/Applications/shapeworks/MeshCommands.cpp
@@ -1089,6 +1089,11 @@ bool WarpMesh::execute(const optparse::Values &options, SharedCommandData &share
           outMeshes.push_back(line);
       inputFileMeshes.close();
       
+      if (paths.size() - 1 != outMeshes.size()){
+        std::cerr << "warpmesh error: number of output point files should be equal to the number of output mesh files\n";
+        return false;
+      }
+
       ParticleSystem particlesystem(paths);
       Eigen::MatrixXd allPts = particlesystem.Particles();
       Eigen::MatrixXd staticPoints = allPts.col(0);

--- a/Applications/shapeworks/MeshCommands.cpp
+++ b/Applications/shapeworks/MeshCommands.cpp
@@ -1076,20 +1076,22 @@ bool WarpMesh::execute(const optparse::Values &options, SharedCommandData &share
 
     std::vector<std::string> paths;
     paths.push_back(inputPointsFilename);
-    if(multiple){
+    if (multiple) {
       std::vector<std::string> outMeshes;
       std::ifstream inputFile(targetPointsFilename);
       std::string line;
-      while(inputFile >> line)
+      while (inputFile >> line) {
           paths.push_back(line);
+      }
       inputFile.close();
 
       std::ifstream inputFileMeshes(targetMeshFilename);
-      while(inputFileMeshes >> line)
+      while (inputFileMeshes >> line) {
           outMeshes.push_back(line);
+      }
       inputFileMeshes.close();
       
-      if (paths.size() - 1 != outMeshes.size()){
+      if (paths.size() - 1 != outMeshes.size()) {
         std::cerr << "warpmesh error: number of output point files should be equal to the number of output mesh files\n";
         return false;
       }
@@ -1102,7 +1104,7 @@ bool WarpMesh::execute(const optparse::Values &options, SharedCommandData &share
       staticPoints.transposeInPlace();
       MeshWarper warper;
       warper.set_reference_mesh(inputMesh.getVTKMesh(), staticPoints);
-      for (int i = 0; i < outMeshes.size(); i++){
+      for (int i = 0; i < outMeshes.size(); i++) {
         Eigen::MatrixXd movingPoints = allPts.col(i+ 1);
         movingPoints.resize(3, numParticles);
         movingPoints.transposeInPlace();
@@ -1110,7 +1112,7 @@ bool WarpMesh::execute(const optparse::Values &options, SharedCommandData &share
         output.write(outMeshes[i]);  
       }
     }
-    else{
+    else {
       paths.push_back(targetPointsFilename);
       ParticleSystem particlesystem(paths);
       Eigen::MatrixXd allPts = particlesystem.Particles();

--- a/Libs/Mesh/CMakeLists.txt
+++ b/Libs/Mesh/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(
   igl::core
   Particles
   TBB::tbb
+  Boost::filesystem
   )
 
 # Install

--- a/Libs/Mesh/MeshWarper.h
+++ b/Libs/Mesh/MeshWarper.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <string>
 #include <Libs/Mesh/Mesh.h>
+#include <boost/filesystem.hpp>
 
 namespace shapeworks {
 


### PR DESCRIPTION
Updates the` warp-mesh` command to handle warping multiple meshes at once utilizing the same reference mesh and points.

Usage:

- For single warp, it it the same usage `shapeworks warp-mesh --reference_mesh=template.ply --reference_points=template.particles --target_points=output.particles --target_mesh=output.vtk`
- For multiple point files set `--multiple` tag to be true (false by default) and pass a txt file of target point paths and target mesh paths. `shapeworks warp-mesh --reference_mesh=template.ply --reference_points=template.particles --target_points=output_particles.txt --target_mesh=output_meshes.txt --multiple=true`