### PR TITLE
Fix #1535 - crash on DT reconstruction when number of clusters == 1

### DIFF
--- a/Libs/Analyze/Reconstruction.cpp
+++ b/Libs/Analyze/Reconstruction.cpp
@@ -1378,7 +1378,7 @@ ComputeMedianShape(std::vector<vnl_matrix<double> > & shapeList)
 
             vnl_matrix<double> shape_jj = shapeList[jj];
 
-            for(size_t kk =0 ; kk < shape_ii.size(); kk++)
+            for(size_t kk =0 ; kk < shape_ii.rows(); kk++)
                 sum += (fabs(shape_ii[kk][0] - shape_jj[kk][0]) + fabs(shape_ii[kk][1] - shape_jj[kk][1]) + fabs(shape_ii[kk][2] - shape_jj[kk][2]));
 
         }


### PR DESCRIPTION
Fix the crash in #1535.  It looks like this section of code is only ever run when the number of clusters is 1.  I don't see how it ever could have worked as it was obviously using the wrong bounds.