### PR TITLE
DeepSSM Updates

### DIFF
--- a/Examples/Python/RunUseCase.py
+++ b/Examples/Python/RunUseCase.py
@@ -16,85 +16,88 @@ import subprocess
 import sys
 import setupenv
 
-# check that required modules are found
-try:
-    import termcolor
-    import DatasetUtils
-except ImportError as error:
-    print("\nError: Unable to import ShapeWorks Python dependencies\n")
-    print("Please make sure you have run \"source conda_installs.sh\" (once) and \"conda activate shapeworks\" (each time)")
-    print("See https://github.com/SCIInstitute/ShapeWorks for more information")
-    sys.exit(1)
 
-from CommonUtils import *
+if __name__ == '__main__':
 
-# Default installation path for each platform. If using your own build, specify --shapeworks_path
-# Note, the path for linux differs from setupenv.py because it is set up for the notebooks
-# that are two more levels deep
-default_bin_path = "../../bin" # Linux
-if platform.system() == "Windows":
-    default_bin_path = "C:\\Program Files\\ShapeWorks\\bin" # Windows
-if platform.system() == "Darwin":
-    default_bin_path = "/Applications/ShapeWorks/bin" # Mac
-default_subsample = 3
+    # check that required modules are found
+    try:
+        import termcolor
+        import DatasetUtils
+    except ImportError as error:
+        print("\nError: Unable to import ShapeWorks Python dependencies\n")
+        print("Please make sure you have run \"source conda_installs.sh\" (once) and \"conda activate shapeworks\" (each time)")
+        print("See https://github.com/SCIInstitute/ShapeWorks for more information")
+        sys.exit(1)
 
-parser = argparse.ArgumentParser(description='Example ShapeWorks Pipeline')
-parser.add_argument("--use_case", help="Specify which use case to run", choices=["ellipsoid", "ellipsoid_evaluate", "ellipsoid_mesh", "ellipsoid_fd", "ellipsoid_cut", "lumps", "left_atrium", "femur", "femur_mesh", "femur_cut", "deep_ssm", "supershapes_1mode_contour", "thin_cavity_bean"])
-parser.add_argument("--use_subsample", help="Run the pipeline for a subset of data",action="store_true")
-parser.add_argument("--num_subsample", help="Size of subset to run on (default: "+str(default_subsample)+")", nargs='?', type=int, default=default_subsample)
-parser.add_argument("--interactive", help="Run in interactive mode", action="store_true")
-parser.add_argument("--skip_grooming", help="Skip the grooming steps and start with already prepped (i.e., groomed) data", action="store_true")
-parser.add_argument("--groom_images", help = "Apply grooming steps to both the shapes (segmentations or surface meshes) and raw images", action="store_true")
-parser.add_argument("--use_single_scale", help="Use single scale optimization (default: multi scale)", action="store_true")
-parser.add_argument("--tiny_test", help="Run as a short test", action="store_true")
-parser.add_argument("--shapeworks_path", help="Path to ShapeWorks executables (default: "+default_bin_path+" if `shapeworks` is not already in the $PATH)", nargs='?', type=str, default=None)
-args = parser.parse_args()
-shapeworks_bin_path = args.shapeworks_path
+    from CommonUtils import *
 
-#######################################
-# Finding shapeworks, search priority:
-#
-# 1. if --shapeworks_path is given, use this
-# 2. If `shapeworks` is in the current $PATH, use this
-# 3. Platform dependent defaults
-#######################################
-if shapeworks_bin_path is None:
-    # if `shapeworks` is in the path, this will return it, otherwise None
-    shapeworks_bin_path = get_shapeworks_bin_path()
-if shapeworks_bin_path is None:
-    shapeworks_bin_path = default_bin_path
-setupenv.setup_shapeworks_env(shapeworks_bin_dir=shapeworks_bin_path, verbose=False)
+    # Default installation path for each platform. If using your own build, specify --shapeworks_path
+    # Note, the path for linux differs from setupenv.py because it is set up for the notebooks
+    # that are two more levels deep
+    default_bin_path = "../../bin" # Linux
+    if platform.system() == "Windows":
+        default_bin_path = "C:\\Program Files\\ShapeWorks\\bin" # Windows
+    if platform.system() == "Darwin":
+        default_bin_path = "/Applications/ShapeWorks/bin" # Mac
+    default_subsample = 3
 
-# make sure the shapeworks executables can be found
-check_shapeworks_path()
+    parser = argparse.ArgumentParser(description='Example ShapeWorks Pipeline')
+    parser.add_argument("--use_case", help="Specify which use case to run", choices=["ellipsoid", "ellipsoid_evaluate", "ellipsoid_mesh", "ellipsoid_fd", "ellipsoid_cut", "lumps", "left_atrium", "femur", "femur_mesh", "femur_cut", "deep_ssm", "supershapes_1mode_contour", "thin_cavity_bean"])
+    parser.add_argument("--use_subsample", help="Run the pipeline for a subset of data",action="store_true")
+    parser.add_argument("--num_subsample", help="Size of subset to run on (default: "+str(default_subsample)+")", nargs='?', type=int, default=default_subsample)
+    parser.add_argument("--interactive", help="Run in interactive mode", action="store_true")
+    parser.add_argument("--skip_grooming", help="Skip the grooming steps and start with already prepped (i.e., groomed) data", action="store_true")
+    parser.add_argument("--groom_images", help = "Apply grooming steps to both the shapes (segmentations or surface meshes) and raw images", action="store_true")
+    parser.add_argument("--use_single_scale", help="Use single scale optimization (default: multi scale)", action="store_true")
+    parser.add_argument("--tiny_test", help="Run as a short test", action="store_true")
+    parser.add_argument("--shapeworks_path", help="Path to ShapeWorks executables (default: "+default_bin_path+" if `shapeworks` is not already in the $PATH)", nargs='?', type=str, default=None)
+    args = parser.parse_args()
+    shapeworks_bin_path = args.shapeworks_path
 
-print(f"Using shapeworks from {get_shapeworks_bin_path()}")
+    #######################################
+    # Finding shapeworks, search priority:
+    #
+    # 1. if --shapeworks_path is given, use this
+    # 2. If `shapeworks` is in the current $PATH, use this
+    # 3. Platform dependent defaults
+    #######################################
+    if shapeworks_bin_path is None:
+        # if `shapeworks` is in the path, this will return it, otherwise None
+        shapeworks_bin_path = get_shapeworks_bin_path()
+    if shapeworks_bin_path is None:
+        shapeworks_bin_path = default_bin_path
+    setupenv.setup_shapeworks_env(shapeworks_bin_dir=shapeworks_bin_path, verbose=False)
 
-if args.use_subsample:
-    dataExists = dataset_exists_check(args.use_case)
-    args.use_subsample = args.num_subsample
-    if(dataExists==False):
-        print("Please note : For --use_subsample argument the entire dataset will be downloaded.For a quick test use the --tiny_test argument")
-        input("Press any key to continue")
+    # make sure the shapeworks executables can be found
+    check_shapeworks_path()
 
-if len(sys.argv)==1:
-    parser.print_help(sys.stderr)
-    sys.exit(1)
+    print(f"Using shapeworks from {get_shapeworks_bin_path()}")
 
-module = __import__(args.use_case.lower())
+    if args.use_subsample:
+        dataExists = dataset_exists_check(args.use_case)
+        args.use_subsample = args.num_subsample
+        if(dataExists==False):
+            print("Please note : For --use_subsample argument the entire dataset will be downloaded.For a quick test use the --tiny_test argument")
+            input("Press any key to continue")
 
-image_use_cases = ['femur', 'femur_cut', 'left_atrium']
-if args.groom_images and args.use_case.lower() not in image_use_cases:
-    print("\n\n*************************** WARNING ***************************")
-    print("'groom_images' tag was used but use case does not have images.")
-    print("Running use case with segmentations or meshes only.")
-    print("***************************************************************\n\n")
+    if len(sys.argv)==1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
 
-try:
-    module.Run_Pipeline(args)
-    print("\nShapeworks Pipeline Complete!")
-except KeyboardInterrupt:
-    print("KeyboardInterrupt exception caught")
-    sys.exit(1)
-except subprocess.CalledProcessError as e:
-    print("General exception caught.\n\tReturncode: "+str(e.returncode)+"\n\tOutput: "+str(e.output))
+    module = __import__(args.use_case.lower())
+
+    image_use_cases = ['femur', 'femur_cut', 'left_atrium']
+    if args.groom_images and args.use_case.lower() not in image_use_cases:
+        print("\n\n*************************** WARNING ***************************")
+        print("'groom_images' tag was used but use case does not have images.")
+        print("Running use case with segmentations or meshes only.")
+        print("***************************************************************\n\n")
+
+    try:
+        module.Run_Pipeline(args)
+        print("\nShapeworks Pipeline Complete!")
+    except KeyboardInterrupt:
+        print("KeyboardInterrupt exception caught")
+        sys.exit(1)
+    except subprocess.CalledProcessError as e:
+        print("General exception caught.\n\tReturncode: "+str(e.returncode)+"\n\tOutput: "+str(e.output))

--- a/Examples/Python/deep_ssm.py
+++ b/Examples/Python/deep_ssm.py
@@ -3,7 +3,6 @@
 ====================================================================
 Full Example Pipeline for Statistical Shape Modeling with ShapeWorks DeepSSM
 ====================================================================
-Jadie Adams
 """
 import os
 import DataAugmentationUtils
@@ -56,6 +55,8 @@ def Run_Pipeline(args):
 	train_local_particle_list = local_particle_list[:partition]
 	train_world_particle_list = world_particle_list[:partition]
 	test_img_list = img_list[partition:]
+	if args.tiny_test:
+		test_img_list = test_img_list[:3]
 
 	print("\n\n\nStep 2. Augment data\n") ###################################################################################
 	'''
@@ -133,7 +134,8 @@ def Run_Pipeline(args):
 		"use_best_model":True
 	}
 	if args.tiny_test:
-		model_parameters["trainer"]["epochs"] = 5
+		model_parameters["trainer"]["epochs"] = 1
+		model_parameters["fine_tune"]["epochs"] = 1
 	# Save config file	
 	config_file = out_dir + model_name + ".json"
 	with open(config_file, "w") as outfile:
@@ -148,7 +150,6 @@ def Run_Pipeline(args):
 	'''
 	PCA_scores_path = out_dir + "Augmentation/PCA_Particle_Info/"
 	prediction_dir = out_dir + 'Results/PredictedParticles/'
-	# DeepSSMUtils.testDeepSSM(prediction_dir, best_model_path, loader_dir, PCA_scores_path, embedded_dim)
 	DeepSSMUtils.testDeepSSM(config_file)
 	print('Predicted particles saved at: ' + prediction_dir)
 

--- a/Examples/Python/deep_ssm.py
+++ b/Examples/Python/deep_ssm.py
@@ -82,7 +82,9 @@ def Run_Pipeline(args):
 	aug_dir = out_dir + "Augmentation/"
 	embedded_dim = DataAugmentationUtils.runDataAugmentation(aug_dir, train_img_list, train_local_particle_list, num_samples, num_dim, percent_variability, sampler_type, mixture_num=0, processes=1, world_point_list=train_world_particle_list)
 	aug_data_csv = out_dir + "Augmentation/TotalData.csv"
-	DataAugmentationUtils.visualizeAugmentation(aug_data_csv, "violin")
+
+	if not args.tiny_test:
+	        DataAugmentationUtils.visualizeAugmentation(aug_data_csv, "violin")
 
 	print("\n\n\nStep 3. Reformat Data for Pytorch\n") #######################################################################
 	'''

--- a/Examples/Python/deep_ssm.py
+++ b/Examples/Python/deep_ssm.py
@@ -66,7 +66,8 @@ def Run_Pipeline(args):
 	- aug_type is the augmentation method to use (1 is based on just particles wheras 2 is based on images and particles)
 	- sample type is the distribution to use for sampling. Can be gaussian, mixture, or kde
 	'''
-	num_samples = 4960
+	# num_samples = 4960
+	num_samples = 50
 	num_dim = 6
 	percent_variability = 0.95
 	sampler_type = "kde"
@@ -149,16 +150,19 @@ def Run_Pipeline(args):
 	Test DeepSSM
 	'''
 	PCA_scores_path = out_dir + "Augmentation/PCA_Particle_Info/"
-	prediction_dir = out_dir + 'Results/PredictedParticles/'
+	prediction_dir = out_dir + model_name + '/predictions/'
 	DeepSSMUtils.testDeepSSM(config_file)
 	print('Predicted particles saved at: ' + prediction_dir)
+
+	if args.tiny_test:
+		exit()
 
 	print("\n\n\nStep 6. Analyze results.\n") #####################################################################################
 	'''
 	Analyze DeepSSM
 	'''
 	DT_dir = input_dir + "groomed/distance_transforms/"
-	out_dir = out_dir + "Results/"
+	out_dir = out_dir + model_name+ "/Results/"
 	mean_prefix = input_dir + "shape_models/femur/mean/femur"
-	avg_distance = DeepSSMUtils.analyzeResults(out_dir, DT_dir, prediction_dir, mean_prefix)
+	avg_distance = DeepSSMUtils.analyzeResults(out_dir, DT_dir, prediction_dir + 'FT_Predictions/', mean_prefix)
 	print("Average surface-to-surface distance from the original to predicted shape = " + str(avg_distance))

--- a/Examples/Python/deep_ssm.py
+++ b/Examples/Python/deep_ssm.py
@@ -9,6 +9,7 @@ import DataAugmentationUtils
 import DeepSSMUtils
 import CommonUtils
 import json
+import platform
 
 def Run_Pipeline(args):
 	if args.tiny_test:
@@ -25,6 +26,10 @@ def Run_Pipeline(args):
 	if not os.path.exists(out_dir):
 		os.makedirs(out_dir)
 
+	if platform.system() == "Darwin":
+        	# On MacOS, CPU PyTorch is hanging with parallel
+        	os.environ['OMP_NUM_THREADS'] = "1"
+                
 	if args.tiny_test:
 		CommonUtils.download_subset(args.use_case,datasetName, out_dir)
 		partition = 4

--- a/Examples/Python/deep_ssm.py
+++ b/Examples/Python/deep_ssm.py
@@ -66,8 +66,7 @@ def Run_Pipeline(args):
 	- aug_type is the augmentation method to use (1 is based on just particles wheras 2 is based on images and particles)
 	- sample type is the distribution to use for sampling. Can be gaussian, mixture, or kde
 	'''
-	# num_samples = 4960
-	num_samples = 50
+	num_samples = 4960
 	num_dim = 6
 	percent_variability = 0.95
 	sampler_type = "kde"

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/__init__.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/__init__.py
@@ -36,4 +36,3 @@ def testPytorch():
 		print("please reinstall Pytorch to your shapeworks conda ")
 		print("environment with the correct CUDA version.")
 		print("**********************************************************")
-		exit()

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/eval_utils.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/eval_utils.py
@@ -1,8 +1,10 @@
 # Jadie Adams
 import os
 import re
+import shutil
 import subprocess
 import numpy as np
+import shapeworks as sw
 
 def get_distance_meshes(out_dir, DT_dir, prediction_dir, mean_prefix):
 	# Step 1: Get list of test names
@@ -25,15 +27,13 @@ def get_distance_meshes(out_dir, DT_dir, prediction_dir, mean_prefix):
 	pred_mesh_list = sorted(get_mesh_from_particles(particle_files, out_dir + "PredcitedMeshes/", mean_prefix))
 	# Step 4: Get distance between original and predicted mesh
 	print("\n\nGetting distance between original and predicted meshes...")
-	orig_dist_mesh_list, pred_dist_mesh_list = surface_to_surface_distance(orig_mesh_list, pred_mesh_list, out_dir)
-	# Step 5: Get aggregate values regarding distance
-	avg_distance = analyze_diffs(orig_dist_mesh_list, pred_dist_mesh_list, out_dir)
+	orig_dist_mesh_list, pred_dist_mesh_list, avg_distance = surface_to_surface_distance(orig_mesh_list, pred_mesh_list, out_dir)
 	print("Done.\n")
 	return avg_distance
 
 def get_prefix(path):
 	file_name = os.path.basename(path)
-	file_name = file_name.replace("predicted_","")
+	file_name = file_name.replace("predicted_ft_","")
 	prefix = "_".join(file_name.split("_")[0:2])
 	prefix = prefix.split(".")[0]
 	return prefix
@@ -44,48 +44,40 @@ def get_mesh_from_DT(DT_list, mesh_dir):
 	mesh_files = []
 	xml_filename = mesh_dir + "temp.xml"
 	for input_file in DT_list:
+		print('	' + get_prefix(input_file))
 		output_vtk = mesh_dir + "original_" + get_prefix(input_file) + ".vtk"
-		create_meshfromDT_xml(xml_filename, input_file, output_vtk)
-		execCommand = ["MeshFromDistanceTransforms", xml_filename]
-		subprocess.check_call(execCommand)
+		image = sw.Image(input_file)
+		image.toMesh(isovalue=0).write(output_vtk)
 		mesh_files.append(output_vtk)
-	return mesh_files
-
-def create_meshfromDT_xml(xmlfilename, tpdtnrrdfilename, vtkfilename):
-    file = open(xmlfilename, "w+")
-    file.write("<lsSmootherIterations>\n1.0\n</lsSmootherIterations>")
-    file.write("<targetReduction>\n0.0001\n</targetReduction>")
-    file.write("<featureAngle>\n30.0\n</featureAngle>")
-    file.write("<preserveTopology>\n1\n</preserveTopology>")
-    file.write("<inputs>\n" + str(tpdtnrrdfilename) +"\n</inputs>")
-    file.write("<outputs>\n"+str(vtkfilename) + "\n</outputs>")
-    file.close()
+	return sorted(mesh_files)
 
 def get_mesh_from_particles(particle_list, mesh_dir, mean_prefix):
+	template_mesh = mean_prefix + "_dense.vtk"
+	template_points = mean_prefix + "_sparse.particles"
+	num_particles = np.loadtxt(particle_list[0]).shape[0]
+	particle_dir = particle_list[0].rsplit('/', 1)[0] + '/'
+	execCommand = ["shapeworks", 
+			"warp-mesh", "--reference_mesh", template_mesh,
+			"--reference_points", template_points,
+			"--target_points" ]
+	for fl in particle_list:
+		print('	' + get_prefix(fl))
+		execCommand.append(fl)
+	execCommand.append('--')
+	subprocess.check_call(execCommand)
+
 	if not os.path.exists(mesh_dir):
 		os.makedirs(mesh_dir)
-	mesh_files = []
-	xmlfilename = mesh_dir + "temp.xml"
-	create_mesh_from_particles_XML(xmlfilename, mesh_dir, mean_prefix, particle_list)
-	execCommand = ["ReconstructSurface", xmlfilename]
-	subprocess.check_call(execCommand)
-	for file in os.listdir(mesh_dir):
-		if ".vtk" in file:
-			mesh_files.append(mesh_dir + file)
-	return mesh_files
+	
+	outmeshes = []
+	for i in range(len(particle_list)):
+		infnm = particle_list[i].replace('.particles', '.vtk')
+		outfnm = infnm.replace(particle_dir, mesh_dir)
+		outmeshes.append(outfnm)
+		shutil.move(infnm, outfnm)
 
-def create_mesh_from_particles_XML(xmlfilename, out_dir, mean_prefix, filelist):
-	file = open(xmlfilename, "w+")
-	file.write("<local_point_files>\n")
-	for filename in filelist:
-		file.write(str(filename)+"\n")
-	file.write("</local_point_files>\n")
-	file.write("<out_prefix>\n" + str(out_dir) + "\n</out_prefix>\n")
-	file.write("<mean_prefix>\n")
-	file.write(str(mean_prefix)+ "\n")
-	file.write("</mean_prefix>\n")
-	file.write("<display>\nFalse\n</display>\n")
-	file.close()
+	return sorted(outmeshes)
+
 
 def surface_to_surface_distance(orig_list, pred_list, out_dir):
 	orig_out_dir = out_dir + "OriginalMeshesWithDistance/"
@@ -96,52 +88,20 @@ def surface_to_surface_distance(orig_list, pred_list, out_dir):
 		os.makedirs(pred_out_dir)
 	orig_out_list = []
 	pred_out_list = []
+	mean_distances = []
 	for index in range(len(orig_list)):
 		orig = orig_list[index]
 		pred = pred_list[index]
 		name = os.path.basename(orig).replace("original_", "")
+		print(name)
 		orig_out = orig_out_dir + name
 		pred_out = pred_out_dir + name
 		orig_out_list.append(orig_out)
 		pred_out_list.append(pred_out)
-		indicesO = orig_out.replace(".vtk",".indices")
-		indicesP = pred_out.replace(".vtk",".indices")
-		execCommand = ["SurfaceToSurfaceDistance",
-			"-a", orig,
-			"-b", pred,
-			"-A", orig_out,
-			"-B", pred_out,
-			"-Ax", indicesO,
-			"-Bx", indicesP,
-			"-t", "1"
-		]
-		subprocess.check_call(execCommand)
-	return orig_out_list, pred_out_list
-
-def analyze_diffs(orig_files, pred_files, out_dir):
-	diffs = []
-	for index in range(len(orig_files)):
-		orig_diff = read_dist(orig_files[index])
-		pred_diff = read_dist(pred_files[index])
-		diff = (orig_diff + pred_diff)/2
-		diffs.append(diff)
-	diffs = np.array(diffs)
-	np.save(out_dir + 'surface-distances.npy', diffs)
-	mean = np.mean(diffs)
-	print("Mean surface-to-surface disatnce: " + str(mean))
-	std = np.std(diffs)
-	print("Standard deviation: " + str(std))
-	minn = np.min(diffs)
-	print("Min: " + str(minn))
-	median_index = np.argsort(diffs)[len(diffs)//2]
-	median = diffs[median_index]
-	print("Median: " + str(median))
-	maxx = np.max(diffs)
-	print("Max: "+ str(maxx))
-	return mean
-
-def read_dist(vtk_file):
-	with open(vtk_file) as f:
-		lines = f.readlines()
-	dist = float(lines[6])
-	return dist
+		orig_mesh = sw.Mesh(orig)
+		pred_mesh = sw.Mesh(pred)
+		dist1 = orig_mesh.distance(pred_mesh).write(orig_out).getFieldMean("distance")
+		dist2 = pred_mesh.distance(orig_mesh).write(pred_out).getFieldMean("distance")
+		mean_distances.append(dist1)
+		mean_distances.append(dist2)
+	return orig_out_list, pred_out_list, np.mean(np.array(mean_distances))

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/loaders.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/loaders.py
@@ -221,7 +221,6 @@ def get_images(loader_dir, image_list, down_factor, down_dir):
 decreases the size of the image 
 '''
 def apply_down_sample(image_path, output_path, factor=0.75):
-	img = sw.Image()
 	image = sw.Image(image_path)
 	size = image.size()
 	sizex = int(size[0]*factor)

--- a/Testing/UseCaseTests/UseCaseTests.cpp
+++ b/Testing/UseCaseTests/UseCaseTests.cpp
@@ -124,10 +124,8 @@ TEST(UseCaseTests, femur_cut)
 //---------------------------------------------------------------------------
 TEST(UseCaseTests, deep_ssm)
 {
-  /// TODO: Disabled, doesn't run on windows GH
-  return;
   run_use_case("deep_ssm",
-               "Output/deep_ssm/Augmentation/violin.png");
+               "Output/deep_ssm/femur_deepssm/predictions/PCA_Predictions/predicted_pca_m07_L.particles");
 }
 //---------------------------------------------------------------------------
 TEST(UseCaseTests, supershapes_1mode_contour)


### PR DESCRIPTION
This PR addresses:

- Issue #1105 Refactoring DeepSSM to use a config file
- Issue #1223 Fixing surface to surface distance in eval
- Updates getting meshes from distance transforms to use pybind `toImage()` instead of command line `MeshFromDistanceTransforms`
- Updates getting meshes from particles to use `mesh-warp` instead of `ReconstructSurface`
- Updates use case to print warning but still run on CPU rather than exiting
- Improves the tiny test so it runs in about 2 min

To test, run the tiny test or the full use case (both should run on GPU or CPU). 
This will probably require running:
 `pip install Python/DeepSSMUtilsPackage/` 
`pip install Python/DataAugmentationUtilsPackage/`