### PR TITLE
Move to Ubuntu 16 docker image

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,0 +1,48 @@
+FROM ubuntu:xenial-20210429 AS env
+MAINTAINER akenmorris@gmail.com
+
+
+RUN apt-get update -y && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get install build-essential software-properties-common -y && add-apt-repository ppa:ubuntu-toolchain-r/test -y && apt-get update -y
+RUN apt-get install gcc-9 g++-9 -y
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9 && update-alternatives --config gcc
+
+ENV PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get install git curl -y
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+RUN apt-get install git-lfs -y
+
+
+RUN which git
+RUN which git-lfs
+
+RUN curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -o /tmp/Miniconda3-latest-Linux-x86_64.sh \
+    && bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda \
+    && ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh \
+    && conda update -n base -c defaults conda \
+    && conda install pip \
+    && echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc \
+    && echo "conda activate base" >> ~/.bashrc
+
+RUN pip3 install --upgrade aqtinstall setuptools
+
+RUN apt-get install rsync freeglut3-dev -y
+
+ARG QT=5.9.9
+ARG QT_HOST=linux
+ARG QT_TARGET=desktop
+RUN aqt install --outputdir /opt/qt ${QT} ${QT_HOST} ${QT_TARGET} -m all \
+    && rsync -qabuP /opt/qt/${QT}/gcc_64/ /usr/local/
+
+ENV PATH=/opt/conda/bin:/hbb_shlib/bin:/hbb/bin:/opt/rh/devtoolset-9/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+ENV LDFLAGS=-L/opt/conda/lib
+
+# Get and decompress linuxdeployqt, it's complicated to use fuse with docker due to the kernel module
+RUN curl -L -o $HOME/linuxdeployqt.AppImage https://github.com/probonopd/linuxdeployqt/releases/download/5/linuxdeployqt-5-x86_64.AppImage && chmod +x $HOME/linuxdeployqt.AppImage ; cd $HOME ; ./linuxdeployqt.AppImage --appimage-extract
+
+RUN add-apt-repository ppa:git-core/ppa
+RUN apt-get update
+RUN apt-get upgrade git -y
+RUN git --version
+RUN apt-get install zip -y

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release_v*
+      - gha_docker2
     tags:
     - '*'
   pull_request:
@@ -19,35 +20,10 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
+    container: akenmorris/ubuntu-build-box
     
     steps:
-
-    - name: Choose gcc 9
-      run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
-
-    - name: Acquire LinuxDeployQt
-      run: curl -L -o $HOME/linuxdeployqt https://github.com/probonopd/linuxdeployqt/releases/download/5/linuxdeployqt-5-x86_64.AppImage && chmod +x $HOME/linuxdeployqt
-    
-    - name: Prepare ccache timestamp
-      id: ccache_cache_timestamp
-      shell: cmake -P {0}
-      run: |
-        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
-
-    - name: ccache cache files
-      uses: actions/cache@v1.1.0
-      with:
-        path: ~/.ccache
-        key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
-        restore-keys: |
-          ${{ runner.os }}-ccache-
-    
-    - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2.0.0
-      with:
-          miniconda-version: 'latest'
 
     - name: Conda info
       run: conda info
@@ -68,26 +44,12 @@ jobs:
       shell: bash -l {0}
       run: conda activate shapeworks && conda install -c conda-forge ccache=3.7.7
 
-    - name: Cache Qt
-      id: cache-qt
-      uses: actions/cache@v1
-      with:
-        path: ../Qt
-        key: QtCache-linux
-
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v2.13.0
-      with:
-        version: "5.9.9"
-        mirror: 'http://mirrors.ocf.berkeley.edu/qt/'
-        cached: ${{ steps.cache-qt.outputs.cache-hit }}
-
     - name: Cache dependencies
       id: cache-dependencies
       uses: actions/cache@v1
       with:
         path: ~/install
-        key: ${{ runner.os }}-ub16-${{ hashFiles('**/build_dependencies.sh') }}
+        key: ${{ runner.os }}-docker-ub16-${{ hashFiles('**/build_dependencies.sh') }}
 
     - name: Build dependencies
       shell: bash -l {0}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -15,7 +15,7 @@ env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: RelWithDebInfo
   SW_PORTAL_LOGIN: ${{ secrets.PORTAL_LOGIN }}
-  LD_LIBRARY_PATH: /usr/share/miniconda3/envs/shapeworks/lib
+  LD_LIBRARY_PATH: /opt/conda/envs/shapeworks/lib
     
 jobs:
   build:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -69,7 +69,7 @@ jobs:
       run: conda activate shapeworks && cd build && make install
       
     - name: Remove Qt SQL Stuff
-      run: mv /home/runner/work/ShapeWorks/Qt/5.9.9/gcc_64/plugins/sqldrivers/libqsqlmysql.so /home/runner/work/ShapeWorks/Qt/5.9.9/gcc_64/plugins/sqldrivers/libqsqlpsql.so /tmp
+      run: mv /usr/local/plugins/sqldrivers/libqsqlmysql.so /usr/local/plugins/sqldrivers/libqsqlmysql.solibqsqlpsql.so /tmp
 
     - name: Build Binary Package
       shell: bash -l {0}
@@ -82,7 +82,7 @@ jobs:
       run: conda activate shapeworks && source ./devenv.sh ./build/bin && cd build && ctest -VV
   
     - name: Replace Qt SQL Stuff
-      run: mv /tmp/lib*.so /home/runner/work/ShapeWorks/Qt/5.9.9/gcc_64/plugins/sqldrivers/
+      run: mv /tmp/lib*.so /usr/local/plugins/sqldrivers
 
     - name: ccache statistics
       shell: bash -l {0}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - release_v*
-      - gha_docker2
+      - gha-docker2
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -69,7 +69,7 @@ jobs:
       run: conda activate shapeworks && cd build && make install
       
     - name: Remove Qt SQL Stuff
-      run: mv /usr/local/plugins/sqldrivers/libqsqlmysql.so /usr/local/plugins/sqldrivers/libqsqlmysql.solibqsqlpsql.so /tmp
+      run: mv /usr/local/plugins/sqldrivers/libqsqlmysql.so /usr/local/plugins/sqldrivers/libqsqlpsql.so /tmp
 
     - name: Build Binary Package
       shell: bash -l {0}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release_v*
-      - gha-docker2
     tags:
     - '*'
   pull_request:


### PR DESCRIPTION
Ubuntu 16 GitHub Action Runner will be removed in September 2021.  This PR switches to ubuntu-latest runner but using a specially made Ubuntu 16 docker image (Dockerfile included).