### PR TITLE
Add OSX preinstall script to remove /Application/ShapeWorks

### DIFF
--- a/Support/osxscripts/preinstall
+++ b/Support/osxscripts/preinstall
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "ShapeWorks preinstall"
+env
+echo "Removing previous ShapeWorks install"
+rm -rf /Application/ShapeWorks

--- a/Support/package.sh
+++ b/Support/package.sh
@@ -145,7 +145,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     cp ${ROOT}/docs/users/Mac_README.txt ${VERSION}/README.txt
     pkgbuild --quiet --analyze --root ${VERSION} ShapeWorks.plist
     plutil -replace BundleIsRelocatable -bool NO ShapeWorks.plist
-    pkgbuild --component-plist ShapeWorks.plist --install-location /Applications/ShapeWorks --root ${VERSION} --identifier edu.utah.sci.shapeworks ${ROOT}/artifacts/${VERSION}.pkg
+    pkgbuild --component-plist ShapeWorks.plist --install-location /Applications/ShapeWorks --root ${VERSION} --identifier edu.utah.sci.shapeworks ${ROOT}/artifacts/${VERSION}.pkg --scripts ${ROOT}/Support/osxscripts
 fi
 
 cd $ROOT


### PR DESCRIPTION
Address #1296.

This won't work if the user hasn't installed it on their main volume.  I'm wary of using the undocumented $DSTROOT which seems to point to the right place, but without guarantees I don't want to remove it if it could be wrong.