### PR TITLE
Adding option to save mesh file as binary (default is ascii)

### DIFF
--- a/Applications/shapeworks/MeshCommands.cpp
+++ b/Applications/shapeworks/MeshCommands.cpp
@@ -49,6 +49,7 @@ void WriteMesh::buildParser()
   parser.prog(prog).description(desc);
 
   parser.add_option("--name").action("store").type("string").set_default("").help("Name of file to write.");
+  parser.add_option("--binary").action("store").type("bool").set_default(false).help("Whether to write file as binary.");
 
   Command::buildParser();
 }
@@ -66,8 +67,9 @@ bool WriteMesh::execute(const optparse::Values &options, SharedCommandData &shar
     std::cerr << "writemesh error: no filename specified, must pass `--name <filename>`\n";
     return false;
   }
+  bool binary = static_cast<bool>(options.get("binary"));
 
-  sharedData.mesh->write(filename);
+  sharedData.mesh->write(filename, binary);
   return true;
 }
 

--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -115,7 +115,7 @@ Mesh::MeshType Mesh::read(const std::string &pathname)
   }
 }
 
-Mesh& Mesh::write(const std::string &pathname)
+Mesh& Mesh::write(const std::string &pathname, bool binaryFile)
 {
   if (!this->mesh) { throw std::invalid_argument("Mesh invalid"); }
   if (pathname.empty()) { throw std::invalid_argument("Empty pathname"); }
@@ -126,7 +126,10 @@ Mesh& Mesh::write(const std::string &pathname)
       writer->SetFileName(pathname.c_str());
       writer->SetInputData(this->mesh);
       writer->WriteArrayMetaDataOff(); // needed for older readers to read these files
-      writer->SetFileTypeToBinary();
+      if (binaryFile)
+        writer->SetFileTypeToBinary();
+      else
+        writer->SetFileTypeToASCII();
       writer->Update();
       return *this;
     }
@@ -135,6 +138,10 @@ Mesh& Mesh::write(const std::string &pathname)
       auto writer = vtkSmartPointer<vtkXMLPolyDataWriter>::New();
       writer->SetFileName(pathname.c_str());
       writer->SetInputData(this->mesh);
+      if (binaryFile)
+        writer->SetDataModeToBinary();
+      else
+        writer->SetDataModeToAscii();
       writer->Update();
       return *this;
     }
@@ -146,6 +153,10 @@ Mesh& Mesh::write(const std::string &pathname)
       auto writer = vtkSmartPointer<vtkSTLWriter>::New();
       writer->SetFileName(pathname.c_str());
       writer->SetInputData(this->mesh);
+      if (binaryFile)
+        writer->SetFileTypeToBinary();
+      else
+        writer->SetFileTypeToASCII();
       writer->Update();
       return *this;
     }
@@ -168,6 +179,10 @@ Mesh& Mesh::write(const std::string &pathname)
       auto writer = vtkSmartPointer<vtkPLYWriter>::New();
       writer->SetFileName(pathname.c_str());
       writer->SetInputData(this->mesh);
+      if (binaryFile)
+        writer->SetFileTypeToBinary();
+      else
+        writer->SetFileTypeToASCII();
       writer->Update();
       return *this;
     }

--- a/Libs/Mesh/Mesh.h
+++ b/Libs/Mesh/Mesh.h
@@ -39,7 +39,7 @@ public:
   MeshType getVTKMesh() const { return this->mesh; }
 
   /// writes mesh, format specified by filename extension
-  Mesh& write(const std::string &pathname);
+  Mesh& write(const std::string &pathname, bool binaryFile = false);
 
   /// determines coverage between current mesh and another mesh (e.g. acetabular cup / femoral head)
   Mesh& coverage(const Mesh& otherMesh, bool allowBackIntersections = true,

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -886,7 +886,7 @@ PYBIND11_MODULE(shapeworks_py, m)
   .def("write",
        &Mesh::write,
        "writes mesh, format specified by filename extension",
-       "pathname"_a)
+       "pathname"_a, "binaryFile"_a=false)
 
   .def("coverage",
        &Mesh::coverage,

--- a/Testing/MeshTests/MeshTests.cpp
+++ b/Testing/MeshTests/MeshTests.cpp
@@ -9,6 +9,26 @@
 
 using namespace shapeworks;
 
+TEST(MeshTests, writeTest1)
+{
+  Mesh ellipsoid(std::string(TEST_DATA_DIR) + "/ellipsoid_01.vtk");
+  ellipsoid.write(std::string(TEST_DATA_DIR) + "/ellipsoidBinary.vtk", true);
+
+  Mesh ellipsoidBinary(std::string(TEST_DATA_DIR) + "/ellipsoidBinary.vtk");
+
+  ASSERT_TRUE(ellipsoid == ellipsoidBinary);
+}
+
+TEST(MeshTests, writeTest2)
+{
+  Mesh ellipsoid(std::string(TEST_DATA_DIR) + "/ellipsoid_0.ply");
+  ellipsoid.write(std::string(TEST_DATA_DIR) + "/ellipsoidBinary.ply", true);
+
+  Mesh ellipsoidBinary(std::string(TEST_DATA_DIR) + "/ellipsoidBinary.ply");
+
+  ASSERT_TRUE(ellipsoid == ellipsoidBinary);
+}
+
 TEST(MeshTests, subdivisionTest1)
 {
   Mesh femur(std::string(TEST_DATA_DIR) + "/m03.vtk");

--- a/Testing/PythonTests/PythonTests.cpp
+++ b/Testing/PythonTests/PythonTests.cpp
@@ -9,6 +9,11 @@ void run_use_case(const std::string& name)
   ASSERT_FALSE(system(command.c_str()));
 }
 
+TEST(pythonTests, meshwriteTest)
+{
+  run_use_case("meshwrite.py");
+}
+
 TEST(pythonTests, subdivisionTest)
 {
   run_use_case("subdivision.py");

--- a/Testing/PythonTests/meshwrite.py
+++ b/Testing/PythonTests/meshwrite.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from shapeworks import *
+
+success = True
+
+def writeTest1():
+  ellipsoid = Mesh(os.environ["DATA"] + "/ellipsoid_01.vtk");
+  ellipsoid.write(os.environ["DATA"] + "/ellipsoidBinary.vtk", True);
+
+  ellipsoidBinary = Mesh(os.environ["DATA"] + "/ellipsoidBinary.vtk");
+
+  return ellipsoid == ellipsoidBinary
+
+success &= utils.test(writeTest1)
+
+def writeTest2():
+  ellipsoid = Mesh(os.environ["DATA"] + "/ellipsoid_0.ply");
+  ellipsoid.write(os.environ["DATA"] + "/ellipsoidBinary.ply", True);
+
+  ellipsoidBinary = Mesh(os.environ["DATA"] + "/ellipsoidBinary.ply");
+
+  return ellipsoid == ellipsoidBinary
+
+success &= utils.test(writeTest2)
+
+sys.exit(not success)

--- a/Testing/shapeworksTests/meshwrite.sh
+++ b/Testing/shapeworksTests/meshwrite.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+shapeworks read-mesh --name $DATA/ellipsoid_01.vtk write-mesh --name $DATA/ellipsoidBinary.vtk --binary 1 compare-mesh --name $DATA/ellipsoidBinary.vtk
+if [[ $? != 0 ]]; then exit -1; fi
+shapeworks read-mesh --name $DATA/ellipsoid_0.ply write-mesh --name $DATA/ellipsoidBinary.ply --binary 1 compare-mesh --name $DATA/ellipsoidBinary.ply

--- a/Testing/shapeworksTests/shapeworksTests.cpp
+++ b/Testing/shapeworksTests/shapeworksTests.cpp
@@ -9,6 +9,11 @@ void run_use_case(const std::string& name)
   ASSERT_FALSE(system(command.c_str()));
 }
 
+TEST(shapeworksTests, meshwriteTest)
+{
+  run_use_case("meshwrite.sh");
+}
+
 TEST(shapeworksTests, meancurvatureTest)
 {
   run_use_case("meshcurvature.sh");


### PR DESCRIPTION
This PR addresses #1400. Mesh files can be saved as binary or ASCII files. The default option is ASCII. This change has been added to command-line, C++, and Python API. Unit tests have been added.