### PR TITLE
Fix #1598 - CMake check for git-lfs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
 cmake_minimum_required(VERSION 3.11)
-set(CMAKE_CXX_STANDARD 14)             # available options are [98, 11, 14, 17. 20]
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
-find_package(Python3 3.7 EXACT REQUIRED)
-
 
 ##########################################
 # SHAPEWORKS VERSION
@@ -13,9 +9,18 @@ SET(SHAPEWORKS_PATCH_VERSION 0 CACHE INTERNAL "Patch version number" FORCE)
 SET(SHAPEWORKS_VERSION_STRING "6.3.0-dev")
 
 
-#
-# ShapeWorks options
-#
+
+# First, check that files were checked out properly using git-lfs
+file(MD5 "${CMAKE_CURRENT_SOURCE_DIR}/Testing/data/icp_baseline.nrrd" HASH)
+if (NOT "${HASH}" STREQUAL "bb94438a695c749b264180019abbbb97")
+  message( FATAL_ERROR "MD5 hash of '${CMAKE_CURRENT_SOURCE_DIR}/Testing/data/icp_baseline.nrrd' is incorrect.  This most likely means that git-lfs was not installed when ShapeWorks was cloned." )
+endif()
+
+set(CMAKE_CXX_STANDARD 14)             # available options are [98, 11, 14, 17. 20]
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/CMake")
+find_package(Python3 3.7 EXACT REQUIRED)
+
 if (NOT APPLE)
   option(USE_OPENMP      "Build using OpenMP" ON)
 endif()


### PR DESCRIPTION
This should fix #1598.

This uses CMake to check the hash of one of the files tracked by git-lfs.  If a user/developer clone ShapeWorks without git-lfs, it will error out, rather than let them build and produce strange errors for `make test` and other things.

Now CMake will immediately bomb out with something like this:

CMake Error at CMakeLists.txt:16 (message):
  MD5 hash of
  '/home/user/shapeworks/Testing/data/icp_baseline.nrrd' is
  incorrect.  This most likely means that git-lfs was not installed when
  ShapeWorks was cloned.
