### PR TITLE
ensure Mesh invalidates locators when appropriate

### DIFF
--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -72,7 +72,7 @@
 
 namespace shapeworks {
 
-Mesh::MeshType Mesh::read(const std::string &pathname)
+Mesh::MeshType MeshReader::read(const std::string &pathname)
 {
   if (pathname.empty()) { throw std::invalid_argument("Empty pathname"); }
   if (!ShapeworksUtils::exists(pathname)) { throw std::invalid_argument(pathname + " does not exist"); }
@@ -119,6 +119,10 @@ Mesh::MeshType Mesh::read(const std::string &pathname)
   catch (const std::exception &exp) {
     throw std::invalid_argument("Failed to read: " + pathname);
   }
+}
+
+Mesh::Mesh(const std::string& pathname) : mesh(MeshReader::read(pathname)) {
+  invalidateLocators();
 }
 
 Mesh& Mesh::write(const std::string &pathname, bool binaryFile)

--- a/Testing/MeshTests/MeshTests.cpp
+++ b/Testing/MeshTests/MeshTests.cpp
@@ -9,6 +9,25 @@
 
 using namespace shapeworks;
 
+TEST(MeshTests, meshLocators)
+{
+  Mesh mesh1(std::string(TEST_DATA_DIR) + "/butterfly.vtk");
+  Mesh mesh2(std::string(TEST_DATA_DIR) + "/smoothsinc.vtk");
+  Point center_1 = mesh1.center();
+  Point center_2 = mesh2.center();
+  int center_id_1 = mesh1.closestPointId(center_1);
+  int center_id_2 = mesh2.closestPointId(center_2);
+  Point center_point_1 = mesh1.getPoint(center_id_1);
+  Point center_point_2 = mesh2.getPoint(center_id_2);
+  ASSERT_TRUE(center_id_1 != center_id_2 &&  // ensure next test doesn't succeed by coincidene
+              center_point_1 != center_point_2);
+
+  mesh2 = mesh1; // mesh2 should no longer use cached locators from mesh1
+  ASSERT_TRUE(mesh2.center() != center_2); // function doesn't update any locators, so uses cached
+  ASSERT_TRUE(mesh2.getPoint(center_id_1) == center_point_1); // doesn't update locators
+  ASSERT_TRUE(mesh2.closestPointId(center_1) == center_id_1); // updates point locater, so noop
+}
+
 TEST(MeshTests, writeTest1)
 {
   Mesh ellipsoid(std::string(TEST_DATA_DIR) + "/ellipsoid_01.vtk");


### PR DESCRIPTION
for copy ctors and assignment
also moves Mesh::read into independent class, protecting its undesired use by other Mesh functions
#1702 
