### PR TITLE
Fix for #1483

### DIFF
--- a/Libs/Image/Image.cpp
+++ b/Libs/Image/Image.cpp
@@ -742,14 +742,13 @@ Image& Image::crop(PhysicalRegion region, const int padding)
     throw std::invalid_argument("Invalid region specified (it may lie outside physical bounds of image).");
   }
 
-  using FilterType = itk::ExtractImageFilter<ImageType, ImageType>;
+  using FilterType = itk::RegionOfInterestImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
-  
+
   IndexRegion indexRegion(physicalToLogical(region));
   indexRegion.pad(padding);
-  filter->SetExtractionRegion(ImageType::RegionType(indexRegion.min, indexRegion.size()));
+  filter->SetRegionOfInterest(ImageType::RegionType(indexRegion.min, indexRegion.size()));
   filter->SetInput(this->image);
-  filter->SetDirectionCollapseToIdentity();
   filter->Update();
   this->image = filter->GetOutput();
 

--- a/Testing/ImageTests/ImageTests.cpp
+++ b/Testing/ImageTests/ImageTests.cpp
@@ -431,6 +431,20 @@ TEST(ImageTests, cropTest2)
   ASSERT_TRUE(image == ground_truth);
 }
 
+TEST(ImageTests, cropTest3)
+{
+  Image image(std::string(TEST_DATA_DIR) + "/seg.ellipsoid_1.nrrd");
+  auto region = image.physicalBoundingBox(0.5);
+  image.crop(region);
+  image.write(std::string(TEST_DATA_DIR) + "/ellipsoid_crop.nrrd");
+  image.resample(1.0);
+
+  Image cropped(std::string(TEST_DATA_DIR) + "/ellipsoid_crop.nrrd");
+  cropped.resample(1.0);
+
+  ASSERT_TRUE(image == cropped);
+}
+
 TEST(ImageTests, boundingBoxSingleTest1)
 {
   auto img = Image(std::string(TEST_DATA_DIR) + "/femurImage.nrrd");

--- a/Testing/PythonTests/crop.py
+++ b/Testing/PythonTests/crop.py
@@ -34,4 +34,17 @@ def cropTest2():
 
 success &= utils.test(cropTest2)
 
+def cropTest3():
+  img = Image(os.environ["DATA"] + "/seg.ellipsoid_1.nrrd")
+  img.crop(img.physicalBoundingBox(0.5))
+  img.write(os.environ["DATA"] + "/ellipsoid_crop.nrrd")
+  img.resample(1.0)
+
+  cropped = Image(os.environ["DATA"] + "/ellipsoid_crop.nrrd")
+  cropped.resample(1.0)
+
+  return img.compare(cropped)
+
+success &= utils.test(cropTest3)
+
 sys.exit(not success)


### PR DESCRIPTION
This PR resolves #1483.

Image.crop has been updated to use RegionOfInterestImageFilter instead of ExtractImageFilter.
Added tests.