### PR TITLE
Mode of variation check for shape evaluation

### DIFF
--- a/Examples/Python/ellipsoid_evaluate.py
+++ b/Examples/Python/ellipsoid_evaluate.py
@@ -27,6 +27,10 @@ def Run_Pipeline(args):
 
     # get the list of all the world particles
     particleFilesList = glob.glob(shape_models_dir+"/*world.particles")
+    if(len(particleFilesList)==0):
+        print(f'Shape model file at {shape_models_dir} empty. No particle files found',file=sys.stderr)
+        print(f'Please run the ellipsoid use case first.', file=sys.stderr)
+        sys.exit(1)
     # read all he particles files into a particleSystem object
     particleSystem = sw.ParticleSystem(particleFilesList)
 
@@ -43,8 +47,8 @@ def Run_Pipeline(args):
 
     # Calculate compactness and saved the values in scree.txt
     # Get the compactness of a specific mode 
-    nCompactness = sw.ShapeEvaluation.ComputeCompactness(particleSystem=particleSystem,nModes=3)
-    print("Compactness value of the 3rd mode - ", nCompactness)
+    nCompactness = sw.ShapeEvaluation.ComputeCompactness(particleSystem=particleSystem,nModes=1)
+    print("Compactness value of the 1st mode - ", nCompactness)
 
     # Get compactness of all the modes
     allCompactness = sw.ShapeEvaluation.ComputeFullCompactness(particleSystem=particleSystem)
@@ -71,8 +75,8 @@ def Run_Pipeline(args):
 
     # Calculate generalization
     # Get the generalization of a specific mode and saves the reconstructions
-    nGeneralization = sw.ShapeEvaluation.ComputeGeneralization(particleSystem=particleSystem, nModes=3,saveTo=save_dir)
-    print("Generalization value of the 3rd mode - ", nGeneralization)
+    nGeneralization = sw.ShapeEvaluation.ComputeGeneralization(particleSystem=particleSystem, nModes=1,saveTo=save_dir)
+    print("Generalization value of the 1st mode - ", nGeneralization)
 
     #Get generalization values for all modes
     allGeneralization = sw.ShapeEvaluation.ComputeFullGeneralization(particleSystem=particleSystem)
@@ -101,8 +105,8 @@ def Run_Pipeline(args):
     save_dir = eval_dir + '/specificity/'
 
     # Calculate specificity of a given mode and saves the reconstructions
-    nSpecificity = sw.ShapeEvaluation.ComputeSpecificity(particleSystem=particleSystem, nModes=3,saveTo=save_dir)
-    print("Specificity value of the 3rd mode - ", nSpecificity)
+    nSpecificity = sw.ShapeEvaluation.ComputeSpecificity(particleSystem=particleSystem, nModes=1,saveTo=save_dir)
+    print("Specificity value of the 1st mode - ", nSpecificity)
 
     #Get specificity values for all modes
     allSpecificity = sw.ShapeEvaluation.ComputeFullSpecificity(particleSystem=particleSystem)

--- a/Libs/Particles/ShapeEvaluation.cpp
+++ b/Libs/Particles/ShapeEvaluation.cpp
@@ -15,8 +15,7 @@ double ShapeEvaluation::ComputeCompactness(const ParticleSystem &particleSystem,
 {
   const int N = particleSystem.N();
   if (nModes > N-1){
-    std::cerr << "Invalid mode of variation specified\n";
-    return false;
+    throw std::invalid_argument("Invalid mode of variation specified");
   }
   Eigen::VectorXd cumsum = ShapeEvaluation::ComputeFullCompactness(particleSystem);
 
@@ -68,8 +67,7 @@ double ShapeEvaluation::ComputeGeneralization(const ParticleSystem &particleSyst
   const Eigen::MatrixXd &P = particleSystem.Particles();
 
   if (nModes > N-1){
-    std::cerr << "Invalid mode of variation specified\n";
-    return false;
+    throw std::invalid_argument("Invalid mode of variation specified");
   }
   // Keep track of the reconstructions so we can visualize them later
   std::vector<Reconstruction> reconstructions;
@@ -163,10 +161,9 @@ double ShapeEvaluation::ComputeSpecificity(const ParticleSystem &particleSystem,
 
   const int N = particleSystem.N();
   const int D = particleSystem.D();
-    
+
   if (nModes > N-1){
-    std::cerr << "Invalid mode of variation specified\n";
-    return false;
+    throw std::invalid_argument("Invalid mode of variation specified");
   }
   const int nSamples = 1000;
 

--- a/Libs/Particles/ShapeEvaluation.cpp
+++ b/Libs/Particles/ShapeEvaluation.cpp
@@ -13,6 +13,11 @@ namespace shapeworks {
 double ShapeEvaluation::ComputeCompactness(const ParticleSystem &particleSystem, const int nModes,
                                                        const std::string &saveTo)
 {
+  const int N = particleSystem.N();
+  if (nModes > N-1){
+    std::cerr << "Invalid mode of variation specified\n";
+    return false;
+  }
   Eigen::VectorXd cumsum = ShapeEvaluation::ComputeFullCompactness(particleSystem);
 
   if (!saveTo.empty()) {
@@ -62,6 +67,10 @@ double ShapeEvaluation::ComputeGeneralization(const ParticleSystem &particleSyst
   const int D = particleSystem.D();
   const Eigen::MatrixXd &P = particleSystem.Particles();
 
+  if (nModes > N-1){
+    std::cerr << "Invalid mode of variation specified\n";
+    return false;
+  }
   // Keep track of the reconstructions so we can visualize them later
   std::vector<Reconstruction> reconstructions;
 
@@ -154,7 +163,11 @@ double ShapeEvaluation::ComputeSpecificity(const ParticleSystem &particleSystem,
 
   const int N = particleSystem.N();
   const int D = particleSystem.D();
-
+    
+  if (nModes > N-1){
+    std::cerr << "Invalid mode of variation specified\n";
+    return false;
+  }
   const int nSamples = 1000;
 
   // Keep track of the reconstructions so we can visualize them later


### PR DESCRIPTION
Address #1630 

After the warnings this is the output if the 3rd mode is queried for tiny test with 3 samples: 
```
(shapeworks_new) iyerkrithika@krithika:~/ShapeWorks_new/ShapeWorks/Examples/Python> python RunUseCase.py ellipsoid_evaluate --tiny_test
Using shapeworks module from /home/sci/iyerkrithika/ShapeWorks_new/ShapeWorks/Python/shapeworks/shapeworks/__init__.py
Using shapeworks from /home/sci/iyerkrithika/ShapeWorks_new/ShapeWorks/build/bin/shapeworks

Compactness
-----------
Invalid mode of variation specified
Compactness value of the 3rd mode -  0.0

Generalization
--------------
Invalid mode of variation specified
Generalization value of the 3rd mode -  0.0

Specificity
--------------
Invalid mode of variation specified
Specificity value of the 3rd mode -  0.0

````