### PR TITLE
Add MeshWarper in Python bindings.

### DIFF
--- a/Libs/Mesh/MeshWarper.h
+++ b/Libs/Mesh/MeshWarper.h
@@ -31,11 +31,21 @@ public:
   //! Return if the warp is available
   bool get_warp_available();
 
+  //! Check if the warp is ready, if not do it (thread safely), return true if warp is valid
+  bool check_warp_ready();
+
   //! Build a mesh for a given set of particles
   vtkSmartPointer<vtkPolyData> build_mesh(const Eigen::MatrixXd& particles);
 
   //! Return if set as a contour
   bool is_contour() { return this->is_contour_; }
+
+  //! Return true if warping has removed any bad particle(s)
+  bool has_bad_particles() const { return this->nb_bad_particles() > 0; }
+
+  vtkSmartPointer<vtkPolyData> get_reference_mesh() { return this->reference_mesh_; }
+  const Eigen::MatrixXd& get_reference_particles() const { return this->reference_particles_; }
+  const Eigen::MatrixXd& get_warp_matrix() const { return this->warp_; }
 
 protected:
 
@@ -60,9 +70,6 @@ private:
   //! Identify the good particles
   void find_good_particles();
 
-  //! Check if the warp is ready, return true if warp is valid
-  bool check_warp_ready();
-
   //! Prep incoming mesh
   static vtkSmartPointer<vtkPolyData> prep_mesh(vtkSmartPointer<vtkPolyData> mesh);
 
@@ -79,6 +86,11 @@ private:
   //! Generate a polydata from a set of points (e.g. warp the reference mesh)
   vtkSmartPointer<vtkPolyData> warp_mesh(const Eigen::MatrixXd& points);
 
+  //! Return the number of bad particles
+  size_t nb_bad_particles() const { return size_t(reference_particles_.rows()) - good_particles_.size(); }
+
+  // Members
+
   Eigen::MatrixXi faces_;
   Eigen::MatrixXd vertices_;
   Eigen::MatrixXd warp_;
@@ -93,7 +105,7 @@ private:
   vtkSmartPointer<vtkPolyData> incoming_reference_mesh_;
   //! Processed reference mesh
   vtkSmartPointer<vtkPolyData> reference_mesh_;
-  //! Reference particles
+  //! Reference particles (matrix [Nx3])
   Eigen::MatrixXd reference_particles_;
   //! Whether the reference is a contour
   bool is_contour_ = false;


### PR DESCRIPTION
Allow to do the mesh warping in Python without calling the external exe tool shapeworks.
Allow to retrieve the warping matrix and the cleaned reference model.