### PR TITLE
Fix #1689 - Particle splitting needs to use domain transforms

### DIFF
--- a/Libs/Optimize/ParticleSystem/ContourDomain.cpp
+++ b/Libs/Optimize/ParticleSystem/ContourDomain.cpp
@@ -1,11 +1,12 @@
 #include "ContourDomain.h"
-#include <iostream>
-#include <fstream>
+
 #include <vtkDijkstraGraphGeodesicPath.h>
 #include <vtkDoubleArray.h>
 
+#include <fstream>
+#include <iostream>
 
-namespace itk{
+namespace itk {
 
 const double epsilon = 1e-6;
 
@@ -19,12 +20,12 @@ void ContourDomain::SetPolyLine(vtkSmartPointer<vtkPolyData> poly_data) {
   this->poly_data_->BuildLinks();
 
   auto cell = vtkSmartPointer<vtkGenericCell>::New();
-  for(int i=0; i<this->poly_data_->GetNumberOfCells(); i++) {
+  for (int i = 0; i < this->poly_data_->GetNumberOfCells(); i++) {
     poly_data_->GetCell(i, cell);
     assert(cell->GetNumberOfPoints() == 2);
 
     auto line = vtkSmartPointer<vtkLine>::New();
-    line->GetPointIds()->SetNumberOfIds(2); // is this necessary?
+    line->GetPointIds()->SetNumberOfIds(2);  // is this necessary?
     line->GetPointIds()->SetId(0, cell->GetPointId(0));
     line->GetPointIds()->SetId(1, cell->GetPointId(1));
     line->GetPoints()->SetPoint(0, cell->GetPoints()->GetPoint(0));
@@ -42,9 +43,8 @@ void ContourDomain::SetPolyLine(vtkSmartPointer<vtkPolyData> poly_data) {
   this->ComputeGeodesics(this->poly_data_);
 }
 
-vnl_vector_fixed<double, DIMENSION>
-ContourDomain::ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, 3> &gradE,
-                                             const PointType &p, int idx) const {
+vnl_vector_fixed<double, DIMENSION> ContourDomain::ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, 3> &gradE,
+                                                                                 const PointType &p, int idx) const {
   PointType closest_pt;
   double dist;
   const int closest_line = GetLineForPoint(p.GetDataPointer(), idx, dist, closest_pt.GetDataPointer());
@@ -57,19 +57,15 @@ ContourDomain::ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, 3> &gradE,
   const double grad_mag = gradE_eigen.norm();
 
   // Particle wants to move perpendicular to the line, this is disallowed.
-  if(grad_dot_line_dir == 0.0) {
-    return { 0.0, 0.0, 0.0 };
+  if (grad_dot_line_dir == 0.0) {
+    return {0.0, 0.0, 0.0};
   }
 
   // Since the particle is on a line, there are only two meaningful directions to take. We choose the one which
   // has a closer direction to the gradient. The result is scaled by the gradient magnitude.
   const double dir = grad_dot_line_dir > 0.0 ? 1.0 : -1.0;
 
-  return {
-          line_dir[0]*grad_mag*dir,
-          line_dir[1]*grad_mag*dir,
-          line_dir[2]*grad_mag*dir
-  };
+  return {line_dir[0] * grad_mag * dir, line_dir[1] * grad_mag * dir, line_dir[2] * grad_mag * dir};
 }
 
 bool ContourDomain::ApplyConstraints(PointType &p, int idx, bool dbg) const {
@@ -82,11 +78,12 @@ bool ContourDomain::ApplyConstraints(PointType &p, int idx, bool dbg) const {
 
 ContourDomain::PointType ContourDomain::UpdateParticlePosition(const PointType &point, int idx,
                                                                vnl_vector_fixed<double, 3> &update) const {
-  const Eigen::Vector3d update_vec { -update[0], -update[1], -update[2] };
+  const Eigen::Vector3d update_vec{-update[0], -update[1], -update[2]};
   return GeodesicWalk(point, idx, update_vec);
 }
 
-ContourDomain::PointType ContourDomain::GeodesicWalk(const PointType& start_pt, int idx, const Eigen::Vector3d& update_vec) const {
+ContourDomain::PointType ContourDomain::GeodesicWalk(const PointType &start_pt, int idx,
+                                                     const Eigen::Vector3d &update_vec) const {
   double dist;
   Eigen::Vector3d current_pt;
   int current_line = GetLineForPoint(start_pt.GetDataPointer(), idx, dist, current_pt.data());
@@ -100,18 +97,17 @@ ContourDomain::PointType ContourDomain::GeodesicWalk(const PointType& start_pt, 
   const double update_dot_line_dir = update_vec.dot(line_dir);
 
   // if the particle wants to travel perpendicular to the line, disallow it.
-  if(update_dot_line_dir == 0.0) {
+  if (update_dot_line_dir == 0.0) {
     return start_pt;
   }
   int current_target_idx = update_dot_line_dir > 0.0 ? p1_idx : p0_idx;
   auto neighbors = vtkSmartPointer<vtkIdList>::New();
 
-  while(remaining_update_mag >= 0.0) {
-
+  while (remaining_update_mag >= 0.0) {
     const auto target_pt = this->GetPoint(current_target_idx);
     const double dist_to_target = (target_pt - current_pt).norm();
 
-    if(dist_to_target > remaining_update_mag) {
+    if (dist_to_target > remaining_update_mag) {
       current_pt += (target_pt - current_pt) * remaining_update_mag / dist_to_target;
       break;
     } else {
@@ -121,27 +117,27 @@ ContourDomain::PointType ContourDomain::GeodesicWalk(const PointType& start_pt, 
 
     this->poly_data_->GetPointCells(current_target_idx, neighbors);
 
-    assert(neighbors->GetNumberOfIds() <= 2); // todo remove this when ready to handle branches
+    assert(neighbors->GetNumberOfIds() <= 2);  // todo remove this when ready to handle branches
 
     // hit a dead end. Stop
-    if(neighbors->GetNumberOfIds() == 1) {
+    if (neighbors->GetNumberOfIds() == 1) {
       break;
     }
 
-    if(neighbors->GetId(0) == current_line) {
+    if (neighbors->GetId(0) == current_line) {
       current_line = neighbors->GetId(1);
     } else {
       current_line = neighbors->GetId(0);
     }
 
-    if(current_target_idx == this->lines_[current_line]->GetPointId(0)) {
+    if (current_target_idx == this->lines_[current_line]->GetPointId(0)) {
       current_target_idx = this->lines_[current_line]->GetPointId(1);
     } else {
       current_target_idx = this->lines_[current_line]->GetPointId(0);
     }
   }
 
-  if(idx >= 0) {
+  if (idx >= 0) {
     this->particle_lines_[idx] = current_line;
   }
 
@@ -149,14 +145,13 @@ ContourDomain::PointType ContourDomain::GeodesicWalk(const PointType& start_pt, 
   return res;
 }
 
-double ContourDomain::Distance(const PointType &a, int idx_a,
-                               const PointType &b, int idx_b,
-                               vnl_vector_fixed<double, 3>* out_grad) const {
+double ContourDomain::Distance(const PointType &a, int idx_a, const PointType &b, int idx_b,
+                               vnl_vector_fixed<double, 3> *out_grad) const {
   Eigen::Vector3d pt_a, pt_b;
   double dist_a, dist_b;
   int line_a, line_b;
 
-  if(idx_a == geo_lq_idx_) {
+  if (idx_a == geo_lq_idx_) {
     pt_a = {a[0], a[1], a[2]};
     line_a = geo_lq_line_;
     dist_a = geo_lq_dist_;
@@ -169,9 +164,9 @@ double ContourDomain::Distance(const PointType &a, int idx_a,
 
   line_b = this->GetLineForPoint(b.GetDataPointer(), idx_b, dist_b, pt_b.data());
 
-  if(line_a == line_b) {
-    if(out_grad != nullptr) {
-      for(int i=0; i<DIMENSION; i++) {
+  if (line_a == line_b) {
+    if (out_grad != nullptr) {
+      for (int i = 0; i < DIMENSION; i++) {
         (*out_grad)[i] = a[i] - b[i];
       }
     }
@@ -182,25 +177,25 @@ double ContourDomain::Distance(const PointType &a, int idx_a,
   double shortest_dist = std::numeric_limits<double>::infinity();
   int chosen_dir = 0;
 
-  for(int i=0; i<2; i++) {
+  for (int i = 0; i < 2; i++) {
     const auto ai_idx = this->lines_[line_a]->GetPointId(i);
     const auto ai = this->GetPoint(ai_idx);
     const double dist_to_ai = (pt_a - ai).norm();
 
-    for(int j=0; j<2; j++) {
+    for (int j = 0; j < 2; j++) {
       const auto bi_idx = this->lines_[line_b]->GetPointId(j);
       const auto bj = this->GetPoint(bi_idx);
       const double dist_to_bj = (pt_b - bj).norm();
 
       const double dist = dist_to_ai + geodesics_(ai_idx, bi_idx) + dist_to_bj;
-      if(dist < shortest_dist) {
+      if (dist < shortest_dist) {
         shortest_dist = dist;
         chosen_dir = i;
       }
     }
   }
 
-  if(out_grad != nullptr) {
+  if (out_grad != nullptr) {
     const auto ai_idx = this->lines_[line_a]->GetPointId(chosen_dir);
     const Eigen::Vector3d out_grad_eigen = (pt_a - this->GetPoint(ai_idx)).normalized() * shortest_dist;
     out_grad->set(out_grad_eigen.data());
@@ -208,14 +203,13 @@ double ContourDomain::Distance(const PointType &a, int idx_a,
   return shortest_dist;
 }
 
-double ContourDomain::SquaredDistance(const PointType &a, int idx_a,
-                                      const PointType &b, int idx_b) const {
+double ContourDomain::SquaredDistance(const PointType &a, int idx_a, const PointType &b, int idx_b) const {
   const double dist = this->Distance(a, idx_a, b, idx_b);
-  return dist*dist;
+  return dist * dist;
 }
 
 void ContourDomain::ComputeBounds() {
-  double buffer = 5.0; // copied from MeshDomain
+  double buffer = 5.0;  // copied from MeshDomain
   double bounds[6];
   this->poly_data_->GetBounds(bounds);
   this->lower_bound_[0] = bounds[0] - buffer;
@@ -232,7 +226,7 @@ void ContourDomain::ComputeGeodesics(vtkSmartPointer<vtkPolyData> poly_data) {
   geodesics_.resize(N, N);
   geodesics_.fill(std::numeric_limits<double>::infinity());
 
-  for(int i=0; i<N; i++) {
+  for (int i = 0; i < N; i++) {
     auto dijkstra = vtkSmartPointer<vtkDijkstraGraphGeodesicPath>::New();
     dijkstra->SetInputData(poly_data);
     dijkstra->SetStartVertex(i);
@@ -241,29 +235,25 @@ void ContourDomain::ComputeGeodesics(vtkSmartPointer<vtkPolyData> poly_data) {
     auto out = vtkSmartPointer<vtkDoubleArray>::New();
     dijkstra->GetCumulativeWeights(out);
 
-    for(int j=0; j<N; j++) {
+    for (int j = 0; j < N; j++) {
       geodesics_(i, j) = out->GetValue(j);
     }
   }
 }
 
-int ContourDomain::NumberOfLines() const {
-  return poly_data_->GetNumberOfCells();
-}
+int ContourDomain::NumberOfLines() const { return poly_data_->GetNumberOfCells(); }
 
-int ContourDomain::NumberOfPoints() const {
-  return poly_data_->GetNumberOfPoints();
-}
+int ContourDomain::NumberOfPoints() const { return poly_data_->GetNumberOfPoints(); }
 
-int ContourDomain::GetLineForPoint(const double pt[3], int idx, double& closest_distance, double closest_pt[3]) const {
-  if(idx >= 0) {
-    if(particle_lines_.size() <= idx) {
+int ContourDomain::GetLineForPoint(const double pt[3], int idx, double &closest_distance, double closest_pt[3]) const {
+  if (idx >= 0) {
+    if (particle_lines_.size() <= idx) {
       particle_lines_.resize(idx + 1, -1);
     }
     const auto guess = particle_lines_[idx];
-    if(guess != -1) {
+    if (guess != -1) {
       const auto weight = ComputeLineCoordinate(pt, guess);
-      if(weight >= -epsilon && weight <= epsilon) {
+      if (weight >= -epsilon && weight <= epsilon) {
         closest_pt[0] = pt[0];
         closest_pt[1] = pt[1];
         closest_pt[2] = pt[2];
@@ -272,24 +262,24 @@ int ContourDomain::GetLineForPoint(const double pt[3], int idx, double& closest_
     }
   }
 
-  vtkIdType cell_id; //the cell id of the cell containing the closest point will be returned here
+  vtkIdType cell_id;  // the cell id of the cell containing the closest point will be returned here
   int sub_id;
   this->cell_locator_->FindClosestPoint(pt, closest_pt, cell_id, sub_id, closest_distance);
-  if(idx >= 0) {
+  if (idx >= 0) {
     particle_lines_[idx] = cell_id;
   }
   return cell_id;
 }
 
 double ContourDomain::ComputeLineCoordinate(const double pt[3], int line) const {
-  //todo GetLineForPoint is computing this almost always. just return it there
+  // todo GetLineForPoint is computing this almost always. just return it there
 
   double closest[3];
   int sub_id;
   double pcoords[3];
   double dist2;
   double weights[2];
-  if(this->lines_[line]->EvaluatePosition(pt, closest, sub_id, pcoords, dist2, weights) == -1) {
+  if (this->lines_[line]->EvaluatePosition(pt, closest, sub_id, pcoords, dist2, weights) == -1) {
     // todo vtk says this is a rare occasion where a numerical error has occurred. return _something_? or crash?
     // see https://vtk.org/doc/nightly/html/classvtkLine.html#a42025caa9c76a44ef740ae1ac3bf6b95
     throw std::runtime_error("numerical error in ContourDomain::ComputeLineCoordinate");
@@ -304,7 +294,7 @@ Eigen::Vector3d ContourDomain::GetPoint(int id) const {
 }
 
 void ContourDomain::InvalidateParticlePosition(int idx) const {
-  assert(idx >= 0); // should always be passed a valid particle
+  assert(idx >= 0);  // should always be passed a valid particle
   if (idx >= particle_lines_.size()) {
     particle_lines_.resize(idx + 1, -1);
   }
@@ -312,9 +302,9 @@ void ContourDomain::InvalidateParticlePosition(int idx) const {
   this->geo_lq_idx_ = -1;
 }
 
-ContourDomain::PointType ContourDomain::GetPositionAfterSplit(const PointType& pt,
-                                                              const vnl_vector_fixed<double, 3>& local_direction,
-                                                              const vnl_vector_fixed<double, 3>& global_direction,
+ContourDomain::PointType ContourDomain::GetPositionAfterSplit(const PointType &pt,
+                                                              const vnl_vector_fixed<double, 3> &local_direction,
+                                                              const vnl_vector_fixed<double, 3> &global_direction,
                                                               double epsilon) const {
   // This relies on all the lines being in a consistent order(either clockwise or anticlockwise). With that, it ensures
   // that given a seed(`random`) all the domains end up returning a consistent split direction
@@ -330,14 +320,15 @@ ContourDomain::PointType ContourDomain::GetPositionAfterSplit(const PointType& p
 
   // pick one of two directions depending on the `random` passed in
   Eigen::Vector3d split_dir = (p1 - p0).normalized();
-  if(global_direction[0] < 0.0) {
+  if (global_direction[0] < 0.0) {
     split_dir *= -1;
   }
 
   // ContourDomain requires very small epsilon because it is impossible to recover from crossing particles
   split_dir *= epsilon / 50000.0;
   vnl_vector_fixed<double, 3> vnl_split_dir(split_dir.data());
-  return UpdateParticlePosition(pt, -1, vnl_split_dir); // pass -1 because this really corresponds to an unborn particle
+  return UpdateParticlePosition(pt, -1,
+                                vnl_split_dir);  // pass -1 because this really corresponds to an unborn particle
 }
 
 int ContourDomain::NumberOfLinesIncidentOnPoint(int i) const {
@@ -346,4 +337,4 @@ int ContourDomain::NumberOfLinesIncidentOnPoint(int i) const {
   return neighbors->GetNumberOfIds();
 }
 
-}
+}  // namespace itk

--- a/Libs/Optimize/ParticleSystem/ContourDomain.cpp
+++ b/Libs/Optimize/ParticleSystem/ContourDomain.cpp
@@ -313,7 +313,8 @@ void ContourDomain::InvalidateParticlePosition(int idx) const {
 }
 
 ContourDomain::PointType ContourDomain::GetPositionAfterSplit(const PointType& pt,
-                                                              const vnl_vector_fixed<double, 3>& random,
+                                                              const vnl_vector_fixed<double, 3>& local_direction,
+                                                              const vnl_vector_fixed<double, 3>& global_direction,
                                                               double epsilon) const {
   // This relies on all the lines being in a consistent order(either clockwise or anticlockwise). With that, it ensures
   // that given a seed(`random`) all the domains end up returning a consistent split direction
@@ -329,7 +330,7 @@ ContourDomain::PointType ContourDomain::GetPositionAfterSplit(const PointType& p
 
   // pick one of two directions depending on the `random` passed in
   Eigen::Vector3d split_dir = (p1 - p0).normalized();
-  if(random[0] < 0.0) {
+  if(global_direction[0] < 0.0) {
     split_dir *= -1;
   }
 

--- a/Libs/Optimize/ParticleSystem/ContourDomain.h
+++ b/Libs/Optimize/ParticleSystem/ContourDomain.h
@@ -26,7 +26,7 @@ public:
   itkSimpleNewMacro(ContourDomain);
 
   /** Point type used to store particle locations. */
-  typedef typename ParticleDomain::PointType PointType;
+  using PointType = ParticleDomain::PointType;
 
   explicit ContourDomain() {}
   virtual ~ContourDomain() {}
@@ -40,16 +40,16 @@ public:
   virtual bool ApplyConstraints(PointType& p, int idx, bool dbg = false) const override;
 
   virtual PointType UpdateParticlePosition(const PointType &point,
-                                           int idx, vnl_vector_fixed<double, DIMENSION> &update) const override;
+                                           int idx, VectorDoubleType &update) const override;
 
-  virtual vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION>& gradE,
+  virtual VectorDoubleType ProjectVectorToSurfaceTangent(VectorDoubleType& gradE,
                                                                             const PointType &pos, int idx) const override;
 
-  virtual vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(const PointType &point, int idx) const override {
+  virtual VectorFloatType SampleNormalAtPoint(const PointType &point, int idx) const override {
     throw std::runtime_error("Contours do not have normals");
   }
 
-  virtual vnl_vector_fixed<float, DIMENSION> SampleGradientAtPoint(const PointType &point, int idx) const override {
+  virtual VectorFloatType SampleGradientAtPoint(const PointType &point, int idx) const override {
     throw std::runtime_error("Contours do not have gradients");
   }
 
@@ -87,7 +87,7 @@ public:
   }
 
   double Distance(const PointType &a, int idx_a, const PointType &b, int idx_b,
-                         vnl_vector_fixed<double, 3>* out_grad=nullptr) const override;
+                         VectorDoubleType* out_grad=nullptr) const override;
 
   double SquaredDistance(const PointType &a, int idx_a, const PointType &b, int idx_b) const override;
 
@@ -117,10 +117,10 @@ public:
     // TODO what?
   }
 
-  virtual void InvalidateParticlePosition(int idx) const override;
+  void InvalidateParticlePosition(int idx) const override;
 
-  virtual PointType GetPositionAfterSplit(const PointType& pt,
-                                          const vnl_vector_fixed<double, 3>& random, double epsilon) const override;
+  PointType GetPositionAfterSplit(const PointType& pt,
+                                          const VectorDoubleType& local_direction, const VectorDoubleType& global_direction, double epsilon) const override;
 
 protected:
   void PrintSelf(std::ostream& os, Indent indent) const override

--- a/Libs/Optimize/ParticleSystem/ContourDomain.h
+++ b/Libs/Optimize/ParticleSystem/ContourDomain.h
@@ -8,52 +8,46 @@
 =========================================================================*/
 #pragma once
 
-#include "itkParticleDomain.h"
-#include <Eigen/Dense>
-#include <vtkPolyData.h>
-#include <vtkLine.h>
-#include <vtkGenericCell.h>
-#include <vtkCellLocator.h>
 #include <itkObjectFactory.h>
+#include <vtkCellLocator.h>
+#include <vtkGenericCell.h>
+#include <vtkLine.h>
+#include <vtkPolyData.h>
 
-namespace itk
-{
-class ContourDomain : public ParticleDomain
-{
-public:
+#include <Eigen/Dense>
+
+#include "itkParticleDomain.h"
+
+namespace itk {
+class ContourDomain : public ParticleDomain {
+ public:
   /** Standard class typedefs */
-  typedef SmartPointer<ContourDomain>  Pointer;
+  typedef SmartPointer<ContourDomain> Pointer;
   itkSimpleNewMacro(ContourDomain);
-
-  /** Point type used to store particle locations. */
-  using PointType = ParticleDomain::PointType;
 
   explicit ContourDomain() {}
   virtual ~ContourDomain() {}
 
   void SetPolyLine(vtkSmartPointer<vtkPolyData> poly_data);
 
-  shapeworks::DomainType GetDomainType() const override {
-    return shapeworks::DomainType::Contour;
-  }
+  shapeworks::DomainType GetDomainType() const override { return shapeworks::DomainType::Contour; }
 
   virtual bool ApplyConstraints(PointType& p, int idx, bool dbg = false) const override;
 
-  virtual PointType UpdateParticlePosition(const PointType &point,
-                                           int idx, VectorDoubleType &update) const override;
+  virtual PointType UpdateParticlePosition(const PointType& point, int idx, VectorDoubleType& update) const override;
 
-  virtual VectorDoubleType ProjectVectorToSurfaceTangent(VectorDoubleType& gradE,
-                                                                            const PointType &pos, int idx) const override;
+  virtual VectorDoubleType ProjectVectorToSurfaceTangent(VectorDoubleType& gradE, const PointType& pos,
+                                                         int idx) const override;
 
-  virtual VectorFloatType SampleNormalAtPoint(const PointType &point, int idx) const override {
+  virtual VectorFloatType SampleNormalAtPoint(const PointType& point, int idx) const override {
     throw std::runtime_error("Contours do not have normals");
   }
 
-  virtual VectorFloatType SampleGradientAtPoint(const PointType &point, int idx) const override {
+  virtual VectorFloatType SampleGradientAtPoint(const PointType& point, int idx) const override {
     throw std::runtime_error("Contours do not have gradients");
   }
 
-  virtual GradNType SampleGradNAtPoint(const PointType &p, int idx) const override {
+  virtual GradNType SampleGradNAtPoint(const PointType& p, int idx) const override {
     throw std::runtime_error("Contours do not have gradient of normals");
   }
 
@@ -63,16 +57,14 @@ public:
   }
 
   virtual double GetMaxDiameter() const override {
-    //todo copied from MeshDomain: should this not be the length of the bounding box diagonal?
+    // todo copied from MeshDomain: should this not be the length of the bounding box diagonal?
     const PointType bb = upper_bound_ - lower_bound_;
     return std::max({bb[0], bb[1], bb[2]});
   }
 
-  virtual void UpdateZeroCrossingPoint() override { }
+  virtual void UpdateZeroCrossingPoint() override {}
 
-  double GetCurvature(const PointType &p, int idx) const override {
-    return GetSurfaceMeanCurvature();
-  }
+  double GetCurvature(const PointType& p, int idx) const override { return GetSurfaceMeanCurvature(); }
 
   virtual double GetSurfaceMeanCurvature() const override {
     // This function is used by MeanCurvatureAttribute which is used for good/bad assessment
@@ -86,18 +78,14 @@ public:
     return 0.02;
   }
 
-  double Distance(const PointType &a, int idx_a, const PointType &b, int idx_b,
-                         VectorDoubleType* out_grad=nullptr) const override;
+  double Distance(const PointType& a, int idx_a, const PointType& b, int idx_b,
+                  VectorDoubleType* out_grad = nullptr) const override;
 
-  double SquaredDistance(const PointType &a, int idx_a, const PointType &b, int idx_b) const override;
+  double SquaredDistance(const PointType& a, int idx_a, const PointType& b, int idx_b) const override;
 
-  const PointType& GetLowerBound() const override {
-    return lower_bound_;
-  }
+  const PointType& GetLowerBound() const override { return lower_bound_; }
 
-  const PointType& GetUpperBound() const override {
-    return upper_bound_;
-  }
+  const PointType& GetUpperBound() const override { return upper_bound_; }
 
   PointType GetZeroCrossingPoint() const override {
     PointType out;
@@ -106,9 +94,7 @@ public:
     return out;
   }
 
-  double GetSurfaceArea() const override {
-    throw std::runtime_error("Contours do not have area");
-  }
+  double GetSurfaceArea() const override { throw std::runtime_error("Contours do not have area"); }
 
   void DeleteImages() override {
     // TODO what?
@@ -119,33 +105,16 @@ public:
 
   void InvalidateParticlePosition(int idx) const override;
 
-  PointType GetPositionAfterSplit(const PointType& pt,
-                                          const VectorDoubleType& local_direction, const VectorDoubleType& global_direction, double epsilon) const override;
+  PointType GetPositionAfterSplit(const PointType& pt, const VectorDoubleType& local_direction,
+                                  const VectorDoubleType& global_direction, double epsilon) const override;
 
-protected:
-  void PrintSelf(std::ostream& os, Indent indent) const override
-  {
+ protected:
+  void PrintSelf(std::ostream& os, Indent indent) const override {
     DataObject::Superclass::PrintSelf(os, indent);
     os << indent << "ContourDomain\n";
   }
 
-private:
-  PointType lower_bound_, upper_bound_;
-
-  vtkSmartPointer<vtkPolyData> poly_data_;
-  vtkSmartPointer<vtkCellLocator> cell_locator_;
-  std::vector<vtkSmartPointer<vtkLine>> lines_;
-
-  // Geodesics between all point pairs. Assumes the number of points is very small
-  Eigen::MatrixXd geodesics_;
-
-  // cache which line a particle is on
-  mutable std::vector<int> particle_lines_;
-  // store some information about the last geodesic query. The next one will most likely reuse this
-  mutable int geo_lq_idx_ = -1;
-  mutable int geo_lq_line_ = -1;
-  mutable double geo_lq_dist_ = -1;
-
+ private:
   void ComputeBounds();
   void ComputeGeodesics(vtkSmartPointer<vtkPolyData> poly_data);
 
@@ -161,6 +130,22 @@ private:
   int NumberOfPoints() const;
 
   Eigen::Vector3d GetPoint(int id) const;
+
+  PointType lower_bound_, upper_bound_;
+
+  vtkSmartPointer<vtkPolyData> poly_data_;
+  vtkSmartPointer<vtkCellLocator> cell_locator_;
+  std::vector<vtkSmartPointer<vtkLine>> lines_;
+
+  // Geodesics between all point pairs. Assumes the number of points is very small
+  Eigen::MatrixXd geodesics_;
+
+  // cache which line a particle is on
+  mutable std::vector<int> particle_lines_;
+  // store some information about the last geodesic query. The next one will most likely reuse this
+  mutable int geo_lq_idx_ = -1;
+  mutable int geo_lq_line_ = -1;
+  mutable double geo_lq_dist_ = -1;
 };
 
-} // end namespace itk
+}  // end namespace itk

--- a/Libs/Optimize/ParticleSystem/itkParticleDomain.h
+++ b/Libs/Optimize/ParticleSystem/itkParticleDomain.h
@@ -26,8 +26,10 @@ public:
   typedef SmartPointer<ParticleDomain>  Pointer;
 
   /** Point type used to store particle locations. */
-  typedef Point<double, DIMENSION> PointType;
-  typedef vnl_matrix_fixed<float, DIMENSION, DIMENSION> GradNType;
+  using PointType = Point<double, 3>;
+  using GradNType = vnl_matrix_fixed<float, 3, 3>;
+  using VectorDoubleType = vnl_vector_fixed<double, 3>;
+  using VectorFloatType = vnl_vector_fixed<float, 3>;
 
   /** Apply any constraints to the given point location.
       This should force the point to a position on the surface that satisfies all constraints. */
@@ -35,23 +37,21 @@ public:
 
   /** Applies the update to the point and returns the new point position. */
   //todo update should be const?
-  virtual PointType UpdateParticlePosition(const PointType &point, int idx, vnl_vector_fixed<double, DIMENSION> &update) const = 0;
+  virtual PointType UpdateParticlePosition(const PointType &point, int idx, VectorDoubleType &update) const = 0;
 
-  virtual void InvalidateParticlePosition(int idx) const {
-  }
+  virtual void InvalidateParticlePosition(int idx) const {}
 
   /** Projects the vector to the surface tangent at the point. */
-  virtual vnl_vector_fixed<double, DIMENSION> ProjectVectorToSurfaceTangent(vnl_vector_fixed<double, DIMENSION>& gradE, const PointType& pos, int idx) const = 0;
-
-  virtual vnl_vector_fixed<float, DIMENSION> SampleGradientAtPoint(const PointType &point, int idx) const = 0;
-  virtual vnl_vector_fixed<float, DIMENSION> SampleNormalAtPoint(const PointType & point, int idx) const = 0;
+  virtual VectorDoubleType ProjectVectorToSurfaceTangent(VectorDoubleType& gradE, const PointType& pos, int idx) const = 0;
+  virtual VectorFloatType SampleGradientAtPoint(const PointType &point, int idx) const = 0;
+  virtual VectorFloatType SampleNormalAtPoint(const PointType & point, int idx) const = 0;
   virtual GradNType SampleGradNAtPoint(const PointType &p, int idx) const = 0;
 
   /** Distance between locations is used for computing energy and neighborhoods. Optionally
       return the gradient of the distance */
   virtual double Distance(const PointType &a, int idx_a,
                           const PointType &b, int idx_b,
-                          vnl_vector_fixed<double, DIMENSION> *out_grad=nullptr) const {
+                          VectorDoubleType *out_grad=nullptr) const {
     if(out_grad != nullptr) {
       for(int i=0; i<DIMENSION; i++) {
         (*out_grad)[i] = a[i] - b[i];
@@ -107,14 +107,14 @@ public:
 
   // Use `random` to advance a particle and return a new position
   virtual PointType GetPositionAfterSplit(const PointType& pt,
-                                          const vnl_vector_fixed<double, 3>& random, double epsilon) const {
+                                          const VectorDoubleType& local_direction, const VectorDoubleType& global_direction, double epsilon) const {
     // todo this has been copied from itkParticleSystem::AdvancedAllParticleSplitting.
     //  Ideally, we should compute a direction that is "consistent" depending on the domain type and use the
     //  `UpdateParticlePosition` API to advance the particle. See ContourDomain for an example. Leaving this be for
     //  now because we'd have to retest all MeshDomain and ImageDomain use cases if this behaviour changes.
     PointType new_pt;
     for (unsigned int k = 0; k < 3; k++) {
-      new_pt[k] = pt[k] + epsilon * random[k] / 5.;
+      new_pt[k] = pt[k] + epsilon * local_direction[k] / 5.;
     }
     return new_pt;
   }

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.cxx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.cxx
@@ -267,18 +267,21 @@ void ParticleSystem::AdvancedAllParticleSplitting(double epsilon, unsigned int d
         double norm = random.magnitude();
         random /= norm;
 
-        // Check where the update will take us after applying it to the point and th constraints.
+        // Check where the update will take us after applying it to the point and the constraints.
         newposs_good.clear();
         bool good = true;  // flag to check if the new update violates in any domain
         for (size_t j = 0; j < lists.size(); j++) {
           // Add epsilon times random direction to existing point and apply domain
           // constraints to generate a new particle position.
-          PointType newpos = this->GetDomain(dom_to_process + j * domains_per_shape)
-                                 ->GetPositionAfterSplit(lists[j][i], random, epsilon);
+
+          int local_domain = dom_to_process + j * domains_per_shape;
+          auto transformed_vector = TransformVector(random, GetInversePrefixTransform(local_domain) * GetInverseTransform(local_domain));
+          PointType newpos = GetDomain(local_domain)->GetPositionAfterSplit(lists[j][i], transformed_vector, epsilon);
+
           // Go to surface
-          if (!this->m_DomainFlags[dom_to_process + j * domains_per_shape] &&
-              !this->GetDomain(dom_to_process + j * domains_per_shape)->GetConstraints()->isAnyViolated(newpos)) {
-            this->GetDomain(dom_to_process + j * domains_per_shape)->ApplyConstraints(newpos, -1);
+          if (!this->m_DomainFlags[local_domain] &&
+              !this->GetDomain(local_domain)->GetConstraints()->isAnyViolated(newpos)) {
+            this->GetDomain(local_domain)->ApplyConstraints(newpos, -1);
           }
           newposs_good.push_back(newpos);
           // Check for plane constraint violations
@@ -292,7 +295,8 @@ void ParticleSystem::AdvancedAllParticleSplitting(double epsilon, unsigned int d
 
         if (good) {
           for (size_t j = 0; j < lists.size(); j++) {
-            this->AddPosition(newposs_good[j], dom_to_process + j * domains_per_shape, 0);
+            int local_domain = dom_to_process + j * domains_per_shape;
+            this->AddPosition(newposs_good[j], local_domain, 0);
             // Debuggg
             // std::cout << "Domain " << j << " Curr Pos " << lists[j][i] << " random "
             // << random  << " epsilon " << epsilon << " picked " << newposs_good[j] << std::endl;

--- a/Libs/Optimize/ParticleSystem/itkParticleSystem.cxx
+++ b/Libs/Optimize/ParticleSystem/itkParticleSystem.cxx
@@ -276,7 +276,7 @@ void ParticleSystem::AdvancedAllParticleSplitting(double epsilon, unsigned int d
 
           int local_domain = dom_to_process + j * domains_per_shape;
           auto transformed_vector = TransformVector(random, GetInversePrefixTransform(local_domain) * GetInverseTransform(local_domain));
-          PointType newpos = GetDomain(local_domain)->GetPositionAfterSplit(lists[j][i], transformed_vector, epsilon);
+          PointType newpos = GetDomain(local_domain)->GetPositionAfterSplit(lists[j][i], transformed_vector, random, epsilon);
 
           // Go to surface
           if (!this->m_DomainFlags[local_domain] &&


### PR DESCRIPTION
This PR fixes:

* #1689 

We now apply the per domain local inverse transforms to the shared split direction.  This fixes the reflection problem and should also improve splitting consistency any time that procrustes or input prefix transforms are used.

<img width="580" alt="Screen Shot 2022-03-18 at 12 44 05 PM" src="https://user-images.githubusercontent.com/1693349/159065085-72c98a3f-07b4-4ff9-80c2-5ae573777cb6.png">

