### PR TITLE
[1611] Add superimposition of groomed and reconstructed models in Studio

### DIFF
--- a/Libs/Mesh/MeshWarper.cpp
+++ b/Libs/Mesh/MeshWarper.cpp
@@ -487,13 +487,13 @@ bool MeshWarper::generate_warp_matrix(Eigen::MatrixXd TV, Eigen::MatrixXi TF,
   // Throw away interior tet-vertices, keep weights and indices of boundary
   Eigen::VectorXi I, J;
   igl::remove_unreferenced(TV.rows(), TF, I, J);
-  std::for_each(TF.data(), TF.data() + TF.size(), [&I](int& a) {
+  /*std::for_each(TF.data(), TF.data() + TF.size(), [&I](int& a) {
       a = I(a);
     });
   std::for_each(b.data(), b.data() + b.size(), [&I](int& a) {
       a = I(a);
     });
-  igl::slice(Eigen::MatrixXd(TV), J, 1, TV);
+  igl::slice(Eigen::MatrixXd(TV), J, 1, TV);*/
   igl::slice(Eigen::MatrixXd(W), J, 1, W);
   return true;
 }

--- a/Studio/src/Data/Shape.cpp
+++ b/Studio/src/Data/Shape.cpp
@@ -612,9 +612,11 @@ vtkSmartPointer<vtkTransform> Shape::get_groomed_transform(int domain)
 //---------------------------------------------------------------------------
 vtkSmartPointer<vtkTransform> Shape::get_procrustest_transform(int domain)
 {
-  auto transforms = this->subject_->get_procrustes_transforms();
-  if (domain < transforms.size()) {
-    return ProjectUtils::convert_transform(transforms[domain]);
+  if (this->subject_) {
+    auto transforms = this->subject_->get_procrustes_transforms();
+    if (domain < transforms.size()) {
+      return ProjectUtils::convert_transform(transforms[domain]);
+    }
   }
   return nullptr;
 }

--- a/Studio/src/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Interface/ShapeWorksStudioApp.cpp
@@ -49,7 +49,7 @@ static int ITEM_ROLE = Qt::UserRole - 1;
 
 const std::string ShapeWorksStudioApp::SETTING_ZOOM_C("zoom_state");
 
-const QString qss_green_background = QString("background-color: %1").arg(QColor(Qt::green).name());
+const QString qss_orange_background = QString("background-color: rgb(170, 81, 0)");
 const QString qss_empty;
 
 //---------------------------------------------------------------------------
@@ -1090,7 +1090,7 @@ void ShapeWorksStudioApp::update_view_mode()
 void ShapeWorksStudioApp::toggle_show_groomed_surfaces()
 {
   if (this->ui_->show_groomed_surfaces->isChecked())
-    this->ui_->show_groomed_surfaces->setStyleSheet(qss_green_background);
+    this->ui_->show_groomed_surfaces->setStyleSheet(qss_orange_background);
   else
     this->ui_->show_groomed_surfaces->setStyleSheet(qss_empty);
   if (visualizer_)
@@ -1101,12 +1101,43 @@ void ShapeWorksStudioApp::toggle_show_groomed_surfaces()
 void ShapeWorksStudioApp::toggle_show_reconstructed_surfaces()
 {
   if (this->ui_->show_reconstructed_surfaces->isChecked())
-    this->ui_->show_reconstructed_surfaces->setStyleSheet(qss_green_background);
+    this->ui_->show_reconstructed_surfaces->setStyleSheet(qss_orange_background);
   else
     this->ui_->show_reconstructed_surfaces->setStyleSheet(qss_empty);
   if (visualizer_)
     visualizer_->set_superimpose_surfaces(this->ui_->show_reconstructed_surfaces->isChecked());
   this->update_display(true);
+}
+
+void ShapeWorksStudioApp::reset_toggle_show_surfaces()
+{
+  this->ui_->show_groomed_surfaces->setEnabled(false);
+  this->ui_->show_reconstructed_surfaces->setEnabled(false);
+  
+  if (this->get_view_mode()==Visualizer::MODE_GROOMED_C)
+  {
+    this->ui_->show_groomed_surfaces->setStyleSheet(qss_orange_background);
+    this->ui_->show_groomed_surfaces->setChecked(true);
+  }
+  else
+  {
+    this->ui_->show_groomed_surfaces->setStyleSheet(qss_empty);
+    this->ui_->show_groomed_surfaces->setChecked(false);
+  }
+
+  if (this->get_view_mode()==Visualizer::MODE_RECONSTRUCTION_C)
+  {
+    this->ui_->show_reconstructed_surfaces->setStyleSheet(qss_orange_background);
+    this->ui_->show_reconstructed_surfaces->setChecked(true);
+  }
+  else
+  {
+    this->ui_->show_reconstructed_surfaces->setStyleSheet(qss_empty);
+    this->ui_->show_reconstructed_surfaces->setChecked(false);
+  }
+
+  if (visualizer_)
+    this->visualizer_->set_superimpose_surfaces(false);
 }
 
 //---------------------------------------------------------------------------
@@ -1417,6 +1448,7 @@ void ShapeWorksStudioApp::update_display(bool force)
         this->set_view_combo_item_enabled(VIEW_MODE::ORIGINAL, false);
         this->set_view_combo_item_enabled(VIEW_MODE::GROOMED, false);
         this->set_view_combo_item_enabled(VIEW_MODE::RECONSTRUCTED, true);
+        reset_toggle_show_surfaces();
 
         this->set_view_mode(Visualizer::MODE_RECONSTRUCTION_C);
         this->visualizer_->set_mean(
@@ -1428,6 +1460,8 @@ void ShapeWorksStudioApp::update_display(bool force)
         this->set_view_combo_item_enabled(VIEW_MODE::ORIGINAL, false);
         this->set_view_combo_item_enabled(VIEW_MODE::GROOMED, false);
         this->set_view_combo_item_enabled(VIEW_MODE::RECONSTRUCTED, true);
+        reset_toggle_show_surfaces();
+        
         this->set_view_mode(Visualizer::MODE_RECONSTRUCTION_C);
         this->compute_mode_shape();
         this->visualizer_->reset_camera();
@@ -1857,13 +1891,13 @@ bool ShapeWorksStudioApp::set_view_mode(std::string view_mode)
 
     this->ui_->show_groomed_surfaces->setChecked(show_groomed_surfaces);
     if (show_groomed_surfaces)
-      this->ui_->show_groomed_surfaces->setStyleSheet(qss_green_background);
+      this->ui_->show_groomed_surfaces->setStyleSheet(qss_orange_background);
     else
       this->ui_->show_groomed_surfaces->setStyleSheet(qss_empty);
 
     this->ui_->show_reconstructed_surfaces->setChecked(show_reconstructed_surfaces);
     if (show_reconstructed_surfaces)
-      this->ui_->show_reconstructed_surfaces->setStyleSheet(qss_green_background);
+      this->ui_->show_reconstructed_surfaces->setStyleSheet(qss_orange_background);
     else
       this->ui_->show_reconstructed_surfaces->setStyleSheet(qss_empty);
   }

--- a/Studio/src/Interface/ShapeWorksStudioApp.h
+++ b/Studio/src/Interface/ShapeWorksStudioApp.h
@@ -91,6 +91,9 @@ public Q_SLOTS:
   void on_view_mode_combobox_currentIndexChanged(QString disp_mode);
   void on_auto_view_button_clicked();
 
+  void toggle_show_groomed_surfaces();
+  void toggle_show_reconstructed_surfaces();
+
   void handle_pca_changed();
   void handle_slider_update();
 

--- a/Studio/src/Interface/ShapeWorksStudioApp.h
+++ b/Studio/src/Interface/ShapeWorksStudioApp.h
@@ -93,6 +93,7 @@ public Q_SLOTS:
 
   void toggle_show_groomed_surfaces();
   void toggle_show_reconstructed_surfaces();
+  void reset_toggle_show_surfaces();
 
   void handle_pca_changed();
   void handle_slider_update();

--- a/Studio/src/Interface/ShapeWorksStudioApp.ui
+++ b/Studio/src/Interface/ShapeWorksStudioApp.ui
@@ -163,6 +163,26 @@
            </widget>
           </item>
           <item>
+           <widget class="QToolButton" name="show_groomed_surfaces">
+            <property name="text">
+             <string>Groomed</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="show_reconstructed_surfaces">
+            <property name="text">
+             <string>Recons.</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QComboBox" name="view_mode_combobox">
             <property name="toolTip">
              <string>View mode</string>
@@ -441,7 +461,7 @@
      <x>0</x>
      <y>0</y>
      <width>1154</width>
-     <height>22</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -565,7 +585,7 @@
           <x>0</x>
           <y>0</y>
           <width>398</width>
-          <height>640</height>
+          <height>634</height>
          </rect>
         </property>
         <property name="minimumSize">
@@ -739,8 +759,8 @@
                           <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.AppleSystemUIFont'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'.AppleSystemUIFont'; font-size:13pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                          </property>
                         </widget>
                        </item>

--- a/Studio/src/Visualization/Viewer.cpp
+++ b/Studio/src/Visualization/Viewer.cpp
@@ -488,6 +488,8 @@ void Viewer::display_shape(QSharedPointer<Shape> shape)
 
   this->meshes_ = shape->get_meshes(this->visualizer_->get_display_mode());
 
+  cout << "get_superimpose_surfaces: " << this->visualizer_->get_superimpose_surfaces() << std::endl;
+
   if (!this->meshes_.valid() && this->loading_displayed_) {
     // no need to proceed
     this->mesh_ready_ = false;

--- a/Studio/src/Visualization/Visualizer.h
+++ b/Studio/src/Visualization/Visualizer.h
@@ -43,6 +43,10 @@ public:
   //! get centering on/off
   bool get_center();
 
+  void set_superimpose_surfaces(bool superimpose) { superimpose_surfaces_ = superimpose; }
+
+  bool get_superimpose_surfaces() const { return superimpose_surfaces_; }
+
   //! set the alignment domain
   void set_alignment_domain(int domain);
   //! get the current alignment domain
@@ -145,6 +149,7 @@ private:
 
   bool center_;
   bool needs_camera_reset_ = true;
+  bool superimpose_surfaces_ = false; /** If true, superimpose groomed and reconstructed surfaces  */
 
   bool show_glyphs_;
   bool show_surface_;


### PR DESCRIPTION
Pull request for code-review of #1611  features

Added two toggle buttons to show groomed and reconstructed surfaces that allow to superimpose both spaces and visualize surfaces/particles.

![Toggle_buttons](https://user-images.githubusercontent.com/80735487/149926033-6c0487da-b698-4881-8ad1-a34fc1f3574d.PNG)


Improvements maybe todo: opacities can be used (currently not working in superimposition mode)