### PR TITLE
Fix crash #1405

### DIFF
--- a/Libs/Mesh/MeshWarper.cpp
+++ b/Libs/Mesh/MeshWarper.cpp
@@ -193,6 +193,7 @@ void MeshWarper::add_particle_vertices()
       }
     }
   }
+  this->reference_mesh_->RemoveDeletedCells();
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Mesh/MeshWarper.cpp
+++ b/Libs/Mesh/MeshWarper.cpp
@@ -168,9 +168,6 @@ void MeshWarper::add_particle_vertices()
 
         // split the current cell into two triangles
         this->split_cell_on_edge(cell_id, new_vertex, v0_index, v1_index);
-
-        this->reference_mesh_->RemoveDeletedCells();
-
       }
       else {
         vtkSmartPointer<vtkIdList> list = vtkSmartPointer<vtkIdList>::New();
@@ -193,8 +190,6 @@ void MeshWarper::add_particle_vertices()
         this->reference_mesh_->InsertNextCell(VTK_TRIANGLE, list);
 
         this->reference_mesh_->DeleteCell(cell_id);
-        this->reference_mesh_->RemoveDeletedCells();
-
       }
     }
   }


### PR DESCRIPTION
No longer calling RemoveDeletedCells.  We don't seem to need it and it appears to be crashing sometimes (#1405)

Looking at the code and the crash, it appears to me that an array is
attempting to be copied from the old poly data to the new one, but
they have different numbers of points.