### PR TITLE
Updating reference selection

### DIFF
--- a/Python/shapeworks/shapeworks/__init__.py
+++ b/Python/shapeworks/shapeworks/__init__.py
@@ -5,5 +5,5 @@ import platform
 from shapeworks_py import *
 from .conversion import sw2vtkImage, sw2vtkMesh
 from .plot import plot_meshes, plot_volumes, plot_meshes_volumes_mix, add_mesh_to_plotter, add_volume_to_plotter, plot_mesh_contour
-from .utils import num_subplots, postive_factors, save_images, get_file_with_ext, find_reference_image_index, find_reference_mesh_index
+from .utils import num_subplots, postive_factors, save_images, get_file_with_ext, find_reference_image_index
 from .data import download_and_unzip_dataset, download_subset, get_file_list, sample_images, sample_meshes


### PR DESCRIPTION
Addresses issue #1247
Updates find_reference_image_index() to convert the segmentations to meshes and use sw.MeshUtils.findReferenceMesh() to select reference. 
Removes find_reference_mesh_index() because it wasn't being used anywhere and now sw.MeshUtils.findReferenceMesh() can be used directly. 