### PR TITLE
Notebook Visualization Fix

### DIFF
--- a/Examples/Python/notebooks/tutorials/getting-started-with-data-augmentation.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-data-augmentation.ipynb
@@ -319,7 +319,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "# define parameters that controls the plotter\n",
     "use_same_window = False # plot using multiple rendering windows if false\n",
-    "is_interactive  = True  # to enable interactive plots\n",
+    "notebook        = False # True will enable the plots to lie inline\n",
     "show_borders    = True  # show borders for each rendering window\n",
     "shade_volumes   = True  # use shading when performing volume rendering\n",
     "color_map       = \"viridis\" # color map for volume rendering, e.g., 'bone', 'coolwarm', 'cool', 'viridis', 'magma'\n",
@@ -195,7 +195,8 @@
     "sw.plot_volumes(shapeSegList,    \n",
     "             volumeNames     = shapeNames, \n",
     "             use_same_window = use_same_window,\n",
-    "             is_interactive  = is_interactive, \n",
+    "             is_interactive  = is_interactive,\n",
+    "             notebook        = notebook,\n",
     "             show_borders    = show_borders,  \n",
     "             shade_volumes   = shade_volumes, \n",
     "             color_map       = color_map,\n",
@@ -543,7 +544,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
@@ -195,7 +195,6 @@
     "sw.plot_volumes(shapeSegList,    \n",
     "             volumeNames     = shapeNames, \n",
     "             use_same_window = use_same_window,\n",
-    "             is_interactive  = is_interactive,\n",
     "             notebook        = notebook,\n",
     "             show_borders    = show_borders,  \n",
     "             shade_volumes   = shade_volumes, \n",
@@ -460,7 +459,7 @@
    "source": [
     "sw.plot_meshes(shapeSegIsosurfaces,       \n",
     "            use_same_window = True, \n",
-    "            is_interactive  = True,  \n",
+    "            notebook        = False,  \n",
     "            show_borders    = True,  \n",
     "            meshes_color    = ['tan', 'blue','red'], \n",
     "            mesh_style      = \"surface\", \n",

--- a/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
@@ -187,7 +187,8 @@
     "# to have an interactive visualization, \n",
     "# click r to reset the view after zooming\n",
     "# click w to show wireframe and s to return back to sur\n",
-    "shapeMesh_vtk.plot() "
+    "notebook = False # True sets the figure inline in the notebook.\n",
+    "shapeMesh_vtk.plot(notebook = notebook) "
    ]
   },
   {
@@ -253,7 +254,7 @@
    "source": [
     "meshList = [shapeMesh, shapeMesh2]\n",
     "# View meshes side-by-side\n",
-    "sw.plot_meshes(meshList, use_same_window=False)"
+    "sw.plot_meshes(meshList, use_same_window=False, notebook=notebook)"
    ]
   },
   {
@@ -270,7 +271,7 @@
    "outputs": [],
    "source": [
     "# View meshes in the same window\n",
-    "sw.plot_meshes(meshList, use_same_window=True)"
+    "sw.plot_meshes(meshList, use_same_window=True, notebook=notebook)"
    ]
   },
   {
@@ -283,7 +284,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/Examples/Python/notebooks/tutorials/getting-started-with-notebooks.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-notebooks.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3f71293c",
+   "id": "605c6d64",
    "metadata": {},
    "source": [
     "#  Getting Started with Jupyter Notebooks"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14492f5c",
+   "id": "36a1cf38",
    "metadata": {},
    "source": [
     "In this notebook, you will find:\n",
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7007834",
+   "id": "52974586",
    "metadata": {},
    "source": [
     "## ShapeWorks Jupyter Notebook Tutorials"
@@ -30,7 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "759ed150",
+   "id": "d64631ad",
    "metadata": {},
    "source": [
     "### What is Jupyter Notebook?\n",
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f165e127",
+   "id": "994ee7f3",
    "metadata": {},
    "source": [
     "### Running a Jupyter notebook tutorial\n",
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e0c3764a",
+   "id": "3230354f",
    "metadata": {},
    "source": [
     "### Importing ShapeWorks\n",
@@ -82,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c27892f2",
+   "id": "5e510752",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b80134ea",
+   "id": "eb718e4c",
    "metadata": {},
    "source": [
     "If the cell above gave an error make sure you have run `install_shapeworks` and have the `shapeworks` conda environment activated. See [How to Install ShapeWorks?](http://sciinstitute.github.io/ShapeWorks/users/install.html) for more information. \n",
@@ -101,7 +101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "df917896",
+   "id": "7888dd41",
    "metadata": {},
    "source": [
     "## Notebook keyboard shortcuts\n",
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0dc436b",
+   "id": "a8ad0389",
    "metadata": {},
    "source": [
     "## Jupyter Notebook Resources\n",
@@ -132,11 +132,19 @@
     "    (c) [Stack Exchange](https://datascience.stackexchange.com/questions/tagged/jupyter)\n",
     "    "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "885a8b4b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
@@ -186,9 +186,11 @@
    "source": [
     "import pyvista as pv\n",
     "\n",
+    "notebook = False # True will bring the renderings inline\n",
     "# click r to reset the view after zooming\n",
     "shapeSeg_vtk.plot(volume     = True,     # volume render\n",
-    "                  shade      = True)     # enable shading"
+    "                  shade      = True,\n",
+    "                  notebook = notebook)     # enable shading"
    ]
   },
   {
@@ -273,7 +275,7 @@
    "source": [
     "\n",
     "# define parameters that controls the plotter\n",
-    "is_interactive = True  # to enable interactive plots\n",
+    "notebook       = False  # True will bring the renderings inline in the notebook\n",
     "show_borders   = True  # show borders for each rendering window\n",
     "shade_volumes  = True  # use shading when performing volume rendering\n",
     "color_map      = \"coolwarm\" # color map for volume rendering, e.g., 'bone', 'coolwarm', 'cool', 'viridis', 'magma'\n",
@@ -310,7 +312,7 @@
     "\n",
     "sw.plot_volumes(shapeSegList,    \n",
     "             volumeNames     = shapeNames, \n",
-    "             is_interactive = is_interactive, \n",
+    "             notebook = notebook, \n",
     "             show_borders   = show_borders,  \n",
     "             shade_volumes  = shade_volumes,  \n",
     "             show_axes      = show_axes,  \n",
@@ -360,7 +362,7 @@
     "\n",
     "sw.plot_volumes(shapeSegList,    \n",
     "             color_map=color_map,\n",
-    "             is_interactive = is_interactive, \n",
+    "             notebook = notebook, \n",
     "             show_borders   = show_borders,  \n",
     "             shade_volumes  = shade_volumes,  \n",
     "             show_axes      = show_axes,  \n",
@@ -377,11 +379,18 @@
    "source": [
     "<p><img src=\"https://sci.utah.edu/~shapeworks/doc-resources/pngs/segs_one_window.png\"></p>"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/Examples/Python/notebooks/tutorials/getting-started-with-shape-cohort-generation.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-shape-cohort-generation.ipynb
@@ -132,7 +132,7 @@
     "# define parameters that controls the plotter\n",
     "\n",
     "# common for volumes and meshes visualization\n",
-    "is_interactive = True  # to enable interactive plots\n",
+    "notebook       = False # True will set the renderings inline\n",
     "show_borders   = True  # show borders for each rendering window\n",
     "show_axes      = True  # show a vtk axes widget for each rendering window\n",
     "show_bounds    = True  # show volume bounding box\n",
@@ -232,7 +232,7 @@
     "    meshList.append(shapeMesh)\n",
     "\n",
     "# Plot the meshes\n",
-    "sw.plot_meshes(meshList, use_same_window=True)"
+    "sw.plot_meshes(meshList, use_same_window=True, notebook=notebook)"
    ]
   },
   {
@@ -296,8 +296,8 @@
     "print(shapeNames)\n",
     "\n",
     "sw.plot_volumes(shapeSegList,    \n",
-    "             volumeNames     = shapeNames, \n",
-    "             is_interactive = is_interactive, \n",
+    "             volumeNames    = shapeNames, \n",
+    "             notebook       = notebook, \n",
     "             show_borders   = show_borders,  \n",
     "             shade_volumes  = shade_volumes,  \n",
     "             show_axes      = show_axes,  \n",
@@ -480,7 +480,7 @@
     "    meshList.append(shapeMesh)\n",
     "    \n",
     "# Plot the meshes\n",
-    "sw.plot_meshes(meshList, use_same_window=True)"
+    "sw.plot_meshes(meshList, use_same_window=True, notebook=notebook)"
    ]
   },
   {
@@ -530,8 +530,8 @@
     "print(shapeNames)\n",
     "\n",
     "sw.plot_volumes(shapeSegList,    \n",
-    "             volumeNames     = shapeNames, \n",
-    "             is_interactive = is_interactive, \n",
+    "             volumeNames    = shapeNames, \n",
+    "             notebook       = notebook, \n",
     "             show_borders   = show_borders,  \n",
     "             shade_volumes  = shade_volumes,  \n",
     "             show_axes      = show_axes,  \n",
@@ -581,7 +581,7 @@
    "source": [
     "print(\"Segmentation:\")\n",
     "seg0 = sw.Image(segFiles[0])\n",
-    "sw.plot_volumes(seg0)"
+    "sw.plot_volumes(seg0, notebook=notebook)"
    ]
   },
   {
@@ -599,7 +599,7 @@
    "source": [
     "print(\"Image:\")\n",
     "img0 = sw.Image(imageFiles[0])\n",
-    "sw.plot_volumes(img0)"
+    "sw.plot_volumes(img0, notebook=notebook)"
    ]
   },
   {
@@ -612,7 +612,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/Python/shapeworks/shapeworks/plot.py
+++ b/Python/shapeworks/shapeworks/plot.py
@@ -78,7 +78,7 @@ def add_mesh_to_plotter(pvPlotter,      # pyvista plotter
 def plot_volumes(volumeList,              # list of shapeworks images to be visualized
                  volumeNames     = None,  # list of strings of same size as shape list used to add text for each plot window, use None to not show text per window
                  use_same_window = False, # plot using multiple rendering windows if false
-                 is_interactive  = True,  # to enable interactive plots
+                 notebook        = False, # Plots inline if true
                  show_borders    = True,  # show borders for each rendering window
                  shade_volumes   = True,  # use shading when performing volume rendering
                  color_map       = "coolwarm", # color map for volume rendering, e.g., 'bone', 'coolwarm', 'cool', 'viridis', 'magma'
@@ -86,7 +86,7 @@ def plot_volumes(volumeList,              # list of shapeworks images to be visu
                  show_bounds     = True,  # show volume bounding box
                  show_all_edges  = True,  # add an unlabeled and unticked box at the boundaries of plot
                  font_size       = 10,    # text font size for windows
-                 link_views      = True   # link all rendering windows so that they share same camera and axes boundaries
+                 link_views      = True  # link all rendering windows so that they share same camera and axes boundaries,
                 ):
     """
     Renders all segmentations in a dataset using a pyvista plotter to render
@@ -114,7 +114,7 @@ def plot_volumes(volumeList,              # list of shapeworks images to be visu
 
     # define plotter
     plotter = pv.Plotter(shape    = (grid_rows, grid_cols),
-                         notebook = is_interactive,
+                         notebook = notebook,
                          border   = show_borders)
 
     # add given volume list (one at a time) to plotter
@@ -160,7 +160,7 @@ def plot_volumes(volumeList,              # list of shapeworks images to be visu
 def plot_meshes(meshList,                # list of shapeworks meshes to be visualized
                 meshNames       = None,  # list of strings of same size as shape list used to add text for each plot window, use None to not show text per window
                 use_same_window = False, # plot using multiple rendering windows if false
-                is_interactive  = True,  # to enable interactive plots
+                notebook        = False, # Plots inline if true
                 show_borders    = True,  # show borders for each rendering window
                 meshes_color    = 'tan', # color to be used for meshes (can be a list with same size as meshList if different colors are needed)
                 mesh_style      = "surface", # visualization style of mesh. style='surface', style='wireframe', style='points'
@@ -203,7 +203,7 @@ def plot_meshes(meshList,                # list of shapeworks meshes to be visua
 
     # define plotter
     plotter = pv.Plotter(shape    = (grid_rows, grid_cols),
-                         # notebook = is_interactive,
+                         notebook = notebook,
                          border   = show_borders)
 
     # add given volume list (one at a time) to plotter
@@ -253,7 +253,7 @@ def plot_meshes_volumes_mix(objectList,              # list of shapeworks meshes
                             objectsType,             # list of 'vol', 'mesh' of same size as objectList
                             objectNames     = None,  # list of strings of same size as shape list used to add text for each plot window, use None to not show text per window
                             use_same_window = False, # plot using multiple rendering windows if false
-                            is_interactive  = True,  # to enable interactive plots
+                            notebook        = False, # Plots inline if true
                             show_borders    = True,  # show borders for each rendering window
                             meshes_color    = 'tan', # color to be used for meshes (can be a list with same size as meshList if different colors are needed)
                             mesh_style      = "surface", # visualization style of mesh. style='surface', style='wireframe', style='points'
@@ -292,7 +292,7 @@ def plot_meshes_volumes_mix(objectList,              # list of shapeworks meshes
 
     # define plotter
     plotter = pv.Plotter(shape    = (grid_rows, grid_cols),
-                         notebook = is_interactive,
+                         notebook = notebook,
                          border   = show_borders)
 
     # add given volume list (one at a time) to plotter


### PR DESCRIPTION
This commit basically removes the interactive flag which was a misleading nomenclature and replaced it with a notebook flag in the pyvista plotters.

[A] When the notebook flag is False (this is the default now), it generates a render window and the visualization is performed in this window, you can close this window (tested on Linux) without affecting the rest of the code.

[B] When the notebook flag is True the rendering process is still done via OpenGL which requires an empty window that will pop open, but the visualization itself will be inline in the notebook:
This causes two problems and the suggestion is to never use this.
- Either you cannot close the window or if you close it then the notebook hangs
- Due to communication between the renderer and notebook the interactivity is very laggy

I have changed the backend plot functions and notebooks accordingly, and by default, it uses option [A].

Testing needed for Windows and Mac -- I suggest running [this notebook](https://github.com/SCIInstitute/ShapeWorks/blob/master/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb)

Fixes issue #1314 and other lagging problems.