### PR TITLE
build windows 

### DIFF
--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -315,7 +315,13 @@ show_shapeworks_build()
     FINDQT="-DQt5_DIR=`qmake -query QT_INSTALL_PREFIX`"
   fi
 
-  echo "cmake -DCMAKE_PREFIX_PATH=${INSTALL_DIR} ${OPENMP_FLAG} -DBuild_Studio=${BUILD_GUI} ${FIND_QT} -Wno-dev -Wno-deprecated -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${SRC}"
+  _VXL_DIR=""
+  if [[ $OSTYPE == "msys" ]]; then
+      # since VXL built in INSTALL_DIR on Windows, need to tell CMake where to find it
+      _VXL_DIR="-DVXL_DIR=${VXL_DIR}"
+  fi
+
+  echo "cmake -DCMAKE_PREFIX_PATH=${INSTALL_DIR} ${_VXL_DIR} ${OPENMP_FLAG} -DBuild_Studio=${BUILD_GUI} ${FIND_QT} -Wno-dev -Wno-deprecated -DCMAKE_BUILD_TYPE=${BUILD_TYPE} ${SRC}"
 }
 
 # determine if we can build using the specified or discovered version of Qt

--- a/docs/dev/build.md
+++ b/docs/dev/build.md
@@ -186,7 +186,17 @@ open ShapeWorks.xcodeproj
 
 ### Windows
 
-Use the cmake from the Anaconda Prompt with shapeworks env activated to configure and generate project files for your preferred build system (e.g., Visual Studio 16 2019).  
+Use the cmake from the Anaconda Prompt with shapeworks env activated to configure and generate project files for your preferred build system (e.g., Visual Studio 16 2019). Like with all the other platforms, after running `build_dependencies.sh` a suggested cmake command is printed. Create a build directory and use it.  
+
+#### Examples
+An example that builds dependencies separately then generates a Visual Studio project for ShapeWorks (note that by default a Visual Studio project will be created):  
+```
+> conda activate shapeworks
+> ./build_dependencies.sh --build-dir=../dependencies --install-dir=../dependencies
+> mkdir build
+> cd build
+> cmake -G"Visual Studio 16 2019" -Ax64 -DVXL_DIR=../dependencies/vxl/build -DCMAKE_PREFIX_PATH=../dependencies -DBuild_Post:BOOL=ON -DBuild_View2:BOOL=ON -DBuild_Studio:BOOL=ON ..
+```
 
 #### Options
 Required:  
@@ -207,12 +217,8 @@ Optional:
   -D CMAKE_BUILD_TYPE=[Debug|Release]  
 ```
 
-#### Examples
-An example that builds dependencies separately then generates a Visual Studio project for ShapeWorks:  
-```
-> conda activate shapeworks
-> ./build_dependencies.sh --build-dir=../dependencies --install-dir=../dependencies
-> mkdir build
-> cd build
-> cmake -G"Visual Studio 16 2019" -Ax64 -DVXL_DIR=../dependencies/vxl/build -DCMAKE_PREFIX_PATH=../dependencies -DBuild_Post:BOOL=ON -DBuild_View2:BOOL=ON -DBuild_Studio:BOOL=ON ..
-```
+After cmake the Visual Studio solution can be opened with `start ShapeWorks.sln` from the build directory.
+
+!!! important "RelWithDebInfo only"
+    Currently it's only possible to build **RelWithDebInfo** on Windows.
+    


### PR DESCRIPTION
- provide complete Windows build command when build_dependencies.sh finishes; 
- update build instructions in docs

I validated the modifications to build_dependencies.sh, that show Windows build instructions upon completion, work correctly by running it again on Windows.