### PR TITLE
user python module installation during conda_installs for all three platforms

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -117,6 +117,12 @@ jobs:
         PR_NUMBER: ${{ github.event.number }}
       run: conda activate shapeworks && PATH=$HOME:$PATH ./Support/package.sh tag ${GITHUB_WORKSPACE}/shapeworks-install $HOME/install
 
+    - name: Install Python Module
+      shell: bash -l {0}
+      env:
+        PR_NUMBER: ${{ github.event.number }}
+      run: conda activate shapeworks && ./install_python_module.sh ${GITHUB_WORKSPACE}/shapeworks-install/bin/shapeworks_py.cpython*.so
+
     - name: make test
       shell: bash -l {0}
       run: conda activate shapeworks && cd build && ctest -VV

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -110,6 +110,10 @@ jobs:
         PR_NUMBER: ${{ github.event.number }}
       run: conda activate shapeworks && ./Support/package.sh tag ${GITHUB_WORKSPACE}/shapeworks-install $HOME/install
 
+    - name: Install Python Module
+      shell: bash -l {0}
+      run: conda activate shapeworks && ./install_python_module.sh ${GITHUB_WORKSPACE}/shapeworks-install/bin/shapeworks_py.cpython*.so ${HOME}/install/lib ${GITHUB_WORKSPACE}/shapeworks-install/bin ${GITHUB_WORKSPACE}/shapeworks-install/bin/ShapeWorksStudio.app/Contents/Frameworks
+
     - name: make test
       shell: bash -l {0}
       run: conda activate shapeworks && cd build && ctest -VV

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -104,6 +104,10 @@ jobs:
       env:
         PR_NUMBER: ${{ github.event.number }}
       run: conda activate shapeworks && pwd ; ls ; cp docs/users/Windows_README.txt . ; cp Support/shapeworks.nsi . ; conda activate shapeworks && ./Support/package_windows.sh tag
+
+    - name: Install Python Module
+      shell: cmd
+      run: conda activate shapeworks && .\install_python_module ${{runner.workspace}}\build\bin\RelWithDebInfo
       
     - name: Test
       working-directory: ${{runner.workspace}}/build

--- a/Python/shapeworks/shapeworks/__init__.py
+++ b/Python/shapeworks/shapeworks/__init__.py
@@ -2,7 +2,7 @@ import os
 import sys
 import platform
 
-from shapeworks_py import *
+from .shapeworks_py import *
 from .conversion import sw2vtkImage, sw2vtkMesh
 from .plot import plot_meshes, plot_volumes, plot_meshes_volumes_mix, add_mesh_to_plotter, add_volume_to_plotter, plot_mesh_contour
 from .utils import num_subplots, postive_factors, save_images, get_file_with_ext, find_reference_image_index

--- a/Support/package.sh
+++ b/Support/package.sh
@@ -49,6 +49,7 @@ cp -a $INSTALL_DIR/* "package/${VERSION}"
 cp -a Examples "package/${VERSION}"
 cp -a Python "package/${VERSION}"
 cp conda_installs.sh package/${VERSION}
+cp install_python_module.sh package/${VERSION}
 cp docs/about/release-notes.md package/${VERSION}
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/Support/shapeworks.nsi
+++ b/Support/shapeworks.nsi
@@ -73,6 +73,7 @@ Section "ShapeWorks (required)"
   
   ; Put file there
   File "conda_installs.bat"
+  File "install_python_module.bat"
   File "Windows_README.txt"
   File /r "bin"
   File /r "Examples"

--- a/conda_installs.bat
+++ b/conda_installs.bat
@@ -45,14 +45,9 @@ call pip install Python/DocumentationUtilsPackage
 call pip install Python/DataAugmentationUtilsPackage
 call pip install Python/DeepSSMUtilsPackage
 call pip install Python/ShapeCohortGenPackage
-call pip install Python/shapeworks
 
-REM install shapeworks_py binary api bindings (don't show output since this silently fail for dev runs, which is okay; succeeds for user runs)
-call copy .\bin\shapeworks_py.cp37-win_amd64.pyd %CONDA_PREFIX%\lib\site-packages\shapeworks > nul 2>&1
-call copy .\bin\shapeworks_py.pdb %CONDA_PREFIX%\lib\site-packages\shapeworks > nul 2>&1
-
-REM copy dependencies of the .pyd to the local directory (it doesn't need quite all 182MB of these, but most all)
-call copy .\bin\*.dll %CONDA_PREFIX%\lib\site-packages\shapeworks > nul 2>&1
+REM install the shapeworks python module (silently fail for dev runs)
+call install_python_module.bat .\bin > nul 2>&1
 
 REM installs for jupyter notebooks
 call pip install nbstripout

--- a/conda_installs.bat
+++ b/conda_installs.bat
@@ -46,7 +46,14 @@ call pip install Python/DataAugmentationUtilsPackage
 call pip install Python/DeepSSMUtilsPackage
 call pip install Python/ShapeCohortGenPackage
 call pip install Python/shapeworks
-  
+
+REM install shapeworks_py binary api bindings (don't show output since this silently fail for dev runs, which is okay; succeeds for user runs)
+call copy .\bin\shapeworks_py.cp37-win_amd64.pyd %CONDA_PREFIX%\lib\site-packages\shapeworks > nul 2>&1
+call copy .\bin\shapeworks_py.pdb %CONDA_PREFIX%\lib\site-packages\shapeworks > nul 2>&1
+
+REM copy dependencies of the .pyd to the local directory (it doesn't need quite all 182MB of these, but most all)
+call copy .\bin\*.dll %CONDA_PREFIX%\lib\site-packages\shapeworks > nul 2>&1
+
 REM installs for jupyter notebooks
 call pip install nbstripout
 call pip install pyvista==0.30.1

--- a/conda_installs.sh
+++ b/conda_installs.sh
@@ -145,8 +145,13 @@ function install_conda() {
   if ! pip install Python/DeepSSMUtilsPackage;          then return 1; fi # install DeepSSM code as a package
   if ! pip install Python/ShapeCohortGenPackage;        then return 1; fi # install shape cohort generation code as a package
   if ! pip install Python/shapeworks;                   then return 1; fi # depends on shapeworks_py, compiled portion of package
-
-
+  
+  if [[ "$(uname)" == "Linux" ]]; then
+    mv ./bin/shapeworks_py.cpython-37m-x86_64-linux-gnu.so $CONDA_PREFIX/lib/python3.7/site-packages/shapeworks >/dev/null 2>&1 # (silently fail for dev runs, which is okay; succeeds for user runs)
+  elif [[ "$(uname)" == "Darwin" ]]; then
+    mv ./bin/shapeworks_py.cpython-37m-darwin.so $CONDA_PREFIX/lib/python3.7/site-packages/shapeworks >/dev/null 2>&1 # (silently fail for dev runs, which is okay; succeeds for user runs)
+  fi
+  
   if [[ "$GITHUB_ACTION" != "" ]]; then
       echo "Running under GitHub Action"
       pushd $HOME/miniconda3/envs/shapeworks/lib

--- a/install_python_module.bat
+++ b/install_python_module.bat
@@ -1,0 +1,12 @@
+REM Installs the shapeworks python module.
+REM Usage: call .\install_python_module.bat <path to directory with shapeworks_py pyd and its dll dependencies>
+REM  NOTE: assumes all library dependencies are in this directory
+
+REM install pip module
+call pip install Python/shapeworks
+
+REM copy compiled portion of package to module directory
+call copy %1\shapeworks_py*.pyd %CONDA_PREFIX%\lib\site-packages\shapeworks
+
+REM copy dependencies of the .pyd to the module directory (it doesn't need quite all 182MB of these, but most all)
+call copy %1\*.dll %CONDA_PREFIX%\lib\site-packages\shapeworks

--- a/install_python_module.sh
+++ b/install_python_module.sh
@@ -28,7 +28,6 @@ if [[ "$(uname)" == "Linux" ]]; then
         else
             VERSION="ShapeWorks-$(git describe --tags)-linux"
         fi
-	      LIBDIR="`pwd`/package/${VERSION}/lib"
 
         # Special case for when we are on the master branch (dev releases)
         BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -37,6 +36,9 @@ if [[ "$(uname)" == "Linux" ]]; then
             HASH=$(git rev-parse --short HEAD)
             VERSION="ShapeWorks-dev-${NUMBER}-${HASH}-linux"
         fi
+
+	      LIBDIR="`pwd`/package/${VERSION}/lib"
+
     elif [ "$#" -gt 1 ]; then
         echo "error: linux shared libraries only have one RUNPATH, but more than one requested"
         exit -1

--- a/install_python_module.sh
+++ b/install_python_module.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -x
+
+if [ "$#" -lt 1 ]; then
+    echo "Installs python module binary (shapeworks_py) into conda, optionally adding necessary runpaths to the library."
+    echo "Usage: $0 <shapeworks_py_library> [<lib_dir_1> ... <lib_dir_n>]"
+    exit 1
+fi
+
+# install pip module
+if ! pip install Python/shapeworks; then exit -1; fi
+
+PYTHON_LIBRARY=$1; shift
+CONDA_INSTALL_DIR=`pip show shapeworks | grep Location | awk '{print $2}'`/shapeworks
+
+# install shapeworks_py, compiled portion of package
+if [[ "$(uname)" == "Linux" ]]; then
+
+    # if unspecified, use package path from github action (see package.sh)
+    if [ "$#" -lt 1 ]; then
+        if [[ "$PR_NUMBER" != "" ]]; then
+            VERSION="ShapeWorks-PR-${PR_NUMBER}-linux"
+        else
+            VERSION="ShapeWorks-$(git describe --tags)-linux"
+        fi
+	      LIBDIR="`pwd`/package/${VERSION}/lib"
+
+        # Special case for when we are on the master branch (dev releases)
+        BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        if [[ "$BRANCH" == "master" ]]; then
+            NUMBER=$(git rev-list start_dev_releases..HEAD --count)
+            HASH=$(git rev-parse --short HEAD)
+            VERSION="ShapeWorks-dev-${NUMBER}-${HASH}-linux"
+        fi
+    elif [ "$#" -gt 1 ]; then
+        echo "error: linux shared libraries only have one RUNPATH, but more than one requested"
+        exit -1
+    else
+        LIBDIR=$1
+    fi
+
+    # add libdir to runpath of python library
+    echo "adding ${LIBDIR}..."
+    patchelf --set-rpath "${LIBDIR}" "${PYTHON_LIBRARY}"
+
+elif [[ "$(uname)" == "Darwin" ]]; then
+
+    # add each libdir to runpath of python library
+    for dir in "$@"
+    do
+        echo "adding $dir..."
+        install_name_tool -add_rpath "${dir}" "${PYTHON_LIBRARY}"
+    done
+
+else
+    echo "Unknown operating system: ${uname}"
+    exit 1
+fi
+
+# move shapeworks_py library to conda install dir
+mv "${PYTHON_LIBRARY}" "${CONDA_INSTALL_DIR}"

--- a/install_python_module.sh
+++ b/install_python_module.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+# Installs shapeworks Python module
+
 if [ "$#" -lt 1 ]; then
     echo "Installs python module binary (shapeworks_py) into conda, optionally adding necessary runpaths to the library."
     echo "Usage: $0 <shapeworks_py_library> [<lib_dir_1> ... <lib_dir_n>]"
@@ -12,7 +14,11 @@ if ! pip install Python/shapeworks; then exit -1; fi
 PYTHON_LIBRARY=$1; shift
 CONDA_INSTALL_DIR=`pip show shapeworks | grep Location | awk '{print $2}'`/shapeworks
 
-# install shapeworks_py, compiled portion of package
+# copy shapeworks_py library to conda install dir
+cp "${PYTHON_LIBRARY}" "${CONDA_INSTALL_DIR}"
+PYTHON_LIBRARY="${CONDA_INSTALL_DIR}/`basename ${PYTHON_LIBRARY}`"
+
+# update runpaths for shapeworks_py, compiled portion of package
 if [[ "$(uname)" == "Linux" ]]; then
 
     # if unspecified, use package path from github action (see package.sh)
@@ -55,6 +61,3 @@ else
     echo "Unknown operating system: ${uname}"
     exit 1
 fi
-
-# move shapeworks_py library to conda install dir
-mv "${PYTHON_LIBRARY}" "${CONDA_INSTALL_DIR}"


### PR DESCRIPTION
- install python module by copying cython and company to the conda install path; 
- no longer need PYTHONPATH to import shapeworks