### PR TITLE
Add MeshWarper in Python bindings.

### DIFF
--- a/Libs/Mesh/MeshWarper.h
+++ b/Libs/Mesh/MeshWarper.h
@@ -31,11 +31,21 @@ public:
   //! Return if the warp is available
   bool get_warp_available();
 
+  //! Check if the warp is ready, if not do it (thread safely), return true if warp is valid
+  bool check_warp_ready();
+
   //! Build a mesh for a given set of particles
   vtkSmartPointer<vtkPolyData> build_mesh(const Eigen::MatrixXd& particles);
 
   //! Return if set as a contour
   bool is_contour() { return this->is_contour_; }
+
+  //! Return true if warping has removed any bad particle(s)
+  bool has_bad_particles() const { return this->nb_bad_particles() > 0; }
+
+  vtkSmartPointer<vtkPolyData> get_reference_mesh() { return this->reference_mesh_; }
+  const Eigen::MatrixXd& get_reference_particles() const { return this->reference_particles_; }
+  const Eigen::MatrixXd& get_warp_matrix() const { return this->warp_; }
 
 protected:
 
@@ -60,9 +70,6 @@ private:
   //! Identify the good particles
   void find_good_particles();
 
-  //! Check if the warp is ready, return true if warp is valid
-  bool check_warp_ready();
-
   //! Prep incoming mesh
   static vtkSmartPointer<vtkPolyData> prep_mesh(vtkSmartPointer<vtkPolyData> mesh);
 
@@ -79,6 +86,11 @@ private:
   //! Generate a polydata from a set of points (e.g. warp the reference mesh)
   vtkSmartPointer<vtkPolyData> warp_mesh(const Eigen::MatrixXd& points);
 
+  //! Return the number of bad particles
+  size_t nb_bad_particles() const { return size_t(reference_particles_.rows()) - good_particles_.size(); }
+
+  // Members
+
   Eigen::MatrixXi faces_;
   Eigen::MatrixXd vertices_;
   Eigen::MatrixXd warp_;
@@ -93,7 +105,7 @@ private:
   vtkSmartPointer<vtkPolyData> incoming_reference_mesh_;
   //! Processed reference mesh
   vtkSmartPointer<vtkPolyData> reference_mesh_;
-  //! Reference particles
+  //! Reference particles (matrix [Nx3])
   Eigen::MatrixXd reference_particles_;
   //! Whether the reference is a contour
   bool is_contour_ = false;

--- a/Libs/Mesh/MeshWarper.h
+++ b/Libs/Mesh/MeshWarper.h
@@ -28,11 +28,11 @@ public:
   void set_reference_mesh(vtkSmartPointer<vtkPolyData> reference_mesh,
                           const Eigen::MatrixXd& reference_particles);
 
+  //! Generate warp, return true on success
+  bool generate_warp();
+
   //! Return if the warp is available
   bool get_warp_available();
-
-  //! Check if the warp is ready, if not do it (thread safely), return true if warp is valid
-  bool check_warp_ready();
 
   //! Build a mesh for a given set of particles
   vtkSmartPointer<vtkPolyData> build_mesh(const Eigen::MatrixXd& particles);
@@ -41,7 +41,7 @@ public:
   bool is_contour() { return this->is_contour_; }
 
   //! Return true if warping has removed any bad particle(s)
-  bool has_bad_particles() const { return this->nb_bad_particles() > 0; }
+  bool has_bad_particles() const { return this->bad_particle_count() > 0; }
 
   vtkSmartPointer<vtkPolyData> get_reference_mesh() { return this->reference_mesh_; }
   const Eigen::MatrixXd& get_reference_particles() const { return this->reference_particles_; }
@@ -54,8 +54,8 @@ protected:
 
 private:
 
-  //! Generate warp, return true on success
-  bool generate_warp();
+  //! Check if the warp is ready, if not do it (thread safely), return true if warp is valid
+  bool check_warp_ready();
 
   //! Add particles as vertices to reference mesh
   void add_particle_vertices();
@@ -87,10 +87,9 @@ private:
   vtkSmartPointer<vtkPolyData> warp_mesh(const Eigen::MatrixXd& points);
 
   //! Return the number of bad particles
-  size_t nb_bad_particles() const { return size_t(reference_particles_.rows()) - good_particles_.size(); }
+  size_t bad_particle_count() const { return size_t(reference_particles_.rows()) - good_particles_.size(); }
 
   // Members
-
   Eigen::MatrixXi faces_;
   Eigen::MatrixXd vertices_;
   Eigen::MatrixXd warp_;

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1225,25 +1225,25 @@ PYBIND11_MODULE(shapeworks_py, m)
 
   .def(py::init<>())
 
-  .def("computeWarping",
+  .def("generateWarp",
         [](MeshWarper &w, const Mesh &mesh_ref, const Eigen::MatrixXd &particles_ref) -> decltype(auto) {
          w.set_reference_mesh(mesh_ref.getVTKMesh(), particles_ref);
-         return w.get_warp_available() && w.check_warp_ready();
+         return w.generate_warp();
         },
         "Assign the reference mesh/particles (matrix [Nx3]) and pre-compute the warping",
         "reference_mesh"_a, "reference_particles"_a)
 
-  .def("getReferenceModel",
+  .def("getReferenceMesh",
       [](MeshWarper &w) -> decltype(auto) {
         return Mesh(w.get_reference_mesh());
       },
-      "Retrurn the mesh used for warping.")
+      "Return the mesh used for warping.")
 
   .def("getReferenceParticles",
       [](MeshWarper &w) -> decltype(auto) {
         return w.get_reference_particles();
       },
-      "Retrurn the particles used for warping.")
+      "Return the particles used for warping.")
 
   .def("hasBadParticles",
       [](MeshWarper &w) -> decltype(auto) {


### PR DESCRIPTION
Allow to do the mesh warping in Python without calling external exe tool shapeworks.
Allow to retrieve the warping matrix and the cleaned reference model.