### PR TITLE
Studio Updates

### DIFF
--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -282,6 +282,17 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize)
     throw std::invalid_argument("No subjects to optimize");
   }
 
+  // landmarks/point files
+  std::vector<std::string> point_files;
+
+  for (auto s : subjects) {
+    auto landmarks = s->get_landmarks_filenames();
+    point_files.insert(std::end(point_files), std::begin(landmarks), std::end(landmarks));
+  }
+  if (point_files.size() > 0) {
+    optimize->SetPointFiles(point_files);
+  }
+
   // passing cutting plane constraints
   // planes dimensions [number_of_inputs, planes_per_input, normal/point]
   std::vector<std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d> > > planes = optimize->GetSampler()->ComputeCuttingPlanes();

--- a/Libs/Optimize/ParticleSystem/MemoryUsage.cxx
+++ b/Libs/Optimize/ParticleSystem/MemoryUsage.cxx
@@ -52,4 +52,10 @@ void process_mem_usage(double& vm_usage, double& resident_set)
   vm_usage     = vsize / 1024.0;
   resident_set = rss * page_size_kb;
 }
+#else // LOG_MEMORY_USAGE
+
+void process_mem_usage(double& vm_usage, double& resident_set) {
+
+}
+
 #endif // LOG_MEMORY_USAGE

--- a/Libs/Optimize/ParticleSystem/MemoryUsage.h
+++ b/Libs/Optimize/ParticleSystem/MemoryUsage.h
@@ -4,6 +4,4 @@
 // Disabled by default because this code is *nix specific.
 // #define LOG_MEMORY_USAGE
 
-#ifdef LOG_MEMORY_USAGE
 void process_mem_usage(double& vm_usage, double& resident_set);
-#endif

--- a/Libs/Project/Project.cpp
+++ b/Libs/Project/Project.cpp
@@ -209,6 +209,7 @@ void Project::load_subjects()
   auto world_particle_columns = this->get_matching_columns(WORLD_PARTICLES);
   auto image_columns = this->get_matching_columns(IMAGE_PREFIX);
   auto name_column = this->get_index_for_column(NAME);
+  auto landmarks_columns = this->get_matching_columns(LANDMARKS_FILE_PREFIX);
 
   auto extra_columns = this->get_extra_columns();
 
@@ -218,6 +219,7 @@ void Project::load_subjects()
     subject->set_number_of_domains(this->num_domains_per_subject_);
     subject->set_segmentation_filenames(this->get_list(seg_columns, i));
     subject->set_groomed_filenames(this->get_list(groomed_columns, i));
+    subject->set_landmarks_filenames(this->get_list(landmarks_columns, i));
     subject->set_groomed_transforms(this->get_transform_list(groomed_transform_columns, i));
     subject->set_procrustes_transforms(this->get_transform_list(procrustes_transform_columns, i));
     subject->set_image_filenames(this->get_list(image_columns, i));
@@ -283,6 +285,7 @@ void Project::store_subjects()
   // segmentation columns
   auto seg_columns = this->get_matching_columns(this->input_prefixes_);
   auto image_columns = this->get_matching_columns(IMAGE_PREFIX);
+  auto landmarks_columns = this->get_matching_columns(LANDMARKS_FILE_PREFIX);
 
   // groomed columns
   std::vector<std::string> groomed_columns;
@@ -311,6 +314,7 @@ void Project::store_subjects()
                                                                PROCRUSTES_TRANSFORMS_PREFIX);
     procrustes_transform_columns.push_back(procrustes_transform_column_name);
   }
+
 
   // local and world particle columns
   std::vector<std::string> local_columns;
@@ -361,6 +365,9 @@ void Project::store_subjects()
       this->set_transform_list(groomed_transform_columns, i, subject->get_groomed_transforms());
       this->set_transform_list(procrustes_transform_columns, i, subject->get_procrustes_transforms());
     }
+
+    // landmarks
+    this->set_list(landmarks_columns, i, subject->get_landmarks_filenames());
 
     // features
     auto features = subject->get_feature_filenames();

--- a/Libs/Project/Project.h
+++ b/Libs/Project/Project.h
@@ -121,6 +121,7 @@ private:
   static constexpr const char* GROUP_PREFIX = "group_";
   static constexpr const char* IMAGE_PREFIX = "image_";
   static constexpr const char* NAME = "name";
+  static constexpr const char* LANDMARKS_FILE_PREFIX = "landmarks_file_";
 
   std::vector<std::string> get_list(std::vector<std::string> columns, int subject);
   void set_list(std::vector<std::string> columns, int subject, std::vector<std::string> values);

--- a/Libs/Project/Subject.cpp
+++ b/Libs/Project/Subject.cpp
@@ -183,6 +183,18 @@ std::vector<std::string> Subject::get_world_particle_filenames()
 }
 
 //---------------------------------------------------------------------------
+void Subject::set_landmarks_filenames(std::vector<std::string> filenames)
+{
+  this->landmarks_filenames_ = filenames;
+}
+
+//---------------------------------------------------------------------------
+std::vector<std::string> Subject::get_landmarks_filenames()
+{
+  return this->landmarks_filenames_;
+}
+
+//---------------------------------------------------------------------------
 void Subject::set_image_filenames(std::vector<std::string> filenames)
 {
   this->image_filenames_ = filenames;

--- a/Libs/Project/Subject.h
+++ b/Libs/Project/Subject.h
@@ -44,6 +44,11 @@ public:
   //! Get the world particle filenames
   std::vector<std::string> get_world_particle_filenames();
 
+  //! Get the landmarks filenames (one per domain)
+  void set_landmarks_filenames(std::vector<std::string> filenames);
+  //! Set the landmarks filenames
+  std::vector<std::string> get_landmarks_filenames();
+
   //! Set the number of domains
   void set_number_of_domains(int number_of_domains);
   //! Get the number of domains
@@ -96,6 +101,7 @@ private:
   std::vector<std::string> groomed_filenames_;
   std::vector<std::string> local_particle_filenames_;
   std::vector<std::string> world_particle_filenames_;
+  std::vector<std::string> landmarks_filenames_;
   std::vector<std::vector<double>> groomed_transforms_;
   std::vector<std::vector<double>> procrustes_transforms_;
 

--- a/Python/shapeworks/shapeworks/utils.py
+++ b/Python/shapeworks/shapeworks/utils.py
@@ -142,6 +142,9 @@ def compute_line_indices(n, is_closed=True):
 
     return lines
 
+def get_api_version():
+    return "6.2"
+
 def set_sw_logger(log_object):
     """Set the shapeworks logger object"""
     global sw_logger

--- a/Studio/src/Data/Preferences.h
+++ b/Studio/src/Data/Preferences.h
@@ -32,8 +32,9 @@ public:
 
   void restore_defaults();
 
-  void add_recent_file(QString file);
+  void add_recent_file(QString file, QString path);
   QStringList get_recent_files();
+  QStringList get_recent_paths();
 
   bool not_saved();
   void set_saved(bool saved = true);
@@ -106,6 +107,10 @@ Q_SIGNALS:
   void sliders_changed_signal();
 
 private:
+
+  void update_recent_files();
+  QStringList recent_files_;
+  QStringList recent_paths_;
 
   QSettings settings_;
   bool saved_ = true;

--- a/Studio/src/Data/Session.cpp
+++ b/Studio/src/Data/Session.cpp
@@ -654,7 +654,7 @@ bool Session::update_particles(std::vector<StudioParticles> particles)
 }
 
 //---------------------------------------------------------------------------
-bool Session::update_procrustes_transforms(std::vector<std::vector<std::vector<double>>> transforms)
+void Session::update_procrustes_transforms(std::vector<std::vector<std::vector<double>>> transforms)
 {
   for (size_t i=0;i<transforms.size();i++) {
     if (this->shapes_.size() > i) {
@@ -901,6 +901,52 @@ void Session::clear_particles()
 {
   std::vector<StudioParticles> particles(this->get_num_shapes());
   this->update_particles(particles);
+}
+
+//---------------------------------------------------------------------------
+bool Session::get_feature_auto_scale()
+{
+  return this->params_.get("feature_auto_scale", true);
+}
+
+//---------------------------------------------------------------------------
+void Session::set_feature_auto_scale(bool value)
+{
+  this->params_.set("feature_auto_scale", value);
+  emit feature_range_changed();
+}
+
+//---------------------------------------------------------------------------
+double Session::get_feature_range_max()
+{
+  return this->params_.get("feature_range_max", 0);
+}
+
+//---------------------------------------------------------------------------
+double Session::get_feature_range_min()
+{
+  return this->params_.get("feature_range_min", 0);
+}
+
+//---------------------------------------------------------------------------
+void Session::set_feature_range(double min, double max)
+{
+  this->set_feature_range_min(min);
+  this->set_feature_range_max(max);
+}
+
+//---------------------------------------------------------------------------
+void Session::set_feature_range_min(double value)
+{
+  this->params_.set("feature_range_min", value);
+  emit feature_range_changed();
+}
+
+//---------------------------------------------------------------------------
+void Session::set_feature_range_max(double value)
+{
+  this->params_.set("feature_range_max", value);
+  emit feature_range_changed();
 }
 
 }

--- a/Studio/src/Data/Session.h
+++ b/Studio/src/Data/Session.h
@@ -72,7 +72,7 @@ public:
 
   bool update_particles(std::vector<StudioParticles> particles);
 
-  bool update_procrustes_transforms(std::vector<std::vector<std::vector<double>>> transforms);
+  void update_procrustes_transforms(std::vector<std::vector<std::vector<double>>> transforms);
 
   bool is_light_project();
 
@@ -120,7 +120,17 @@ public:
   //! clear particles from session (e.g. groom start, optimize start)
   void clear_particles();
 
+  bool get_feature_auto_scale();
+
+  double get_feature_range_max();
+  double get_feature_range_min();
+  void set_feature_range(double min, double max);
+  void set_feature_range_min(double value);
+  void set_feature_range_max(double value);
+
 public Q_SLOTS:
+  void set_feature_auto_scale(bool value);
+
   void handle_clear_cache();
   void handle_new_mesh();
   void handle_message(QString s);
@@ -134,6 +144,7 @@ signals:
   void new_mesh();
   void message(QString);
   void error(QString);
+  void feature_range_changed();
 
 public:
   // constants

--- a/Studio/src/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Interface/ShapeWorksStudioApp.cpp
@@ -89,7 +89,7 @@ ShapeWorksStudioApp::ShapeWorksStudioApp()
   connect(this->py_worker_.data(), &PythonWorker::error_message,
           this, &ShapeWorksStudioApp::handle_error);
 
-#if defined( Q_OS_LINUX )
+#if defined(Q_OS_LINUX)
   this->ui_->action_show_project_folder->setVisible(false);
 #endif
 
@@ -98,7 +98,7 @@ ShapeWorksStudioApp::ShapeWorksStudioApp()
           &ShapeWorksStudioApp::open_project);
 
   this->wheel_event_forwarder_ = QSharedPointer<WheelEventForwarder>
-    (new WheelEventForwarder(this->ui_->vertical_scroll_bar));
+                                   (new WheelEventForwarder(this->ui_->vertical_scroll_bar));
   this->ui_->qvtkWidget->installEventFilter(this->wheel_event_forwarder_.data());
 
   // set the splitter ratio
@@ -184,7 +184,6 @@ ShapeWorksStudioApp::ShapeWorksStudioApp()
           this, &ShapeWorksStudioApp::handle_progress);
   connect(this->deepssm_tool_.data(), &DeepSSMTool::update_view, this,
           &ShapeWorksStudioApp::handle_display_setting_changed);
-
 
   // resize from preferences
   if (!this->preferences_.get_window_geometry().isEmpty()) {
@@ -299,7 +298,6 @@ ShapeWorksStudioApp::ShapeWorksStudioApp()
   connect(this->ui_->actionKeyboard_Shortcuts, &QAction::triggered, this,
           &ShapeWorksStudioApp::keyboard_shortcuts);
 
-
   this->handle_message("ShapeWorks Studio Initialized");
 }
 
@@ -390,8 +388,8 @@ void ShapeWorksStudioApp::on_action_show_project_folder_triggered()
   process.setReadChannelMode(QProcess::MergedChannels);
 
 #ifdef _WIN32
-  qstring_path = qstring_path.replace( QString( "/" ), QString( "\\" ) );
-    process.start( "explorer.exe", QStringList() << qstring_path );
+  qstring_path = qstring_path.replace(QString("/"), QString("\\"));
+  process.start("explorer.exe", QStringList() << qstring_path);
 #else
   process.start("open", QStringList() << "-R" << filename);
 #endif
@@ -510,7 +508,6 @@ void ShapeWorksStudioApp::import_files(QStringList file_names)
       // On first load, we can check if there was an active scalar on loaded meshes
       this->set_feature_map(this->session_->get_default_feature_map());
     }
-
   } catch (std::runtime_error e) {
     this->handle_error(e.what());
   }
@@ -716,7 +713,6 @@ void ShapeWorksStudioApp::update_table()
   this->ui_->table->horizontalHeader()->setStretchLastSection(false);
   this->ui_->table->setSelectionBehavior(QAbstractItemView::SelectRows);
 
-
   /// todo: check if the list has changed before changing
   auto current_feature = this->ui_->features->currentText();
   this->ui_->features->clear();
@@ -731,7 +727,6 @@ void ShapeWorksStudioApp::update_table()
   this->ui_->feature_uniform_scale->setChecked(this->get_feature_uniform_scale());
 
   this->ui_->feature_widget->setVisible(feature_maps.size() > 0);
-
 }
 
 //---------------------------------------------------------------------------
@@ -826,7 +821,6 @@ void ShapeWorksStudioApp::handle_new_mesh()
   }
 
   this->deepssm_tool_->handle_new_mesh();
-
 }
 
 //---------------------------------------------------------------------------
@@ -884,6 +878,10 @@ void ShapeWorksStudioApp::update_tool_mode()
 
   this->analysis_tool_->set_active(tool_state == Session::ANALYSIS_C);
 
+  for (int i = 0; i < this->ui_->stacked_widget->count(); i++) {
+    this->ui_->stacked_widget->widget(i)->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
+  }
+
   if (tool_state == Session::ANALYSIS_C) {
     this->ui_->stacked_widget->setCurrentWidget(this->analysis_tool_.data());
     this->ui_->controlsDock->setWindowTitle("Analysis");
@@ -922,6 +920,10 @@ void ShapeWorksStudioApp::update_tool_mode()
     this->ui_->controlsDock->setWindowTitle("Data");
     this->ui_->action_import_mode->setChecked(true);
   }
+
+  this->ui_->stacked_widget->widget(this->ui_->stacked_widget->currentIndex())->setSizePolicy(QSizePolicy::Preferred,
+                                                                                              QSizePolicy::Preferred);
+  this->ui_->stacked_widget->adjustSize();
 
   this->on_actionShow_Tool_Window_triggered();
 }
@@ -1050,7 +1052,6 @@ void ShapeWorksStudioApp::handle_points_changed()
     this->last_render_ = render_time.elapsed();
     this->time_since_last_update_.start();
   }
-
 }
 
 //---------------------------------------------------------------------------
@@ -1211,7 +1212,8 @@ void ShapeWorksStudioApp::update_display(bool force)
     auto deep_ssm_feature = this->deepssm_tool_->get_display_feature();
     if (deep_ssm_feature == "") {
       this->set_feature_map("");
-    } else {
+    }
+    else {
       this->set_feature_map("");
       this->set_feature_map(deep_ssm_feature);
     }
@@ -1273,7 +1275,6 @@ void ShapeWorksStudioApp::update_display(bool force)
                                           this->session_->particles_present() &&
                                           reconstruct_ready);
       } //TODO regression?
-
     }
   }
 
@@ -1344,7 +1345,6 @@ void ShapeWorksStudioApp::open_project(QString filename)
 
   this->update_tool_mode();
 
-
   // set the zoom state
   //this->ui_->thumbnail_size_slider->setValue(
   //  this->preferences_.get_preference("zoom_state", 1));
@@ -1367,7 +1367,7 @@ void ShapeWorksStudioApp::open_project(QString filename)
   this->ui_->zoom_slider->setValue(zoom_value);
 
   this->ui_->notes->setText(QString::fromStdString(
-    this->session_->parameters().get("notes", "")));
+                              this->session_->parameters().get("notes", "")));
 
   this->block_update_ = false;
   this->update_display(true);
@@ -1395,7 +1395,6 @@ void ShapeWorksStudioApp::open_project(QString filename)
 
   this->handle_progress(100);
   this->handle_message("Project loaded: " + filename);
-
 }
 
 //---------------------------------------------------------------------------
@@ -1412,7 +1411,7 @@ void ShapeWorksStudioApp::on_action_export_current_mesh_triggered()
   auto dir = preferences_.get_last_directory() + "/";
   QString filename = QFileDialog::getSaveFileName(this, tr("Export Current Mesh"),
                                                   dir + "mesh", tr(
-      "Supported types (*.vtk *.ply *.vtp *.obj *.stl)"));
+                                                    "Supported types (*.vtk *.ply *.vtp *.obj *.stl)"));
   if (filename.isEmpty()) {
     return;
   }
@@ -1454,8 +1453,7 @@ bool ShapeWorksStudioApp::write_mesh(vtkSmartPointer<vtkPolyData> poly_data, QSt
   try {
     Mesh mesh(poly_data);
     mesh.write(filename.toStdString());
-  }
-  catch (std::exception& e) {
+  } catch (std::exception& e) {
     this->handle_error(e.what());
     return false;
   }
@@ -1533,7 +1531,6 @@ void ShapeWorksStudioApp::on_action_export_current_particles_triggered()
       this->handle_error("Error writing particle file: " + filename);
     }
     this->handle_message("Wrote: " + filename);
-
   }
   else {
 
@@ -1555,7 +1552,6 @@ void ShapeWorksStudioApp::on_action_export_current_particles_triggered()
       this->handle_message("Wrote: " + name);
     }
   }
-
 }
 
 //---------------------------------------------------------------------------
@@ -1600,7 +1596,6 @@ void ShapeWorksStudioApp::on_action_export_mesh_scalars_triggered()
       this->handle_message("Wrote: " + name);
     }
   }
-
 }
 
 //---------------------------------------------------------------------------
@@ -1738,7 +1733,6 @@ void ShapeWorksStudioApp::save_project(std::string filename)
 
   this->update_table();
   this->setWindowTitle(this->session_->get_display_name());
-
 }
 
 //---------------------------------------------------------------------------
@@ -1865,7 +1859,7 @@ void ShapeWorksStudioApp::on_actionExport_PCA_Mode_Points_triggered()
                                                   QString::fromStdString(dir) + fname,
                                                   tr("Particle files (*.particles)"));
   auto basename = filename.toStdString().
-    substr(0, filename.toStdString().find_last_of(".particles") - 9);
+                  substr(0, filename.toStdString().find_last_of(".particles") - 9);
   if (filename.isEmpty()) {
     return;
   }
@@ -2127,11 +2121,5 @@ QSharedPointer<PythonWorker> ShapeWorksStudioApp::get_py_worker()
   return this->py_worker_;
 }
 
-
-
-
-
 //---------------------------------------------------------------------------
-
 }
-

--- a/Studio/src/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Interface/ShapeWorksStudioApp.cpp
@@ -104,53 +104,7 @@ ShapeWorksStudioApp::ShapeWorksStudioApp()
   // set the splitter ratio
   this->ui_->data_splitter->setSizes(QList<int>({INT_MAX, INT_MAX}));
 
-  // Glyph options in the render window.
-  QMenu* menu = new QMenu();
-  QWidget* widget = new QWidget();
-  QGridLayout* layout = new QGridLayout(widget);
-
-  QLabel* size_label = new QLabel("Glyph Size: ");
-  layout->addWidget(size_label, 0, 0, 1, 1);
-  size_label = new QLabel("Glyph Detail: ");
-  layout->addWidget(size_label, 1, 0, 1, 1);
-
-  this->glyph_quality_label_ = new QLabel("....");
-  this->glyph_quality_label_->setMinimumWidth(50);
-  this->glyph_size_label_ = new QLabel("....");
-  this->glyph_size_label_->setMinimumWidth(50);
-  layout->addWidget(this->glyph_size_label_, 0, 1, 1, 1);
-  layout->addWidget(this->glyph_quality_label_, 1, 1, 1, 1);
-
-  this->glyph_size_slider_ = new QSlider(widget);
-  this->glyph_size_slider_->setOrientation(Qt::Horizontal);
-  this->glyph_size_slider_->setMinimum(1);
-  this->glyph_size_slider_->setMaximum(100);
-  this->glyph_size_slider_->setPageStep(10);
-  this->glyph_size_slider_->setTickPosition(QSlider::TicksBelow);
-  this->glyph_size_slider_->setTickInterval(10);
-  this->glyph_size_slider_->setMinimumWidth(200);
-
-  this->glyph_auto_size_ = new QCheckBox("Auto");
-
-  this->glyph_quality_slider_ = new QSlider(widget);
-  this->glyph_quality_slider_->setMinimum(1);
-  this->glyph_quality_slider_->setMaximum(20);
-  this->glyph_quality_slider_->setPageStep(3);
-  this->glyph_quality_slider_->setOrientation(Qt::Horizontal);
-  this->glyph_quality_slider_->setTickPosition(QSlider::TicksBelow);
-  this->glyph_quality_slider_->setTickInterval(1);
-  this->glyph_quality_slider_->setMinimumWidth(200);
-  this->ui_->glyphs_visible_button->setMenu(menu);
-
-  layout->addWidget(this->glyph_size_slider_, 0, 2, 1, 1);
-  layout->addWidget(this->glyph_auto_size_, 0, 3, 1, 1);
-  layout->addWidget(this->glyph_quality_slider_, 1, 2, 1, 1);
-  widget->setLayout(layout);
-
-  QWidgetAction* widget_action = new QWidgetAction(widget);
-  widget_action->setDefaultWidget(widget);
-  menu->addAction(widget_action);
-
+  this->create_glyph_submenu();
   //analysis tool initializations
   this->analysis_tool_ = QSharedPointer<AnalysisTool>::create(preferences_);
   this->analysis_tool_->set_app(this);
@@ -807,6 +761,57 @@ void ShapeWorksStudioApp::set_message(MessageType message_type, QString message)
 }
 
 //---------------------------------------------------------------------------
+void ShapeWorksStudioApp::create_glyph_submenu()
+{
+  // Glyph options in the render window.
+  QMenu* menu = new QMenu();
+  QWidget* widget = new QWidget();
+  QGridLayout* layout = new QGridLayout(widget);
+
+  QLabel* size_label = new QLabel("Glyph Size: ");
+  layout->addWidget(size_label, 0, 0, 1, 1);
+  size_label = new QLabel("Glyph Detail: ");
+  layout->addWidget(size_label, 1, 0, 1, 1);
+
+  this->glyph_quality_label_ = new QLabel("....");
+  this->glyph_quality_label_->setMinimumWidth(50);
+  this->glyph_size_label_ = new QLabel("....");
+  this->glyph_size_label_->setMinimumWidth(50);
+  layout->addWidget(this->glyph_size_label_, 0, 1, 1, 1);
+  layout->addWidget(this->glyph_quality_label_, 1, 1, 1, 1);
+
+  this->glyph_size_slider_ = new QSlider(widget);
+  this->glyph_size_slider_->setOrientation(Qt::Horizontal);
+  this->glyph_size_slider_->setMinimum(1);
+  this->glyph_size_slider_->setMaximum(100);
+  this->glyph_size_slider_->setPageStep(10);
+  this->glyph_size_slider_->setTickPosition(QSlider::TicksBelow);
+  this->glyph_size_slider_->setTickInterval(10);
+  this->glyph_size_slider_->setMinimumWidth(200);
+
+  this->glyph_auto_size_ = new QCheckBox("Auto");
+
+  this->glyph_quality_slider_ = new QSlider(widget);
+  this->glyph_quality_slider_->setMinimum(1);
+  this->glyph_quality_slider_->setMaximum(20);
+  this->glyph_quality_slider_->setPageStep(3);
+  this->glyph_quality_slider_->setOrientation(Qt::Horizontal);
+  this->glyph_quality_slider_->setTickPosition(QSlider::TicksBelow);
+  this->glyph_quality_slider_->setTickInterval(1);
+  this->glyph_quality_slider_->setMinimumWidth(200);
+
+  layout->addWidget(this->glyph_size_slider_, 0, 2, 1, 1);
+  layout->addWidget(this->glyph_auto_size_, 0, 3, 1, 1);
+  layout->addWidget(this->glyph_quality_slider_, 1, 2, 1, 1);
+  widget->setLayout(layout);
+
+  QWidgetAction* widget_action = new QWidgetAction(widget);
+  widget_action->setDefaultWidget(widget);
+  menu->addAction(widget_action);
+  this->ui_->glyphs_visible_button->setMenu(menu);
+}
+
+//---------------------------------------------------------------------------
 void ShapeWorksStudioApp::handle_new_mesh()
 {
   this->visualizer_->handle_new_mesh();
@@ -862,8 +867,10 @@ void ShapeWorksStudioApp::new_session()
 
   connect(this->ui_->feature_auto_scale, &QCheckBox::toggled, this, &ShapeWorksStudioApp::update_feature_map_scale);
   connect(this->ui_->feature_auto_scale, &QCheckBox::toggled, this->session_.data(), &Session::set_feature_auto_scale);
-  connect(this->ui_->feature_min, qOverload<double>(&QDoubleSpinBox::valueChanged), this->session_.data(), &Session::set_feature_range_min);
-  connect(this->ui_->feature_max, qOverload<double>(&QDoubleSpinBox::valueChanged), this->session_.data(), &Session::set_feature_range_max);
+  connect(this->ui_->feature_min, qOverload<double>(&QDoubleSpinBox::valueChanged),
+          this->session_.data(), &Session::set_feature_range_min);
+  connect(this->ui_->feature_max, qOverload<double>(&QDoubleSpinBox::valueChanged),
+          this->session_.data(), &Session::set_feature_range_max);
 
   this->ui_->notes->setText("");
 
@@ -1949,7 +1956,7 @@ void ShapeWorksStudioApp::update_feature_map_scale()
   if (!auto_mode) {
     if (session_->get_feature_range_min() == 0 && session_->get_feature_range_max() == 0) {
       if (visualizer_->get_feature_range_valid()) {
-        double *range = visualizer_->get_feature_raw_range();
+        double* range = visualizer_->get_feature_raw_range();
         ui_->feature_min->setValue(range[0]);
         ui_->feature_max->setValue(range[1]);
       }

--- a/Studio/src/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Interface/ShapeWorksStudioApp.cpp
@@ -826,26 +826,31 @@ void ShapeWorksStudioApp::create_iso_submenu()
   auto project = this->session_->get_project();
 
   auto names = project->get_domain_names();
-  int row = 0;
   this->iso_opacity_sliders_.clear();
-  for (auto& name : names) {
-    QLabel* size_label = new QLabel(QString::fromStdString(name) + " opacity: ");
+  for (size_t row = 0; row < names.size(); row++) {
+    auto name = names[row];
+    QString text = "Opacity";
+    if (names.size() > 1) {
+      text = QString::fromStdString(name) + " opacity: ";
+    }
+    QLabel* size_label = new QLabel(text);
     layout->addWidget(size_label, row, 0, 1, 1);
 
-    QSlider *slider = new QSlider(widget);
+    QSlider* slider = new QSlider(widget);
     slider->setOrientation(Qt::Horizontal);
     slider->setMinimum(1);
     slider->setMaximum(100);
     slider->setPageStep(10);
     slider->setTickPosition(QSlider::TicksBelow);
     slider->setTickInterval(10);
+    slider->setValue(100);
     slider->setMinimumWidth(200);
+    connect(slider, &QSlider::valueChanged, this, &ShapeWorksStudioApp::handle_opacity_changed);
 
     layout->addWidget(slider, row, 1, 1, 1);
     widget->setLayout(layout);
 
     this->iso_opacity_sliders_.push_back(slider);
-    row++;
   }
 
   QWidgetAction* widget_action = new QWidgetAction(widget);
@@ -924,6 +929,7 @@ void ShapeWorksStudioApp::new_session()
   this->groom_tool_->set_session(this->session_);
   this->optimize_tool_->set_session(this->session_);
   this->deepssm_tool_->set_session(this->session_);
+  this->create_iso_submenu();
 }
 
 //---------------------------------------------------------------------------
@@ -1198,6 +1204,16 @@ void ShapeWorksStudioApp::handle_glyph_changed()
   this->glyph_quality_label_->setText(QString::number(preferences_.get_glyph_quality()));
   this->glyph_size_label_->setText(QString::number(preferences_.get_glyph_size()));
   this->update_display(true);
+}
+
+//---------------------------------------------------------------------------
+void ShapeWorksStudioApp::handle_opacity_changed()
+{
+  std::vector<float> opacities;
+  for (auto& slider : this->iso_opacity_sliders_) {
+    opacities.push_back(slider->value() / 100.0);
+  }
+  this->visualizer_->set_opacities(opacities);
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/src/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Interface/ShapeWorksStudioApp.cpp
@@ -298,6 +298,7 @@ ShapeWorksStudioApp::ShapeWorksStudioApp()
   connect(this->ui_->actionKeyboard_Shortcuts, &QAction::triggered, this,
           &ShapeWorksStudioApp::keyboard_shortcuts);
 
+  this->update_feature_map_scale();
   this->handle_message("ShapeWorks Studio Initialized");
 }
 
@@ -858,6 +859,11 @@ void ShapeWorksStudioApp::new_session()
           SLOT(handle_display_setting_changed()));
   connect(this->session_.data(), &Session::new_mesh, this, &ShapeWorksStudioApp::handle_new_mesh);
   connect(this->session_.data(), &Session::error, this, &ShapeWorksStudioApp::handle_error);
+
+  connect(this->ui_->feature_auto_scale, &QCheckBox::toggled, this, &ShapeWorksStudioApp::update_feature_map_scale);
+  connect(this->ui_->feature_auto_scale, &QCheckBox::toggled, this->session_.data(), &Session::set_feature_auto_scale);
+  connect(this->ui_->feature_min, qOverload<double>(&QDoubleSpinBox::valueChanged), this->session_.data(), &Session::set_feature_range_min);
+  connect(this->ui_->feature_max, qOverload<double>(&QDoubleSpinBox::valueChanged), this->session_.data(), &Session::set_feature_range_max);
 
   this->ui_->notes->setText("");
 
@@ -1932,6 +1938,23 @@ void ShapeWorksStudioApp::on_actionExport_Variance_Graph_triggered()
 void ShapeWorksStudioApp::update_feature_map_selection(const QString& feature_map)
 {
   this->set_feature_map(feature_map.toStdString());
+}
+
+//---------------------------------------------------------------------------
+void ShapeWorksStudioApp::update_feature_map_scale()
+{
+  bool auto_mode = this->ui_->feature_auto_scale->isChecked();
+  this->ui_->feature_min->setEnabled(!auto_mode);
+  this->ui_->feature_max->setEnabled(!auto_mode);
+  if (!auto_mode) {
+    if (session_->get_feature_range_min() == 0 && session_->get_feature_range_max() == 0) {
+      if (visualizer_->get_feature_range_valid()) {
+        double *range = visualizer_->get_feature_raw_range();
+        ui_->feature_min->setValue(range[0]);
+        ui_->feature_max->setValue(range[1]);
+      }
+    }
+  }
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/src/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Interface/ShapeWorksStudioApp.cpp
@@ -105,6 +105,7 @@ ShapeWorksStudioApp::ShapeWorksStudioApp()
   this->ui_->data_splitter->setSizes(QList<int>({INT_MAX, INT_MAX}));
 
   this->create_glyph_submenu();
+  this->create_iso_submenu();
   //analysis tool initializations
   this->analysis_tool_ = QSharedPointer<AnalysisTool>::create(preferences_);
   this->analysis_tool_->set_app(this);
@@ -812,6 +813,48 @@ void ShapeWorksStudioApp::create_glyph_submenu()
 }
 
 //---------------------------------------------------------------------------
+void ShapeWorksStudioApp::create_iso_submenu()
+{
+  // Glyph options in the render window.
+  QMenu* menu = new QMenu();
+  QWidget* widget = new QWidget();
+  QGridLayout* layout = new QGridLayout(widget);
+
+  if (!this->session_) {
+    return;
+  }
+  auto project = this->session_->get_project();
+
+  auto names = project->get_domain_names();
+  int row = 0;
+  this->iso_opacity_sliders_.clear();
+  for (auto& name : names) {
+    QLabel* size_label = new QLabel(QString::fromStdString(name) + " opacity: ");
+    layout->addWidget(size_label, row, 0, 1, 1);
+
+    QSlider *slider = new QSlider(widget);
+    slider->setOrientation(Qt::Horizontal);
+    slider->setMinimum(1);
+    slider->setMaximum(100);
+    slider->setPageStep(10);
+    slider->setTickPosition(QSlider::TicksBelow);
+    slider->setTickInterval(10);
+    slider->setMinimumWidth(200);
+
+    layout->addWidget(slider, row, 1, 1, 1);
+    widget->setLayout(layout);
+
+    this->iso_opacity_sliders_.push_back(slider);
+    row++;
+  }
+
+  QWidgetAction* widget_action = new QWidgetAction(widget);
+  widget_action->setDefaultWidget(widget);
+  menu->addAction(widget_action);
+  this->ui_->surface_visible_button->setMenu(menu);
+}
+
+//---------------------------------------------------------------------------
 void ShapeWorksStudioApp::handle_new_mesh()
 {
   this->visualizer_->handle_new_mesh();
@@ -1406,6 +1449,7 @@ void ShapeWorksStudioApp::open_project(QString filename)
     this->update_view_mode();
   }
 
+  this->create_iso_submenu();
   this->handle_progress(100);
   this->handle_message("Project loaded: " + filename);
 }

--- a/Studio/src/Interface/ShapeWorksStudioApp.h
+++ b/Studio/src/Interface/ShapeWorksStudioApp.h
@@ -105,6 +105,7 @@ public Q_SLOTS:
 
   void handle_display_setting_changed();
   void handle_glyph_changed();
+  void handle_opacity_changed();
 
   void handle_open_recent();
 

--- a/Studio/src/Interface/ShapeWorksStudioApp.h
+++ b/Studio/src/Interface/ShapeWorksStudioApp.h
@@ -119,6 +119,8 @@ public Q_SLOTS:
   void handle_clear_cache();
 
   void update_feature_map_selection(const QString& feature_map);
+  void update_feature_map_scale();
+
   void show_splash_screen();
   void about();
   void keyboard_shortcuts();

--- a/Studio/src/Interface/ShapeWorksStudioApp.h
+++ b/Studio/src/Interface/ShapeWorksStudioApp.h
@@ -199,6 +199,7 @@ private:
   void set_message(MessageType message_type, QString message);
 
   void create_glyph_submenu();
+  void create_iso_submenu();
 
   /// designer form
   Ui_ShapeWorksStudioApp* ui_;
@@ -231,6 +232,8 @@ private:
   QPointer<StatusBarWidget> status_bar_;
   QSharedPointer<shapeworks::SplashScreen> splash_screen_;
   QErrorMessage error_message_dialog_;
+  std::vector<QSlider*> iso_opacity_sliders_;
+
 
   QString current_message_;
 

--- a/Studio/src/Interface/ShapeWorksStudioApp.h
+++ b/Studio/src/Interface/ShapeWorksStudioApp.h
@@ -198,6 +198,8 @@ private:
 
   void set_message(MessageType message_type, QString message);
 
+  void create_glyph_submenu();
+
   /// designer form
   Ui_ShapeWorksStudioApp* ui_;
 

--- a/Studio/src/Interface/ShapeWorksStudioApp.ui
+++ b/Studio/src/Interface/ShapeWorksStudioApp.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1062</width>
+    <width>1154</width>
     <height>705</height>
    </rect>
   </property>
@@ -141,7 +141,7 @@
              <string>Show/hide isosurface</string>
             </property>
             <property name="text">
-             <string>...</string>
+             <string/>
             </property>
             <property name="icon">
              <iconset resource="../Resources/ShapeWorksStudio.qrc">
@@ -153,6 +153,9 @@
             </property>
             <property name="checked">
              <bool>true</bool>
+            </property>
+            <property name="popupMode">
+             <enum>QToolButton::MenuButtonPopup</enum>
             </property>
             <property name="autoRaise">
              <bool>true</bool>
@@ -383,7 +386,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1062</width>
+     <width>1154</width>
      <height>22</height>
     </rect>
    </property>

--- a/Studio/src/Interface/ShapeWorksStudioApp.ui
+++ b/Studio/src/Interface/ShapeWorksStudioApp.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1040</width>
+    <width>1062</width>
     <height>705</height>
    </rect>
   </property>
@@ -270,13 +270,36 @@
        <property name="bottomMargin">
         <number>3</number>
        </property>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="features">
+       <item row="0" column="2">
+        <widget class="QCheckBox" name="feature_uniform_scale">
          <property name="toolTip">
-          <string>Select feature map</string>
+          <string>Apply a uniform scale for all viewers</string>
          </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QComboBox::AdjustToContents</enum>
+         <property name="text">
+          <string>Uniform Scale</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="6">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Max</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="7">
+        <widget class="QDoubleSpinBox" name="feature_max">
+         <property name="toolTip">
+          <string>Maximum scalar range</string>
+         </property>
+         <property name="minimum">
+          <double>-9999999.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>9999999.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -287,7 +310,17 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="3">
+       <item row="0" column="1">
+        <widget class="QComboBox" name="features">
+         <property name="toolTip">
+          <string>Select feature map</string>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToContents</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="9">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -300,13 +333,40 @@
          </property>
         </spacer>
        </item>
-       <item row="0" column="2">
-        <widget class="QCheckBox" name="feature_uniform_scale">
+       <item row="0" column="5">
+        <widget class="QDoubleSpinBox" name="feature_min">
          <property name="toolTip">
-          <string>Uniform scale for feature map</string>
+          <string>Minimum scalar range</string>
+         </property>
+         <property name="minimum">
+          <double>-9999999.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>9999999.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="4">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Min</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="8">
+        <widget class="QCheckBox" name="feature_auto_scale">
+         <property name="toolTip">
+          <string>Automatic scale range</string>
          </property>
          <property name="text">
-          <string>Uniform Scale</string>
+          <string>Auto</string>
          </property>
          <property name="checked">
           <bool>true</bool>
@@ -323,7 +383,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1040</width>
+     <width>1062</width>
      <height>22</height>
     </rect>
    </property>

--- a/Studio/src/Python/PythonWorker.h
+++ b/Studio/src/Python/PythonWorker.h
@@ -13,6 +13,8 @@ class PythonWorker : public QObject {
 
 public:
 
+  constexpr static const char* python_api_version = "6.2";
+
   PythonWorker();
   ~PythonWorker();
 

--- a/Studio/src/Visualization/Viewer.cpp
+++ b/Studio/src/Visualization/Viewer.cpp
@@ -769,6 +769,7 @@ void Viewer::update_actors()
       this->renderer_->AddActor(this->surface_actors_[i]);
     }
   }
+  this->update_opacities();
 }
 
 //-----------------------------------------------------------------------------
@@ -906,6 +907,17 @@ bool Viewer::showing_feature_map()
 void Viewer::update_feature_range(double* range)
 {
   this->update_difference_lut(range[0], range[1]);
+}
+
+//-----------------------------------------------------------------------------
+void Viewer::update_opacities()
+{
+  auto opacities = this->visualizer_->get_opacities();
+  if (opacities.size() == this->surface_mappers_.size()) {
+    for (size_t i=0;i<opacities.size();i++) {
+      this->surface_actors_[i]->GetProperty()->SetOpacity(opacities[i]);
+    }
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/Studio/src/Visualization/Viewer.cpp
+++ b/Studio/src/Visualization/Viewer.cpp
@@ -265,6 +265,7 @@ void Viewer::display_vector_field()
   vtkSmartPointer<vtkFloatArray> vectors = vtkSmartPointer<vtkFloatArray>::New();
   vectors->SetNumberOfComponents(3);
 
+  this->update_points();
   this->compute_point_differences(vecs, magnitudes, vectors);
 
   /////////////////////////////////////////////////////////////////////////////////
@@ -312,7 +313,7 @@ void Viewer::compute_point_differences(const std::vector<Shape::Point>& points,
                                        vtkSmartPointer<vtkFloatArray> vectors)
 {
   auto mesh_group = this->shape_->get_meshes(this->visualizer_->get_display_mode());
-  if (!mesh_group.valid()) {
+  if (!mesh_group.valid() || points.empty()) {
     return;
   }
 
@@ -370,10 +371,14 @@ void Viewer::compute_point_differences(const std::vector<Shape::Point>& points,
 void Viewer::compute_surface_differences(vtkSmartPointer<vtkFloatArray> magnitudes,
                                          vtkSmartPointer<vtkFloatArray> vectors)
 {
+  if (!this->mesh_ready_) {
+    return;
+  }
+
   for (size_t i = 0; i < this->surface_mappers_.size(); i++) {
 
     vtkPolyData* poly_data = this->surface_mappers_[i]->GetInput();
-    if (!poly_data) {
+    if (!poly_data || poly_data->GetNumberOfPoints() < 0) {
       return;
     }
 
@@ -484,6 +489,7 @@ void Viewer::display_shape(QSharedPointer<Shape> shape)
     this->mesh_ready_ = false;
     return;
   }
+  this->mesh_ready_ = true;
 
   QStringList annotations = shape->get_annotations();
   this->corner_annotation_->SetText(0, (annotations[0]).toStdString().c_str());

--- a/Studio/src/Visualization/Viewer.h
+++ b/Studio/src/Visualization/Viewer.h
@@ -75,6 +75,8 @@ public:
 
   void update_feature_range(double* range);
 
+  void update_opacities();
+
   QSharedPointer<Shape> get_shape();
 
 private:

--- a/Studio/src/Visualization/Visualizer.cpp
+++ b/Studio/src/Visualization/Visualizer.cpp
@@ -48,6 +48,7 @@ void Visualizer::set_lightbox(LightboxHandle lightbox)
 void Visualizer::set_session(SessionHandle session)
 {
   this->session_ = session;
+  connect(this->session_.data(), &Session::feature_range_changed, this, &Visualizer::handle_feature_range_changed);
 }
 
 //-----------------------------------------------------------------------------
@@ -242,6 +243,15 @@ void Visualizer::update_viewer_properties()
 }
 
 //-----------------------------------------------------------------------------
+void Visualizer::handle_feature_range_changed()
+{
+  feature_manual_range_[0] = session_->get_feature_range_min();
+  feature_manual_range_[1] = session_->get_feature_range_max();
+  this->lightbox_->update_feature_range();
+  this->lightbox_->redraw();
+}
+
+//-----------------------------------------------------------------------------
 void Visualizer::update_lut()
 {
   int num_points = this->cached_mean_.size() / 3;
@@ -407,7 +417,23 @@ void Visualizer::reset_feature_range()
 //-----------------------------------------------------------------------------
 double* Visualizer::get_feature_range()
 {
+  if (session_->get_feature_auto_scale()) {
+    return this->feature_range_;
+  } else {
+    return this->feature_manual_range_;
+  }
+}
+
+//-----------------------------------------------------------------------------
+double *Visualizer::get_feature_raw_range()
+{
   return this->feature_range_;
+}
+
+//-----------------------------------------------------------------------------
+bool Visualizer::get_feature_range_valid()
+{
+  return this->feature_range_valid_;
 }
 
 //-----------------------------------------------------------------------------

--- a/Studio/src/Visualization/Visualizer.cpp
+++ b/Studio/src/Visualization/Visualizer.cpp
@@ -481,5 +481,23 @@ vtkSmartPointer<vtkTransform> Visualizer::get_transform(QSharedPointer<Shape> sh
   return transform;
 }
 
+//-----------------------------------------------------------------------------
+void Visualizer::set_opacities(std::vector<float> opacities)
+{
+  this->opacities_ = opacities;
+  if (this->lightbox_) {
+      foreach(ViewerHandle viewer, this->lightbox_->get_viewers()) {
+        viewer->update_opacities();
+      }
+    this->lightbox_->redraw();
+  }
+}
+
+//-----------------------------------------------------------------------------
+std::vector<float> Visualizer::get_opacities()
+{
+  return this->opacities_;
+}
+
 
 }

--- a/Studio/src/Visualization/Visualizer.h
+++ b/Studio/src/Visualization/Visualizer.h
@@ -109,6 +109,12 @@ public:
   //! Request the transform for a given shape and domain
   vtkSmartPointer<vtkTransform> get_transform(QSharedPointer<Shape> shape, int domain);
 
+  //! Set domain opacities
+  void set_opacities(std::vector<float> opacities);
+
+  //! Get domain opacities
+  std::vector<float> get_opacities();
+
 public Q_SLOTS:
 
   /// update viewer properties (e.g. glyph size, quality, etc)
@@ -148,6 +154,8 @@ private:
   double feature_manual_range_[2] = {0, 0};
   bool feature_range_valid_ = false;
   bool feature_range_uniform_ = true;
+
+  std::vector<float> opacities_;
 
 };
 

--- a/Studio/src/Visualization/Visualizer.h
+++ b/Studio/src/Visualization/Visualizer.h
@@ -97,6 +97,12 @@ public:
   //! Get the current feature range
   double* get_feature_range();
 
+  //! Get the current raw feature range
+  double *get_feature_raw_range();
+
+  //! Return if the feature range is valid or not
+  bool get_feature_range_valid();
+
   //! Update the feature range with a given range
   void update_feature_range(double* range);
 
@@ -107,6 +113,8 @@ public Q_SLOTS:
 
   /// update viewer properties (e.g. glyph size, quality, etc)
   void update_viewer_properties();
+
+  void handle_feature_range_changed();
 
 private:
   ShapeHandle create_display_object(const StudioParticles& points,
@@ -137,6 +145,7 @@ private:
   StudioParticles current_shape_;
 
   double feature_range_[2] = {0, 0};
+  double feature_manual_range_[2] = {0, 0};
   bool feature_range_valid_ = false;
   bool feature_range_uniform_ = true;
 

--- a/Support/package.sh
+++ b/Support/package.sh
@@ -141,7 +141,7 @@ cp -a Documentation "${ROOT}/package/${VERSION}"
 
 mkdir ${ROOT}/artifacts
 cd ${ROOT}/package
-zip -r ${ROOT}/artifacts/${VERSION}.zip ${VERSION}
+zip -y -r ${ROOT}/artifacts/${VERSION}.zip ${VERSION}
 if [ $? -ne 0 ]; then
     echo "Failed to zip artifact"
     exit 1


### PR DESCRIPTION
This PR addresses the following issues:

#1452 - Opacity controls for each domain
#1284 - Feature Request - Multi-domain transparency
#1359 - Add support for manual feature scalar range
#1448 - Studio: Recent XML projects need to store path as well
#1159 - Studio: Allow passing in initial points
#1401 - Extra space in optimize params in studio 

@patkins, Support for initial points is limited to the running of optimization, there is no display of these points yet.  To use this features, simply add a column with the prefix "landmarks_file_<name>" and these points will be used as the initial points to the optimizer.

For example:

<img width="425" alt="image" src="https://user-images.githubusercontent.com/1693349/132361467-8500daf0-33f4-4a27-a86d-4cbfe7335d25.png">
