### PR TITLE
Add python API for MeshUtils::findReferenceMesh

### DIFF
--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1088,7 +1088,7 @@ PYBIND11_MODULE(shapeworks_py, m)
                 return shapeworks::MeshUtils::findReferenceMesh(meshes);
               },
               "find reference mesh from a set of shapeworks meshes",
-              "meshes")
+              "meshes"_a)
   ;
 
   // ParticleSystem

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1080,8 +1080,15 @@ PYBIND11_MODULE(shapeworks_py, m)
               [](std::vector<Mesh> meshes, bool center) {
                 return shapeworks::MeshUtils::boundingBox(meshes, center);
               },
-              "calculate bounding box incrementally for shapework meshes",
+              "calculate bounding box incrementally for shapeworks meshes",
               "meshes"_a, "center"_a=false)
+
+  .def_static("findReferenceMesh",
+              [](std::vector<Mesh> meshes) {
+                return shapeworks::MeshUtils::findReferenceMesh(meshes);
+              },
+              "find reference mesh from a set of shapeworks meshes",
+              "meshes")
   ;
 
   // ParticleSystem

--- a/Testing/PythonTests/PythonTests.cpp
+++ b/Testing/PythonTests/PythonTests.cpp
@@ -283,3 +283,9 @@ TEST(pythonTests, pcaTest)
 {
   ASSERT_FALSE(system("python pca.py"));
 }
+
+TEST(pythonTests, findReferenceMeshTest)
+{
+  ASSERT_FALSE(system("python findReferenceMesh.py"));
+}
+

--- a/Testing/PythonTests/findReferenceMesh.py
+++ b/Testing/PythonTests/findReferenceMesh.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from shapeworks import *
+
+def findReferenceMeshTest():
+  mesh1 = Mesh(os.environ["DATA"] + "/m03_L_femur.ply")
+  mesh2 = Mesh(os.environ["DATA"] + "/m04_L_femur.ply")
+  mesh3 = Mesh(os.environ["DATA"] + "/m03.vtk")
+
+  meshList = []
+  meshList.append(mesh1)
+  meshList.append(mesh2)
+  meshList.append(mesh3)
+
+  return MeshUtils.findReferenceMesh(meshList) == 2
+
+val = findReferenceMeshTest()
+if val is False:
+  print("findRereferenceMeshTest failed")
+  sys.exit(1)


### PR DESCRIPTION
This adds a python API for MeshUtils::findReferenceMesh and a python test as well.