### PR TITLE
Small fix for cohort generator and added documentation

### DIFF
--- a/Python/ShapeCohortGenPackage/ShapeCohortGen/CohortGenUtils.py
+++ b/Python/ShapeCohortGenPackage/ShapeCohortGen/CohortGenUtils.py
@@ -6,7 +6,7 @@ import vtk
 from vtk.util.numpy_support import vtk_to_numpy
 import shapely
 import matplotlib.pyplot as plt
-from shapeworks import *
+import shapeworks as sw
 
 '''
 Make folder
@@ -67,7 +67,7 @@ def generate_segmentations(meshList, out_dir, randomize_size=True, spacing=[1.0,
     make_dir(segDir)
 
     # get region that includes all of these meshes
-    bball = MeshUtils.boundingBox(meshList)
+    bball = sw.MeshUtils.boundingBox(meshList)
 
     # randomly select 20% meshes for boundary touching samples
     numMeshes = len(meshList)
@@ -84,7 +84,7 @@ def generate_segmentations(meshList, out_dir, randomize_size=True, spacing=[1.0,
         segList.append(segFile)
 
         # load .ply mesh and get its bounding box
-        mesh = Mesh(mesh_)
+        mesh = sw.Mesh(mesh_)
         bb = mesh.boundingBox()
 
         # if mesh isn't in the set for allow_on_boundary, add [random] padding
@@ -215,12 +215,12 @@ def generate_images(segs, outDir, blur_factor, foreground_mean, foreground_var, 
     for seg in segs:
         print("Generating image " + str(index) + " out of " + str(len(segs)))
         name = seg.replace('segmentations/','images/').replace('_seg.nrrd', '_blur' + str(blur_factor) + '.nrrd')
-        img = Image(seg)
+        img = sw.Image(seg)
         origin = img.origin()
         img_array = blur(img.toArray(), blur_factor)
         img_array = apply_noise(img_array, foreground_mean, foreground_var, background_mean, background_var)
         img_array = np.float32(img_array)
-        img = Image(np.float32(img_array)).setOrigin(origin)
+        img = sw.Image(np.float32(img_array)).setOrigin(origin)
         img.write(name,compressed=True)
         index += 1
     return get_files(imgDir)

--- a/docs/use-cases/stats-based/femur-pvalues.md
+++ b/docs/use-cases/stats-based/femur-pvalues.md
@@ -8,6 +8,13 @@ This use case analyzes the femur shape model obtained from running the [Femur: S
 Here are femur samples with their optimized correspondences.
 ![Femur Samples](../../img/use-cases/femur_samples.png)
 
+A brief overview of the analysis:
+1. Given a shape model with group IDs, we create the subsets based on the group IDs. 
+2. Since the shape models are in correspondence, we access one particle location at a time and create two vectors.
+x: All particle locations of group 1 at ith location
+y: All particle locations of group 2 at ith location
+3. Using the two-sample Hotelling-T2 test, we are trying to see if the particle positions at the ith location of all group 1 samples come from the same distribution as the particle position at ith location of group 2 samples. 
+4. If the group differences are significant, the particle positions are not from the same distribution.
 ## Relevant Arguments
 
 [--tiny_test](../use-cases.md#-tiny_test)
@@ -15,6 +22,6 @@ Here are femur samples with their optimized correspondences.
 
 ## Analyzing Shape Model
 
-For the femur mode, separate statistical tests for differences in correspondence positions are applied to every correspondence index. We use Hotelling $T^2$ metric(nonparametric permutation test) with false discovery rate correction (FDR) for multiple comparisons. This method helps identify and visualize localized regions of significant shape differences. The null hypothesis for this test is that the distributions of the locations of corresponding sample points are the same regardless of the groups. Hence, higher p-values here would mean the group differences are significant and are not from the same distribution. 
+For the femur mode, separate statistical tests for differences in correspondence positions are applied to every correspondence index. We use Hotelling $T^2$ metric(nonparametric permutation test) with false discovery rate correction (FDR) for multiple comparisons. This method helps identify and visualize localized regions of significant shape differences. The null hypothesis for this test is that the distributions of the locations of corresponding sample points are the same regardless of the groups. Hence, lower p-values would mean we can reject the null hypothesis and conclude that the group differences are significant and not from the same distribution. 
 
 This use case calculates the p-values and saves them in a text file. This same functionality is also available in ShapeWorks Studio, where you can also visualize the p-values on the mean shapes. 

--- a/docs/use-cases/stats-based/femur-pvalues.md
+++ b/docs/use-cases/stats-based/femur-pvalues.md
@@ -2,13 +2,14 @@
 
 ## What and Where is the Use Case? 
 
-This use case demonstrates the functionality of shape statistics tools to perform hypothesis testing of group shape differences. This use case analyzes the femur shape model obtained from running the [Femur: SSM from Meshes](../mesh-based/femur.md) use case. The data has 21 examples of normal femurs and 5 examples of pathological femurs with cam impingement.
-This use case analyzes the femur shape model obtained from running the [Femur: SSM from Meshes](../mesh-based/femur.md) use case. Separate statistical tests for differences in correspondence positions are applied to every correspondence index. We use Hotelling $T^2$ metric(nonparametric permutation test) with false discovery rate correction (FDR) for multiple comparisons. This method helps identify and visualize localized regions of significant shape differences.
+This use case demonstrates the functionality of shape statistics tools to perform hypothesis testing of group shape differences. This use case analyzes the femur shape model obtained from running the [Femur: SSM from Meshes with Cutting Planes](../constraint-based/femur-cutting-planes.md) use case. The data has 21 examples of normal femurs and 5 examples of pathological femurs with cam impingement.
+This use case analyzes the femur shape model obtained from running the [Femur: SSM from Meshes with Cutting Planes](../constraint-based/femur-cutting-planes.md) use case. Separate statistical tests for differences in correspondence positions are applied to every correspondence index. We use Hotelling $T^2$ metric(nonparametric permutation test) with false discovery rate correction (FDR) for multiple comparisons. This method helps identify and visualize localized regions of significant shape differences.
 
 Here are femur samples with their optimized correspondences.
 ![Femur Samples](../../img/use-cases/femur_samples.png)
 
 A brief overview of the analysis:
+
 1. Given a shape model with group IDs, we create the subsets based on the group IDs. 
 2. Since the shape models are in correspondence, we access one particle location at a time and create two vectors.
 x: All particle locations of group 1 at ith location


### PR DESCRIPTION
1. Added clarification based on a question asked on discourse: https://shapeworks.discourse.group/t/p-value-feature-map/70
2. ShapeCohortGenPackage was failing because of the way shapeworks was imported:
`from shapeworks import *`
This was causing the `range` function to misbehave and hence this error: 
![image](https://user-images.githubusercontent.com/11266258/153775060-c7503c54-11c1-483d-a51a-01fdbdca918a.png)

Changed the import statement to: `import shapeworks as sw`, and now the package works without any error. 
