### PR TITLE
Image::evaluate

### DIFF
--- a/Applications/shapeworks/SharedCommandData.h
+++ b/Applications/shapeworks/SharedCommandData.h
@@ -16,7 +16,7 @@ struct SharedCommandData
   ParticleSystem particleSystem;
   Field field;
 
-  bool validImage() const { return image.image != nullptr; }
+  bool validImage() const { return image.itk_image_ != nullptr; }
   bool validMesh() const { return mesh != nullptr; }
   bool validParticleSystem() const {return particleSystem.N() >= 1 && particleSystem.D() >= 1; }
 };

--- a/Libs/Common/Shapeworks.cpp
+++ b/Libs/Common/Shapeworks.cpp
@@ -215,4 +215,8 @@ std::string axisToString(Axis axis)
   }
 }
 
+bool epsEqual(double a, double b, double eps) {
+  return std::abs(a-b) < eps;
+}
+
 }; //shapeworks

--- a/Libs/Common/Shapeworks.h
+++ b/Libs/Common/Shapeworks.h
@@ -283,4 +283,6 @@ bool epsEqual(const P &a, const P &b, const typename P::ValueType &eps)
   return std::abs(a[0]-b[0]) < eps && std::abs(a[1]-b[1]) < eps && std::abs(a[2]-b[2]) < eps;
 }
 
+bool epsEqual(double a, double b, double eps);
+
 } // shapeworks

--- a/Libs/Image/Image.cpp
+++ b/Libs/Image/Image.cpp
@@ -1,63 +1,61 @@
 #include "Image.h"
-#include "ShapeworksUtils.h"
-#include "itkTPGACLevelSetImageFilter.h"  // actually a shapeworks class, not itk
-#include "MeshUtils.h"
-#include "Exception.h"
 
-#include <itkImageFileReader.h>
-#include <itkImageFileWriter.h>
 #include <itkAntiAliasBinaryImageFilter.h>
-#include <itkResampleImageFilter.h>
-#include <itkChangeInformationImageFilter.h>
-#include <itkBinaryThresholdImageFilter.h>
-#include <itkConstantPadImageFilter.h>
-#include <itkTestingComparisonImageFilter.h>
-#include <itkRegionOfInterestImageFilter.h>
-#include <itkReinitializeLevelSetImageFilter.h>
-#include <itkScalableAffineTransform.h>
-#include <itkNearestNeighborInterpolateImageFunction.h>
 #include <itkBinaryFillholeImageFilter.h>
-#include <itkGradientMagnitudeImageFilter.h>
+#include <itkBinaryThresholdImageFilter.h>
+#include <itkChangeInformationImageFilter.h>
+#include <itkConnectedComponentImageFilter.h>
+#include <itkConstantPadImageFilter.h>
 #include <itkCurvatureFlowImageFilter.h>
-#include <itkSigmoidImageFilter.h>
-#include <itkImageSeriesReader.h>
-#include <itkGDCMImageIO.h>
-#include <itkGDCMSeriesFileNames.h>
 #include <itkDiscreteGaussianImageFilter.h>
 #include <itkExtractImageFilter.h>
+#include <itkGDCMImageIO.h>
+#include <itkGDCMSeriesFileNames.h>
+#include <itkGradientMagnitudeImageFilter.h>
 #include <itkImageDuplicator.h>
-#include <itkVTKImageExport.h>
-#include <itkIntensityWindowingImageFilter.h>
+#include <itkImageFileReader.h>
+#include <itkImageFileWriter.h>
+#include <itkImageSeriesReader.h>
 #include <itkImageToVTKImageFilter.h>
-#include <itkVTKImageToImageFilter.h>
-#include <itkOrientImageFilter.h>
-#include <itkConnectedComponentImageFilter.h>
-#include <itkRelabelComponentImageFilter.h>
-#include <itkThresholdImageFilter.h>
+#include <itkIntensityWindowingImageFilter.h>
 #include <itkMultiplyImageFilter.h>
-
-#include <vtkImageImport.h>
+#include <itkNearestNeighborInterpolateImageFunction.h>
+#include <itkOrientImageFilter.h>
+#include <itkRegionOfInterestImageFilter.h>
+#include <itkReinitializeLevelSetImageFilter.h>
+#include <itkRelabelComponentImageFilter.h>
+#include <itkResampleImageFilter.h>
+#include <itkScalableAffineTransform.h>
+#include <itkSigmoidImageFilter.h>
+#include <itkTestingComparisonImageFilter.h>
+#include <itkThresholdImageFilter.h>
+#include <itkVTKImageExport.h>
+#include <itkVTKImageToImageFilter.h>
 #include <vtkContourFilter.h>
-#include <vtkImageData.h>
 #include <vtkImageCast.h>
+#include <vtkImageData.h>
+#include <vtkImageImport.h>
 
-#include <exception>
 #include <cmath>
+#include <exception>
+
+#include "Exception.h"
+#include "MeshUtils.h"
+#include "ShapeworksUtils.h"
+#include "itkTPGACLevelSetImageFilter.h"  // actually a shapeworks class, not itk
 
 namespace shapeworks {
 
-Image::Image(const Dims dims) : itk_image_(ImageType::New())
-{
+Image::Image(const Dims dims) : itk_image_(ImageType::New()) {
   ImageType::RegionType region;
   region.SetSize(dims);
-  region.SetIndex(Coord({0,0,0}));
+  region.SetIndex(Coord({0, 0, 0}));
 
   itk_image_->SetRegions(region);
   itk_image_->Allocate();
 }
 
-Image::Image(const vtkSmartPointer<vtkImageData> vtkImage)
-{
+Image::Image(const vtkSmartPointer<vtkImageData> vtkImage) {
   // ensure input image data is PixelType (note: it'll either be float or double)
   auto cast = vtkSmartPointer<vtkImageCast>::New();
   cast->SetInputData(vtkImage);
@@ -74,8 +72,7 @@ Image::Image(const vtkSmartPointer<vtkImageData> vtkImage)
   this->itk_image_ = cloneData(filter->GetOutput());
 }
 
-vtkSmartPointer<vtkImageData> Image::getVTKImage() const
-{
+vtkSmartPointer<vtkImageData> Image::getVTKImage() const {
   using connectorType = itk::ImageToVTKImageFilter<Image::ImageType>;
   connectorType::Pointer connector = connectorType::New();
   connector->SetInput(this->itk_image_);
@@ -84,8 +81,7 @@ vtkSmartPointer<vtkImageData> Image::getVTKImage() const
   return connector->GetOutput();
 }
 
-Image::ImageType::Pointer Image::cloneData(const Image::ImageType::Pointer image)
-{
+Image::ImageType::Pointer Image::cloneData(const Image::ImageType::Pointer image) {
   using DuplicatorType = itk::ImageDuplicator<ImageType>;
   DuplicatorType::Pointer duplicator = DuplicatorType::New();
   duplicator->SetInputImage(image);
@@ -93,25 +89,23 @@ Image::ImageType::Pointer Image::cloneData(const Image::ImageType::Pointer image
   return duplicator->GetOutput();
 }
 
-Image& Image::operator=(const Image& img)
-{
+Image& Image::operator=(const Image& img) {
   this->itk_image_ = Image::cloneData(img.itk_image_);
   return *this;
 }
 
-Image& Image::operator=(Image&& img)
-{
-  this->itk_image_ = nullptr;        // make sure to free existing image by setting it to nullptr (works b/c it's a smart ptr)
+Image& Image::operator=(Image&& img) {
+  this->itk_image_ = nullptr;  // make sure to free existing image by setting it to nullptr (works b/c it's a smart ptr)
   this->itk_image_.Swap(img.itk_image_);
   return *this;
 }
 
-Image::ImageType::Pointer Image::read(const std::string &pathname)
-{
-  if (pathname.empty()) { throw std::invalid_argument("Empty pathname"); }
+Image::ImageType::Pointer Image::read(const std::string& pathname) {
+  if (pathname.empty()) {
+    throw std::invalid_argument("Empty pathname");
+  }
 
-  if (ShapeworksUtils::is_directory(pathname))
-    return readDICOMImage(pathname);
+  if (ShapeworksUtils::is_directory(pathname)) return readDICOMImage(pathname);
 
   using ReaderType = itk::ImageFileReader<ImageType>;
   ReaderType::Pointer reader = ReaderType::New();
@@ -119,8 +113,7 @@ Image::ImageType::Pointer Image::read(const std::string &pathname)
 
   try {
     reader->Update();
-  }
-  catch (itk::ExceptionObject &exp) {
+  } catch (itk::ExceptionObject& exp) {
     throw shapeworks_exception(std::string(exp.what()));
   }
 
@@ -132,8 +125,7 @@ Image::ImageType::Pointer Image::read(const std::string &pathname)
     Orienter::Pointer orienter = Orienter::New();
     orienter->UseImageDirectionOn();
     // set orientation to RAI
-    orienter->SetDesiredCoordinateOrientation(
-      itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI);
+    orienter->SetDesiredCoordinateOrientation(itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_RAI);
     orienter->SetInput(img);
     orienter->Update();
     img = orienter->GetOutput();
@@ -142,11 +134,9 @@ Image::ImageType::Pointer Image::read(const std::string &pathname)
   return img;
 }
 
-Image& Image::operator-()
-{
+Image& Image::operator-() {
   itk::ImageRegionIteratorWithIndex<ImageType> iter(this->itk_image_, itk_image_->GetLargestPossibleRegion());
-  while (!iter.IsAtEnd())
-  {
+  while (!iter.IsAtEnd()) {
     iter.Set(-iter.Value());
     ++iter;
   }
@@ -154,62 +144,61 @@ Image& Image::operator-()
   return *this;
 }
 
-Image Image::operator+(const Image& other) const
-{
+Image Image::operator+(const Image& other) const {
   Image ret(*this);
   ret += other;
   return ret;
 }
 
-Image& Image::operator+=(const Image& other)
-{
-  if (dims() != other.dims()) { throw std::invalid_argument("images must have same logical dims"); }
-  
+Image& Image::operator+=(const Image& other) {
+  if (dims() != other.dims()) {
+    throw std::invalid_argument("images must have same logical dims");
+  }
+
   itk::ImageRegionIteratorWithIndex<ImageType> iter(this->itk_image_, itk_image_->GetLargestPossibleRegion());
-  itk::ImageRegionIteratorWithIndex<ImageType> otherIter(other.itk_image_, other.itk_image_->GetLargestPossibleRegion());
-  while (!iter.IsAtEnd() && !otherIter.IsAtEnd())
-  {
+  itk::ImageRegionIteratorWithIndex<ImageType> otherIter(other.itk_image_,
+                                                         other.itk_image_->GetLargestPossibleRegion());
+  while (!iter.IsAtEnd() && !otherIter.IsAtEnd()) {
     iter.Set(iter.Value() + otherIter.Value());
-    ++iter; ++otherIter;
+    ++iter;
+    ++otherIter;
   }
 
   return *this;
 }
 
-Image Image::operator-(const Image& other) const
-{
+Image Image::operator-(const Image& other) const {
   Image ret(*this);
   ret -= other;
   return ret;
 }
 
-Image& Image::operator-=(const Image& other)
-{
-  if (dims() != other.dims()) { throw std::invalid_argument("images must have same logical dims"); }
-  
+Image& Image::operator-=(const Image& other) {
+  if (dims() != other.dims()) {
+    throw std::invalid_argument("images must have same logical dims");
+  }
+
   itk::ImageRegionIteratorWithIndex<ImageType> iter(this->itk_image_, itk_image_->GetLargestPossibleRegion());
-  itk::ImageRegionIteratorWithIndex<ImageType> otherIter(other.itk_image_, other.itk_image_->GetLargestPossibleRegion());
-  while (!iter.IsAtEnd() && !otherIter.IsAtEnd())
-  {
+  itk::ImageRegionIteratorWithIndex<ImageType> otherIter(other.itk_image_,
+                                                         other.itk_image_->GetLargestPossibleRegion());
+  while (!iter.IsAtEnd() && !otherIter.IsAtEnd()) {
     iter.Set(iter.Value() - otherIter.Value());
-    ++iter; ++otherIter;
+    ++iter;
+    ++otherIter;
   }
 
   return *this;
 }
 
-Image Image::operator+(const PixelType x) const
-{
+Image Image::operator+(const PixelType x) const {
   Image ret(*this);
   ret += x;
   return ret;
 }
 
-Image& Image::operator+=(const PixelType x)
-{
+Image& Image::operator+=(const PixelType x) {
   itk::ImageRegionIteratorWithIndex<ImageType> iter(this->itk_image_, itk_image_->GetLargestPossibleRegion());
-  while (!iter.IsAtEnd())
-  {
+  while (!iter.IsAtEnd()) {
     iter.Set(iter.Value() + x);
     ++iter;
   }
@@ -217,18 +206,15 @@ Image& Image::operator+=(const PixelType x)
   return *this;
 }
 
-Image Image::operator-(const PixelType x) const
-{
+Image Image::operator-(const PixelType x) const {
   Image ret(*this);
   ret -= x;
   return ret;
 }
 
-Image& Image::operator-=(const PixelType x)
-{
+Image& Image::operator-=(const PixelType x) {
   itk::ImageRegionIteratorWithIndex<ImageType> iter(this->itk_image_, itk_image_->GetLargestPossibleRegion());
-  while (!iter.IsAtEnd())
-  {
+  while (!iter.IsAtEnd()) {
     iter.Set(iter.Value() - x);
     ++iter;
   }
@@ -236,8 +222,7 @@ Image& Image::operator-=(const PixelType x)
   return *this;
 }
 
-Image Image::operator*(const Image &other) const
-{
+Image Image::operator*(const Image& other) const {
   using FilterType = itk::MultiplyImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -248,18 +233,15 @@ Image Image::operator*(const Image &other) const
   return Image(filter->GetOutput());
 }
 
-Image Image::operator*(const PixelType x) const
-{
+Image Image::operator*(const PixelType x) const {
   Image ret(*this);
   ret *= x;
   return ret;
 }
 
-Image& Image::operator*=(const PixelType x)
-{
+Image& Image::operator*=(const PixelType x) {
   itk::ImageRegionIteratorWithIndex<ImageType> iter(this->itk_image_, itk_image_->GetLargestPossibleRegion());
-  while (!iter.IsAtEnd())
-  {
+  while (!iter.IsAtEnd()) {
     iter.Set(iter.Value() * x);
     ++iter;
   }
@@ -267,18 +249,15 @@ Image& Image::operator*=(const PixelType x)
   return *this;
 }
 
-Image Image::operator/(const PixelType x) const
-{
+Image Image::operator/(const PixelType x) const {
   Image ret(*this);
   ret /= x;
   return ret;
 }
 
-Image& Image::operator/=(const PixelType x)
-{
+Image& Image::operator/=(const PixelType x) {
   itk::ImageRegionIteratorWithIndex<ImageType> iter(this->itk_image_, itk_image_->GetLargestPossibleRegion());
-  while (!iter.IsAtEnd())
-  {
+  while (!iter.IsAtEnd()) {
     iter.Set(iter.Value() / x);
     ++iter;
   }
@@ -286,21 +265,30 @@ Image& Image::operator/=(const PixelType x)
   return *this;
 }
 
-template<>
-Image operator*(const Image& img, const double x) { return img.operator*(x); }
+template <>
+Image operator*(const Image& img, const double x) {
+  return img.operator*(x);
+}
 
-template<>
-Image operator/(const Image& img, const double x) { return img.operator/(x); }
+template <>
+Image operator/(const Image& img, const double x) {
+  return img.operator/(x);
+}
 
-template<>
-Image& operator*=(Image& img, const double x) { return img.operator*=(x); }
+template <>
+Image& operator*=(Image& img, const double x) {
+  return img.operator*=(x);
+}
 
-template<>
-Image& operator/=(Image& img, const double x) { return img.operator/=(x); }
+template <>
+Image& operator/=(Image& img, const double x) {
+  return img.operator/=(x);
+}
 
-Image::ImageType::Pointer Image::readDICOMImage(const std::string &pathname)
-{
-  if (pathname.empty()) { throw std::invalid_argument("Empty pathname"); }
+Image::ImageType::Pointer Image::readDICOMImage(const std::string& pathname) {
+  if (pathname.empty()) {
+    throw std::invalid_argument("Empty pathname");
+  }
 
   using ReaderType = itk::ImageSeriesReader<ImageType>;
   using ImageIOType = itk::GDCMImageIO;
@@ -310,25 +298,27 @@ Image::ImageType::Pointer Image::readDICOMImage(const std::string &pathname)
   InputNamesGeneratorType::Pointer input_names = InputNamesGeneratorType::New();
   input_names->SetInputDirectory(pathname);
 
-  const ReaderType::FileNamesContainer &filenames = input_names->GetInputFileNames();
+  const ReaderType::FileNamesContainer& filenames = input_names->GetInputFileNames();
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetImageIO(gdcm_io);
   reader->SetFileNames(filenames);
 
   try {
     reader->Update();
-  }
-  catch (itk::ExceptionObject &exp) {
+  } catch (itk::ExceptionObject& exp) {
     throw std::invalid_argument("Failed to read DICOM from " + pathname + "(" + std::string(exp.what()) + ")");
   }
 
   return reader->GetOutput();
 }
 
-Image& Image::write(const std::string &filename, bool compressed)
-{
-  if (!this->itk_image_) { throw std::invalid_argument("Image invalid"); }
-  if (filename.empty()) { throw std::invalid_argument("Empty pathname"); }
+Image& Image::write(const std::string& filename, bool compressed) {
+  if (!this->itk_image_) {
+    throw std::invalid_argument("Image invalid");
+  }
+  if (filename.empty()) {
+    throw std::invalid_argument("Empty pathname");
+  }
 
   using WriterType = itk::ImageFileWriter<ImageType>;
   WriterType::Pointer writer = WriterType::New();
@@ -340,9 +330,10 @@ Image& Image::write(const std::string &filename, bool compressed)
   return *this;
 }
 
-Image& Image::antialias(unsigned iterations, double maxRMSErr, int layers)
-{
-  if (layers < 0) { throw std::invalid_argument("layers must be >= 0"); }
+Image& Image::antialias(unsigned iterations, double maxRMSErr, int layers) {
+  if (layers < 0) {
+    throw std::invalid_argument("layers must be >= 0");
+  }
 
   using FilterType = itk::AntiAliasBinaryImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
@@ -359,14 +350,10 @@ Image& Image::antialias(unsigned iterations, double maxRMSErr, int layers)
   return *this;
 }
 
-Image& Image::recenter()
-{
-  return setOrigin(negate(size() / 2.0));
-}
+Image& Image::recenter() { return setOrigin(negate(size() / 2.0)); }
 
 Image& Image::resample(const TransformPtr transform, const Point3 origin, Dims dims, const Vector3 spacing,
-                       const ImageType::DirectionType direction, Image::InterpolationType interp)
-{
+                       const ImageType::DirectionType direction, Image::InterpolationType interp) {
   using FilterType = itk::ResampleImageFilter<ImageType, ImageType>;
   FilterType::Pointer resampler = FilterType::New();
 
@@ -374,8 +361,7 @@ Image& Image::resample(const TransformPtr transform, const Point3 origin, Dims d
     case Linear:
       // linear interpolation is the default
       break;
-    case NearestNeighbor:
-    {
+    case NearestNeighbor: {
       using InterpolatorType = itk::NearestNeighborInterpolateImageFunction<ImageType, double>;
       InterpolatorType::Pointer interpolator = InterpolatorType::New();
       resampler->SetInterpolator(interpolator);
@@ -398,27 +384,24 @@ Image& Image::resample(const TransformPtr transform, const Point3 origin, Dims d
   return *this;
 }
 
-Image& Image::resample(const Vector3& spacing, Image::InterpolationType interp)
-{
+Image& Image::resample(const Vector3& spacing, Image::InterpolationType interp) {
   // compute logical dimensions that keep all image data for this spacing
   Dims inputDims(this->dims());
   Vector3 inputSpacing(this->spacing());
-  Dims dims({ static_cast<unsigned>(std::floor(inputDims[0] * inputSpacing[0] / spacing[0])),
-              static_cast<unsigned>(std::floor(inputDims[1] * inputSpacing[1] / spacing[1])),
-              static_cast<unsigned>(std::floor(inputDims[2] * inputSpacing[2] / spacing[2])) });
-  
+  Dims dims({static_cast<unsigned>(std::floor(inputDims[0] * inputSpacing[0] / spacing[0])),
+             static_cast<unsigned>(std::floor(inputDims[1] * inputSpacing[1] / spacing[1])),
+             static_cast<unsigned>(std::floor(inputDims[2] * inputSpacing[2] / spacing[2]))});
+
   Point3 new_origin = origin() + toPoint(0.5 * (spacing - inputSpacing));  // O' += 0.5 * (p' - p)
 
   return resample(IdentityTransform::New(), new_origin, dims, spacing, coordsys(), interp);
 }
 
-Image& Image::resample(double isoSpacing, Image::InterpolationType interp)
-{
+Image& Image::resample(double isoSpacing, Image::InterpolationType interp) {
   return resample(makeVector({isoSpacing, isoSpacing, isoSpacing}), interp);
 }
 
-Image& Image::resize(Dims dims, Image::InterpolationType interp)
-{
+Image& Image::resize(Dims dims, Image::InterpolationType interp) {
   // use existing dims for any that are unspecified
   Dims inputDims(this->dims());
   if (dims[0] == 0) dims[0] = inputDims[0];
@@ -427,17 +410,17 @@ Image& Image::resize(Dims dims, Image::InterpolationType interp)
 
   // compute new spacing so physical image size remains the same
   Vector3 inputSpacing(spacing());
-  Vector3 spacing(makeVector({ inputSpacing[0] * inputDims[0] / dims[0],
-                               inputSpacing[1] * inputDims[1] / dims[1],
-                               inputSpacing[2] * inputDims[2] / dims[2] }));
+  Vector3 spacing(makeVector({inputSpacing[0] * inputDims[0] / dims[0], inputSpacing[1] * inputDims[1] / dims[1],
+                              inputSpacing[2] * inputDims[2] / dims[2]}));
 
   return resample(IdentityTransform::New(), origin(), dims, spacing, coordsys(), interp);
 }
 
-bool Image::compare(const Image& other, bool verifyall, double tolerance, double precision) const
-{
-  if (tolerance > 1 || tolerance < 0) { throw std::invalid_argument("tolerance value must be between 0 and 1 (inclusive)"); }
-  
+bool Image::compare(const Image& other, bool verifyall, double tolerance, double precision) const {
+  if (tolerance > 1 || tolerance < 0) {
+    throw std::invalid_argument("tolerance value must be between 0 and 1 (inclusive)");
+  }
+
   // we use the region of interest filter here with the full region because our
   // incoming image may be the output of an ExtractImageFilter or PadImageFilter
   // which modify indices and leave the origin intact.  These will not compare
@@ -467,8 +450,7 @@ bool Image::compare(const Image& other, bool verifyall, double tolerance, double
 
   try {
     diff->UpdateLargestPossibleRegion();
-  }
-  catch (itk::ExceptionObject &exp) {
+  } catch (itk::ExceptionObject& exp) {
     return false;
   }
 
@@ -482,13 +464,9 @@ bool Image::compare(const Image& other, bool verifyall, double tolerance, double
   return true;
 }
 
-Image& Image::pad(int padding, PixelType value)
-{
-  return this->pad(padding, padding, padding, value);
-}
+Image& Image::pad(int padding, PixelType value) { return this->pad(padding, padding, padding, value); }
 
-Image& Image::pad(int padx, int pady, int padz, PixelType value)
-{
+Image& Image::pad(int padx, int pady, int padz, PixelType value) {
   ImageType::SizeType lowerExtendRegion;
   lowerExtendRegion[0] = padx;
   lowerExtendRegion[1] = pady;
@@ -502,10 +480,9 @@ Image& Image::pad(int padx, int pady, int padz, PixelType value)
   return this->pad(lowerExtendRegion, upperExtendRegion, value);
 }
 
-Image& Image::pad(IndexRegion &region, PixelType value)
-{
+Image& Image::pad(IndexRegion& region, PixelType value) {
   auto bbox = logicalBoundingBox();
-  
+
   // compute positive numbers to pad in each direction
   ImageType::SizeType lowerExtendRegion;
   lowerExtendRegion[0] = std::max(Coord::IndexValueType(0), -region.min[0]);
@@ -520,8 +497,7 @@ Image& Image::pad(IndexRegion &region, PixelType value)
   return this->pad(lowerExtendRegion, upperExtendRegion, value);
 }
 
-Image& Image::pad(Dims lowerExtendRegion, Dims upperExtendRegion, PixelType value)
-{
+Image& Image::pad(Dims lowerExtendRegion, Dims upperExtendRegion, PixelType value) {
   using FilterType = itk::ConstantPadImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -535,31 +511,30 @@ Image& Image::pad(Dims lowerExtendRegion, Dims upperExtendRegion, PixelType valu
   return *this;
 }
 
-Image& Image::translate(const Vector3 &v)
-{
+Image& Image::translate(const Vector3& v) {
   AffineTransformPtr xform(AffineTransform::New());
-  xform->Translate(-v);            // negate v because ITK applies transformations backwards.
+  xform->Translate(-v);  // negate v because ITK applies transformations backwards.
 
   return applyTransform(xform);
 }
 
-Image& Image::scale(const Vector3 &s)
-{
-  if (s[0] == 0 || s[1] == 0 || s[2] == 0) { throw std::invalid_argument("Invalid scale point"); }
+Image& Image::scale(const Vector3& s) {
+  if (s[0] == 0 || s[1] == 0 || s[2] == 0) {
+    throw std::invalid_argument("Invalid scale point");
+  }
 
-  auto origOrigin(origin());       // scale centered at origin, so temporarily set origin to be the center
+  auto origOrigin(origin());  // scale centered at origin, so temporarily set origin to be the center
   recenter();
 
   AffineTransformPtr xform(AffineTransform::New());
-  xform->Scale(invertValue(Vector(s))); // invert scale ratio because ITK applies transformations backwards.  
+  xform->Scale(invertValue(Vector(s)));  // invert scale ratio because ITK applies transformations backwards.
   applyTransform(xform);
-  setOrigin(origOrigin);           // restore origin
-  
+  setOrigin(origOrigin);  // restore origin
+
   return *this;
 }
 
-Image& Image::rotate(const double angle, Axis axis)
-{
+Image& Image::rotate(const double angle, Axis axis) {
   switch (axis) {
     case X:
       return rotate(angle, makeVector({1.0, 0.0, 0.0}));
@@ -572,41 +547,38 @@ Image& Image::rotate(const double angle, Axis axis)
   }
 }
 
-Image& Image::rotate(const double angle, const Vector3 &axis)
-{
-  if (!axis_is_valid(axis)) { throw std::invalid_argument("Invalid axis"); }
+Image& Image::rotate(const double angle, const Vector3& axis) {
+  if (!axis_is_valid(axis)) {
+    throw std::invalid_argument("Invalid axis");
+  }
 
-  auto origOrigin(origin());       // rotation is around origin, so temporarily set origin to be the center
+  auto origOrigin(origin());  // rotation is around origin, so temporarily set origin to be the center
   recenter();
 
   AffineTransformPtr xform(AffineTransform::New());
-  xform->Rotate3D(axis, -angle);   // negate angle because ITK applies transformations backwards.  
+  xform->Rotate3D(axis, -angle);  // negate angle because ITK applies transformations backwards.
   applyTransform(xform);
-  setOrigin(origOrigin);           // restore origin
-  
+  setOrigin(origOrigin);  // restore origin
+
   return *this;
 }
 
-Image& Image::applyTransform(const TransformPtr transform, Image::InterpolationType interp)
-{
+Image& Image::applyTransform(const TransformPtr transform, Image::InterpolationType interp) {
   return applyTransform(transform, origin(), dims(), spacing(), coordsys(), interp);
 }
 
 Image& Image::applyTransform(const TransformPtr transform, const Point3 origin, const Dims dims, const Vector3 spacing,
-                             const ImageType::DirectionType coordsys, Image::InterpolationType interp)
-{
+                             const ImageType::DirectionType coordsys, Image::InterpolationType interp) {
   return resample(transform, origin, dims, spacing, coordsys, interp);
 }
 
-Image& Image::extractLabel(const PixelType label)
-{
+Image& Image::extractLabel(const PixelType label) {
   binarize(label - std::numeric_limits<PixelType>::epsilon(), label + std::numeric_limits<PixelType>::epsilon());
 
   return *this;
 }
 
-Image& Image::closeHoles(const PixelType foreground)
-{
+Image& Image::closeHoles(const PixelType foreground) {
   using FilterType = itk::BinaryFillholeImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -618,8 +590,7 @@ Image& Image::closeHoles(const PixelType foreground)
   return *this;
 }
 
-Image& Image::binarize(PixelType minVal, PixelType maxVal, PixelType innerVal, PixelType outerVal)
-{
+Image& Image::binarize(PixelType minVal, PixelType maxVal, PixelType innerVal, PixelType outerVal) {
   using FilterType = itk::BinaryThresholdImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -634,8 +605,7 @@ Image& Image::binarize(PixelType minVal, PixelType maxVal, PixelType innerVal, P
   return *this;
 }
 
-Image& Image::computeDT(PixelType isoValue)
-{
+Image& Image::computeDT(PixelType isoValue) {
   using FilterType = itk::ReinitializeLevelSetImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -648,9 +618,10 @@ Image& Image::computeDT(PixelType isoValue)
   return *this;
 }
 
-Image& Image::applyCurvatureFilter(unsigned iterations)
-{
-  if (iterations < 0) { throw std::invalid_argument("iterations must be >= 0"); }
+Image& Image::applyCurvatureFilter(unsigned iterations) {
+  if (iterations < 0) {
+    throw std::invalid_argument("iterations must be >= 0");
+  }
 
   using FilterType = itk::CurvatureFlowImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
@@ -664,20 +635,18 @@ Image& Image::applyCurvatureFilter(unsigned iterations)
   return *this;
 }
 
-Image& Image::applyGradientFilter()
-{
+Image& Image::applyGradientFilter() {
   using FilterType = itk::GradientMagnitudeImageFilter<ImageType, ImageType>;
-  FilterType::Pointer filter  = FilterType::New();
+  FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput(this->itk_image_);
   filter->Update();
   this->itk_image_ = filter->GetOutput();
-  
+
   return *this;
 }
 
-Image& Image::applySigmoidFilter(double alpha, double beta)
-{
+Image& Image::applySigmoidFilter(double alpha, double beta) {
   using FilterType = itk::SigmoidImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -692,11 +661,13 @@ Image& Image::applySigmoidFilter(double alpha, double beta)
   return *this;
 }
 
-Image& Image::applyTPLevelSetFilter(const Image& featureImage, double scaling)
-{
-  if (!featureImage.itk_image_) { throw std::invalid_argument("Invalid feature image"); }
+Image& Image::applyTPLevelSetFilter(const Image& featureImage, double scaling) {
+  if (!featureImage.itk_image_) {
+    throw std::invalid_argument("Invalid feature image");
+  }
 
-  using FilterType = itk::TPGACLevelSetImageFilter<ImageType, ImageType>; // TODO: this is no longer part of ITK and should be updated
+  using FilterType =
+      itk::TPGACLevelSetImageFilter<ImageType, ImageType>;  // TODO: this is no longer part of ITK and should be updated
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetPropagationScaling(scaling);
@@ -712,16 +683,14 @@ Image& Image::applyTPLevelSetFilter(const Image& featureImage, double scaling)
   return *this;
 }
 
-Image& Image::topologyPreservingSmooth(float scaling, float sigmoidAlpha, float sigmoidBeta)
-{
+Image& Image::topologyPreservingSmooth(float scaling, float sigmoidAlpha, float sigmoidBeta) {
   Image featureImage(*this);
   featureImage.applyGradientFilter().applySigmoidFilter(sigmoidAlpha, sigmoidBeta);
 
   return applyTPLevelSetFilter(featureImage, scaling);
 }
 
-Image& Image::applyIntensityFilter(double minVal, double maxVal)
-{
+Image& Image::applyIntensityFilter(double minVal, double maxVal) {
   using FilterType = itk::IntensityWindowingImageFilter<ImageType, ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -736,8 +705,7 @@ Image& Image::applyIntensityFilter(double minVal, double maxVal)
   return *this;
 }
 
-Image& Image::gaussianBlur(double sigma)
-{
+Image& Image::gaussianBlur(double sigma) {
   using BlurType = itk::DiscreteGaussianImageFilter<ImageType, ImageType>;
   BlurType::Pointer blur = BlurType::New();
 
@@ -749,9 +717,8 @@ Image& Image::gaussianBlur(double sigma)
   return *this;
 }
 
-Image& Image::crop(PhysicalRegion region, const int padding)
-{
-  region.shrink(physicalBoundingBox()); // clip region to fit inside image
+Image& Image::crop(PhysicalRegion region, const int padding) {
+  region.shrink(physicalBoundingBox());  // clip region to fit inside image
   if (!region.valid()) {
     throw std::invalid_argument("Invalid region specified (it may lie outside physical bounds of image).");
   }
@@ -769,18 +736,17 @@ Image& Image::crop(PhysicalRegion region, const int padding)
   return *this;
 }
 
-Image& Image::clip(const Plane plane, const PixelType val)
-{
-  if (!axis_is_valid(getNormal(plane))) { throw std::invalid_argument("Invalid clipping plane (zero length normal)"); }
+Image& Image::clip(const Plane plane, const PixelType val) {
+  if (!axis_is_valid(getNormal(plane))) {
+    throw std::invalid_argument("Invalid clipping plane (zero length normal)");
+  }
 
   itk::ImageRegionIteratorWithIndex<ImageType> iter(this->itk_image_, itk_image_->GetLargestPossibleRegion());
-  while (!iter.IsAtEnd())
-  {
+  while (!iter.IsAtEnd()) {
     Vector pq(logicalToPhysical(iter.GetIndex()) - getOrigin(plane));
 
     // if n dot pq is < 0, point q is on the back side of the plane.
-    if (getNormal(plane) * pq < 0.0)
-      iter.Set(val);
+    if (getNormal(plane) * pq < 0.0) iter.Set(val);
 
     ++iter;
   }
@@ -788,11 +754,12 @@ Image& Image::clip(const Plane plane, const PixelType val)
   return *this;
 }
 
-Image& Image::reflect(const Axis &axis)
-{
-  if (!axis_is_valid(axis)) { throw std::invalid_argument("Invalid axis"); }
+Image& Image::reflect(const Axis& axis) {
+  if (!axis_is_valid(axis)) {
+    throw std::invalid_argument("Invalid axis");
+  }
 
-  Vector scale(makeVector({1,1,1}));
+  Vector scale(makeVector({1, 1, 1}));
   scale[axis] = -1;
 
   using ScalableTransform = itk::ScalableAffineTransform<double, 3>;
@@ -804,8 +771,7 @@ Image& Image::reflect(const Axis &axis)
   return *this;
 }
 
-Image& Image::setOrigin(Point3 origin)
-{
+Image& Image::setOrigin(Point3 origin) {
   using FilterType = itk::ChangeInformationImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -818,9 +784,10 @@ Image& Image::setOrigin(Point3 origin)
   return *this;
 }
 
-Image& Image::setSpacing(Vector3 spacing)
-{
-  if (spacing[0]<= 0 || spacing[1] <= 0 || spacing[2] <= 0) { throw std::invalid_argument("Spacing cannot b <= 0"); }
+Image& Image::setSpacing(Vector3 spacing) {
+  if (spacing[0] <= 0 || spacing[1] <= 0 || spacing[2] <= 0) {
+    throw std::invalid_argument("Spacing cannot b <= 0");
+  }
 
   using FilterType = itk::ChangeInformationImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
@@ -834,8 +801,7 @@ Image& Image::setSpacing(Vector3 spacing)
   return *this;
 }
 
-Image& Image::setCoordsys(ImageType::DirectionType coordsys)
-{
+Image& Image::setCoordsys(ImageType::DirectionType coordsys) {
   using FilterType = itk::ChangeInformationImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -848,8 +814,7 @@ Image& Image::setCoordsys(ImageType::DirectionType coordsys)
   return *this;
 }
 
-Image &Image::isolate()
-{
+Image& Image::isolate() {
   typedef itk::Image<unsigned char, 3> IsolateType;
   typedef itk::CastImageFilter<ImageType, IsolateType> ToIntType;
   ToIntType::Pointer filter = ToIntType::New();
@@ -883,17 +848,14 @@ Image &Image::isolate()
   return *this;
 }
 
-Point3 Image::centerOfMass(PixelType minVal, PixelType maxVal) const
-{
+Point3 Image::centerOfMass(PixelType minVal, PixelType maxVal) const {
   itk::ImageRegionIteratorWithIndex<ImageType> imageIt(this->itk_image_, itk_image_->GetLargestPossibleRegion());
   int numPixels = 0;
   Point3 com({0.0, 0.0, 0.0});
 
-  while (!imageIt.IsAtEnd())
-  {
+  while (!imageIt.IsAtEnd()) {
     PixelType val = imageIt.Get();
-    if (val > minVal && val <= maxVal)
-    {
+    if (val > minVal && val <= maxVal) {
       numPixels++;
       com += itk_image_->TransformIndexToPhysicalPoint<double>(imageIt.GetIndex());
     }
@@ -908,8 +870,7 @@ Point3 Image::centerOfMass(PixelType minVal, PixelType maxVal) const
   return com;
 }
 
-Image::StatsPtr Image::statsFilter()
-{
+Image::StatsPtr Image::statsFilter() {
   using FilterType = itk::StatisticsImageFilter<ImageType>;
   FilterType::Pointer filter = FilterType::New();
 
@@ -918,91 +879,73 @@ Image::StatsPtr Image::statsFilter()
   return filter;
 }
 
-Image::PixelType Image::min()
-{
+Image::PixelType Image::min() {
   StatsPtr filter = statsFilter();
   return filter->GetMinimum();
 }
 
-Image::PixelType Image::max()
-{
+Image::PixelType Image::max() {
   StatsPtr filter = statsFilter();
   return filter->GetMaximum();
 }
 
-Image::PixelType Image::mean()
-{
+Image::PixelType Image::mean() {
   StatsPtr filter = statsFilter();
   return filter->GetMean();
 }
 
-Image::PixelType Image::std()
-{
+Image::PixelType Image::std() {
   StatsPtr filter = statsFilter();
   return sqrt(filter->GetVariance());
 }
 
-IndexRegion Image::logicalBoundingBox() const
-{
-  IndexRegion region(Coord({0, 0, 0}), toCoord(dims() - Dims({1,1,1})));
+IndexRegion Image::logicalBoundingBox() const {
+  IndexRegion region(Coord({0, 0, 0}), toCoord(dims() - Dims({1, 1, 1})));
   return region;
 }
 
-PhysicalRegion Image::physicalBoundingBox() const
-{
-  
-  PhysicalRegion region(origin(), origin() + dotProduct(toVector(dims() - Dims({1,1,1})), spacing()));
+PhysicalRegion Image::physicalBoundingBox() const {
+  PhysicalRegion region(origin(), origin() + dotProduct(toVector(dims() - Dims({1, 1, 1})), spacing()));
   return region;
 }
 
-PhysicalRegion Image::physicalBoundingBox(PixelType isoValue) const
-{
+PhysicalRegion Image::physicalBoundingBox(PixelType isoValue) const {
   PhysicalRegion bbox;
 
   itk::ImageRegionIteratorWithIndex<ImageType> imageIterator(itk_image_, itk_image_->GetLargestPossibleRegion());
-  while (!imageIterator.IsAtEnd())
-  {
+  while (!imageIterator.IsAtEnd()) {
     PixelType val = imageIterator.Get();
 
-    if (val >= isoValue)
-      bbox.expand(logicalToPhysical(imageIterator.GetIndex()));
+    if (val >= isoValue) bbox.expand(logicalToPhysical(imageIterator.GetIndex()));
 
     ++imageIterator;
   }
-  
+
   return bbox;
 }
 
-PhysicalRegion Image::logicalToPhysical(const IndexRegion region) const
-{
+PhysicalRegion Image::logicalToPhysical(const IndexRegion region) const {
   return PhysicalRegion(logicalToPhysical(region.min), logicalToPhysical(region.max));
 }
 
-IndexRegion Image::physicalToLogical(const PhysicalRegion region) const
-{
+IndexRegion Image::physicalToLogical(const PhysicalRegion region) const {
   return IndexRegion(physicalToLogical(region.min), physicalToLogical(region.max));
 }
 
-Point3 Image::logicalToPhysical(const Coord &v) const
-{
+Point3 Image::logicalToPhysical(const Coord& v) const {
   Point3 value;
   itk_image_->TransformIndexToPhysicalPoint(v, value);
   return value;
 }
 
-Coord Image::physicalToLogical(const Point3 &p) const
-{
-  return itk_image_->TransformPhysicalPointToIndex(p);
-}
+Coord Image::physicalToLogical(const Point3& p) const { return itk_image_->TransformPhysicalPointToIndex(p); }
 
-Image::ImageIterator Image::iterator()
-{ 
+Image::ImageIterator Image::iterator() {
   ImageIterator iter(this->itk_image_, itk_image_->GetRequestedRegion());
   return iter;
 }
 
-Mesh Image::toMesh(PixelType isoValue) const
-{
+Mesh Image::toMesh(PixelType isoValue) const {
   auto vtkImage = getVTKImage();
 
   auto targetContour = vtkSmartPointer<vtkContourFilter>::New();
@@ -1013,8 +956,7 @@ Mesh Image::toMesh(PixelType isoValue) const
   return Mesh(targetContour->GetOutput());
 }
 
-Image::PixelType Image::evaluate(Point p)
-{
+Image::PixelType Image::evaluate(Point p) {
   if (!interpolator_) {
     interpolator_ = InterpolatorType::New();
     interpolator_->SetInputImage(itk_image_);
@@ -1022,15 +964,13 @@ Image::PixelType Image::evaluate(Point p)
   return interpolator_->Evaluate(p);
 }
 
-TransformPtr Image::createCenterOfMassTransform()
-{
+TransformPtr Image::createCenterOfMassTransform() {
   AffineTransformPtr xform(AffineTransform::New());
-  xform->Translate(-(center() - centerOfMass())); // ITK translations go in a counterintuitive direction
+  xform->Translate(-(center() - centerOfMass()));  // ITK translations go in a counterintuitive direction
   return xform;
 }
 
-TransformPtr Image::createRigidRegistrationTransform(const Image &target_dt, float isoValue, unsigned iterations)
-{
+TransformPtr Image::createRigidRegistrationTransform(const Image& target_dt, float isoValue, unsigned iterations) {
   if (!target_dt.itk_image_) {
     throw std::invalid_argument("Invalid target. Expected distance transform image");
   }
@@ -1041,8 +981,7 @@ TransformPtr Image::createRigidRegistrationTransform(const Image &target_dt, flo
   try {
     auto mat = MeshUtils::createICPTransform(sourceContour, targetContour, Mesh::Rigid, iterations);
     return shapeworks::createTransform(ShapeworksUtils::getMatrix(mat), ShapeworksUtils::getOffset(mat));
-  }
-  catch (std::invalid_argument) {
+  } catch (std::invalid_argument) {
     std::cerr << "failed to create ICP transform.\n";
     if (sourceContour.numPoints() == 0) {
       std::cerr << "\tspecified isoValue (" << isoValue << ") results in an empty mesh for source\n";
@@ -1054,11 +993,9 @@ TransformPtr Image::createRigidRegistrationTransform(const Image &target_dt, flo
   return AffineTransform::New();
 }
 
-std::ostream& operator<<(std::ostream &os, const Image& img)
-{
-  return os << "{\n\tdims: " << img.dims() << ",\n\torigin: "
-            << img.origin() << ",\n\tsize: " << img.size()
-            << ",\n\tspacing: " << img.spacing() <<  "\n}";
+std::ostream& operator<<(std::ostream& os, const Image& img) {
+  return os << "{\n\tdims: " << img.dims() << ",\n\torigin: " << img.origin() << ",\n\tsize: " << img.size()
+            << ",\n\tspacing: " << img.spacing() << "\n}";
 }
 
-} // shapeworks
+}  // namespace shapeworks

--- a/Libs/Image/Image.cpp
+++ b/Libs/Image/Image.cpp
@@ -1012,6 +1012,15 @@ Mesh Image::toMesh(PixelType isoValue) const
   return Mesh(targetContour->GetOutput());
 }
 
+Image::PixelType Image::evaluate(Point p)
+{
+  if (!interpolator_) {
+    interpolator_ = InterpolatorType::New();
+    interpolator_->SetInputImage(image);
+  }
+  return interpolator_->Evaluate(p);
+}
+
 TransformPtr Image::createCenterOfMassTransform()
 {
   AffineTransformPtr xform(AffineTransform::New());

--- a/Libs/Image/Image.h
+++ b/Libs/Image/Image.h
@@ -9,7 +9,7 @@
 #include <vtkImageData.h>
 #include <itkStatisticsImageFilter.h>
 #include <itkImageRegionIterator.h>
-
+#include <itkLinearInterpolateImageFunction.h>
 #include <limits>
 
 namespace shapeworks {
@@ -32,6 +32,7 @@ public:
   using ImageType = itk::Image<PixelType, 3>;
   using StatsPtr = itk::StatisticsImageFilter<ImageType>::Pointer;
   using ImageIterator = itk::ImageRegionIterator<ImageType>;
+  using InterpolatorType = itk::LinearInterpolateImageFunction<ImageType, Image::PixelType>;
 
   // constructors and assignment operators //
   Image(const Dims dims);
@@ -260,6 +261,9 @@ public:
   /// converts image to mesh
   Mesh toMesh(PixelType isovalue) const;
 
+  //! Evaluates the image at a given position
+  Image::PixelType evaluate(Point p);
+
 private:
   friend struct SharedCommandData;
   Image() : image(nullptr) {} // only for use by SharedCommandData since an Image should always be valid, never "empty"
@@ -280,6 +284,9 @@ private:
   StatsPtr statsFilter();
 
   ImageType::Pointer image;
+
+  InterpolatorType::Pointer interpolator_;
+
 };
 
 /// stream insertion operators for Image

--- a/Libs/Image/Image.h
+++ b/Libs/Image/Image.h
@@ -1,16 +1,17 @@
 #pragma once
 
-#include "Shapeworks.h"
-#include "Region.h"
-
 #include <itkImage.h>
-#include <vtkSmartPointer.h>
-#include <vtkPolyData.h>
-#include <vtkImageData.h>
-#include <itkStatisticsImageFilter.h>
 #include <itkImageRegionIterator.h>
 #include <itkLinearInterpolateImageFunction.h>
+#include <itkStatisticsImageFilter.h>
+#include <vtkImageData.h>
+#include <vtkPolyData.h>
+#include <vtkSmartPointer.h>
+
 #include <limits>
+
+#include "Region.h"
+#include "Shapeworks.h"
 
 namespace shapeworks {
 
@@ -23,9 +24,8 @@ class Mesh;
  * This class represents a 3D image volume and operations that can be performed on images.
  *
  */
-class Image
-{
-public:
+class Image {
+ public:
   enum InterpolationType { Linear, NearestNeighbor };
 
   using PixelType = float;
@@ -36,13 +36,15 @@ public:
 
   // constructors and assignment operators //
   Image(const Dims dims);
-  Image(const std::string &pathname) : itk_image_(read(pathname)) {}
-  Image(ImageType::Pointer imagePtr) : itk_image_(imagePtr) { if (!itk_image_) throw std::invalid_argument("null imagePtr"); }
+  Image(const std::string& pathname) : itk_image_(read(pathname)) {}
+  Image(ImageType::Pointer imagePtr) : itk_image_(imagePtr) {
+    if (!itk_image_) throw std::invalid_argument("null imagePtr");
+  }
   Image(const vtkSmartPointer<vtkImageData> vtkImage);
   Image(Image&& img) : itk_image_(nullptr) { this->itk_image_.Swap(img.itk_image_); }
   Image(const Image& img) : itk_image_(cloneData(img.itk_image_)) {}
-  Image& operator=(const Image& img); /// lvalue assignment operator
-  Image& operator=(Image&& img);      /// rvalue assignment operator
+  Image& operator=(const Image& img);  /// lvalue assignment operator
+  Image& operator=(Image&& img);       /// rvalue assignment operator
 
   /// return this as an ITK image
   operator ImageType::Pointer() { return itk_image_; }
@@ -50,7 +52,7 @@ public:
 
   /// creates a VTK filter for the given image
   vtkSmartPointer<vtkImageData> getVTKImage() const;
-  
+
   // modification functions //
 
   /// negation operator
@@ -85,20 +87,24 @@ public:
 
   /// antialiases image
   Image& antialias(unsigned iterations = 50, double maxRMSErr = 0.01f, int layers = 3);
-  
-  /// helper identical to setOrigin(image.center()) changing origin (in the image header) to physcial center of the image
+
+  /// helper identical to setOrigin(image.center()) changing origin (in the image header) to physcial center of the
+  /// image
   Image& recenter();
 
-  /// resamples by applying transform then sampling from given origin along direction axes at spacing physical units per pixel for dims pixels using specified interpolator
-  Image& resample(const TransformPtr transform, const Point3 origin, const Dims dims, const Vector3 spacing, const ImageType::DirectionType direction, InterpolationType interp = NearestNeighbor);
+  /// resamples by applying transform then sampling from given origin along direction axes at spacing physical units per
+  /// pixel for dims pixels using specified interpolator
+  Image& resample(const TransformPtr transform, const Point3 origin, const Dims dims, const Vector3 spacing,
+                  const ImageType::DirectionType direction, InterpolationType interp = NearestNeighbor);
 
   /// resamples image using new physical spacing, updating logical dims to keep all image data for this spacing
   Image& resample(const Vector& physicalSpacing, InterpolationType interp = Linear);
-  
+
   /// resamples image using isotropic physical spacing
   Image& resample(double isoSpacing = 1.0, InterpolationType interp = Linear);
 
-  /// changes logical image size, computing new physical spacing based on this size (i.e., physical image size remains the same)
+  /// changes logical image size, computing new physical spacing based on this size (i.e., physical image size remains
+  /// the same)
   Image& resize(Dims logicalDims, InterpolationType interp = Linear);
 
   /// pads an image by same number of voxels in all directions with constant value
@@ -108,16 +114,16 @@ public:
   Image& pad(int padx, int pady, int padz, PixelType value = 0.0);
 
   /// pads an image to include the given region with constant value
-  Image& pad(IndexRegion &region, PixelType value = 0.0);
+  Image& pad(IndexRegion& region, PixelType value = 0.0);
 
   /// helper to simply translate image
-  Image& translate(const Vector3 &v);
+  Image& translate(const Vector3& v);
 
   /// helper to simply scale image around center (not origin)
-  Image& scale(const Vector3 &v);
+  Image& scale(const Vector3& v);
 
   /// helper to simply rotate around axis through center (not origin) by given angle (in radians)
-  Image& rotate(const double angle, const Vector3 &axis);
+  Image& rotate(const double angle, const Vector3& axis);
 
   /// helper to simply rotate around axis through center (not origin) by given angle (in radians)
   Image& rotate(const double angle, Axis axis);
@@ -125,23 +131,29 @@ public:
   /// creates a transform that translates center of mass to center of image
   TransformPtr createCenterOfMassTransform();
 
-  /// creates transform to target image using iterative closest point (ICP) registration; images MUST be distance transforms; isovalue is used to create meshes from these distance transform images, which are then passed to ICP for the given number of iterations
-  TransformPtr createRigidRegistrationTransform(const Image &target_dt, float isoValue = 0.0, unsigned iterations = 20);
+  /// creates transform to target image using iterative closest point (ICP) registration; images MUST be distance
+  /// transforms; isovalue is used to create meshes from these distance transform images, which are then passed to ICP
+  /// for the given number of iterations
+  TransformPtr createRigidRegistrationTransform(const Image& target_dt, float isoValue = 0.0, unsigned iterations = 20);
 
   /// applies the given transformation to the image by using resampling filter
   Image& applyTransform(const TransformPtr transform, InterpolationType interp = Linear);
 
-  /// applies the given transformation to the image by using resampling filter with new origin, dims, spacing and direction values
-  Image& applyTransform(const TransformPtr transform, const Point3 origin, const Dims dims, const Vector3 spacing, const ImageType::DirectionType direction, InterpolationType interp = NearestNeighbor);
+  /// applies the given transformation to the image by using resampling filter with new origin, dims, spacing and
+  /// direction values
+  Image& applyTransform(const TransformPtr transform, const Point3 origin, const Dims dims, const Vector3 spacing,
+                        const ImageType::DirectionType direction, InterpolationType interp = NearestNeighbor);
 
-  /// extracts/isolates a specific voxel label from a given multi-label volume and outputs the corresponding binary image
+  /// extracts/isolates a specific voxel label from a given multi-label volume and outputs the corresponding binary
+  /// image
   Image& extractLabel(const PixelType label = 1.0);
 
   /// closes holes in a given volume, default foreground value assumes a binary volume
   Image& closeHoles(const PixelType foreground = 0.0);
-  
+
   /// threholds image into binary label based on upper and lower intensity bounds given by user
-  Image& binarize(PixelType minVal = 0.0, PixelType maxVal = std::numeric_limits<PixelType>::max(), PixelType innerVal = 1.0, PixelType outerVal = 0.0);
+  Image& binarize(PixelType minVal = 0.0, PixelType maxVal = std::numeric_limits<PixelType>::max(),
+                  PixelType innerVal = 1.0, PixelType outerVal = 0.0);
 
   /// computes distance transform volume from a (preferably antialiased) binary image using the specified isovalue
   Image& computeDT(PixelType isoValue = 0.0);
@@ -158,7 +170,8 @@ public:
   /// segements structures in images using topology preserving geodesic active contour level set filter
   Image& applyTPLevelSetFilter(const Image& featureImage, double scaling = 20.0);
 
-  /// creates a feature image (by applying gradient then sigmoid filters), then passes it to the TPLevelSet filter [curvature flow filter is often applied to the image before this filter]
+  /// creates a feature image (by applying gradient then sigmoid filters), then passes it to the TPLevelSet filter
+  /// [curvature flow filter is often applied to the image before this filter]
   Image& topologyPreservingSmooth(float scaling = 20.0, float sigmoidAlpha = 10.5, float sigmoidBeta = 10.0);
 
   /// applies intensity windowing image filter
@@ -173,7 +186,8 @@ public:
   /// clips an image using a cutting plane
   Image& clip(const Plane plane, const PixelType val = 0.0);
 
-  /// reflect image around the plane specified by the logical center and the given normal (ex: <1,0,0> reflects across YZ-plane).
+  /// reflect image around the plane specified by the logical center and the given normal (ex: <1,0,0> reflects across
+  /// YZ-plane).
   Image& reflect(const Axis& axis);
 
   /// sets the image origin in physical space to the given value
@@ -239,10 +253,10 @@ public:
   IndexRegion physicalToLogical(PhysicalRegion region) const;
 
   /// converts from pixel coordinates to physical space
-  Point3 logicalToPhysical(const Coord &c) const;
+  Point3 logicalToPhysical(const Coord& c) const;
 
   /// converts from a physical coordinate to a logical coordinate
-  Coord physicalToLogical(const Point3 &p) const;
+  Coord physicalToLogical(const Point3& p) const;
 
   /// creates an image iterator and returns it
   ImageIterator iterator();
@@ -256,7 +270,7 @@ public:
   // export functions //
 
   /// writes image, format specified by filename extension
-  Image& write(const std::string &filename, bool compressed = true);
+  Image& write(const std::string& filename, bool compressed = true);
 
   /// converts image to mesh
   Mesh toMesh(PixelType isovalue) const;
@@ -264,13 +278,15 @@ public:
   //! Evaluates the image at a given position
   Image::PixelType evaluate(Point p);
 
-private:
+ private:
   friend struct SharedCommandData;
-  Image() : itk_image_(nullptr) {} // only for use by SharedCommandData since an Image should always be valid, never "empty"
+  Image()
+      : itk_image_(nullptr) {
+  }  // only for use by SharedCommandData since an Image should always be valid, never "empty"
 
   /// reads image (used only by constructor)
-  static ImageType::Pointer read(const std::string &filename);
-  static ImageType::Pointer readDICOMImage(const std::string &pathname);
+  static ImageType::Pointer read(const std::string& filename);
+  static ImageType::Pointer readDICOMImage(const std::string& pathname);
 
   /// clones the underlying ImageType (ITK) data
   static ImageType::Pointer cloneData(const ImageType::Pointer img);
@@ -286,20 +302,19 @@ private:
   ImageType::Pointer itk_image_;
 
   InterpolatorType::Pointer interpolator_;
-
 };
 
 /// stream insertion operators for Image
-std::ostream& operator<<(std::ostream &os, const Image& img);
+std::ostream& operator<<(std::ostream& os, const Image& img);
 
 /// override templates defined in Shapeworks.h
-template<>
+template <>
 Image operator*(const Image& img, const double x);
-template<>
+template <>
 Image operator/(const Image& img, const double x);
-template<>
+template <>
 Image& operator*=(Image& img, const double x);
-template<>
+template <>
 Image& operator/=(Image& img, const double x);
 
-} // shapeworks
+}  // namespace shapeworks

--- a/Libs/Image/VectorImage.cpp
+++ b/Libs/Image/VectorImage.cpp
@@ -2,23 +2,21 @@
 
 namespace shapeworks {
 
-VectorImage::VectorImage(const Image& dt)
-{
+VectorImage::VectorImage(const Image& dt_img) {
   GradientImageFilter::Pointer filter = GradientImageFilter::New();
-  filter->SetInput(dt.getITKImage());
+  filter->SetInput(dt_img.getITKImage());
   filter->SetUseImageSpacingOn();
   filter->Update();
-  this->image = filter->GetOutput();
-
-  GradientInterpolator::Pointer gradientInterpolator = GradientInterpolator::New();
-  gradientInterpolator->SetInputImage(this->image);
-  this->interpolator = itk::SmartPointer<GradientInterpolator>(gradientInterpolator);
+  itk_image_ = filter->GetOutput();
+  interpolator_ = GradientInterpolatorType::New();
+  interpolator_->SetInputImage(itk_image_);
 }
 
-VectorImage::ImageIterator VectorImage::setIterator()
-{
-  ImageIterator iter(this->image, image->GetRequestedRegion());
+Vector VectorImage::evaluate(Point p) { return toVector(interpolator_->Evaluate(p)); }
+
+VectorImage::ImageIterator VectorImage::iterator() {
+  ImageIterator iter(itk_image_, itk_image_->GetRequestedRegion());
   return iter;
 }
 
-} // shapeworks
+}  // namespace shapeworks

--- a/Libs/Image/VectorImage.h
+++ b/Libs/Image/VectorImage.h
@@ -1,24 +1,18 @@
 #pragma once
 
-#include "Image.h"
-
-#include <itkVectorLinearInterpolateImageFunction.h>
 #include <itkGradientImageFilter.h>
+#include <itkVectorLinearInterpolateImageFunction.h>
+
+#include "Image.h"
 
 namespace shapeworks {
 
-/// Image composed of vectors instead of just scalars
-//
-// TODO: generalize Image class instead of this:
-//       https://github.com/SCIInstitute/ShapeWorks/issues/1053
-class VectorImage
-{
-public:
-
+//! Gradient (vector) image
+class VectorImage {
+ public:
   using GradientImageFilter = itk::GradientImageFilter<Image::ImageType>;
   using ImageType = itk::Image<Covariant, 3>;
-  using GradientInterpolator = itk::VectorLinearInterpolateImageFunction<
-    ImageType, typename Image::PixelType>;
+  using GradientInterpolatorType = itk::VectorLinearInterpolateImageFunction<ImageType, Image::PixelType>;
   using ImageIterator = itk::ImageRegionIterator<ImageType>;
 
   /// Creates a gradient vector image of image (presumably a distance transform)
@@ -27,12 +21,12 @@ public:
   ~VectorImage() = default;
 
   /// Returns a Vector (which can be normalized using `v.Normalize()`).
-  Vector evaluate(Point p) { return toVector(interpolator->Evaluate(p)); }
-  ImageIterator setIterator();
+  Vector evaluate(Point p);
+  ImageIterator iterator();
 
-private:
-  itk::SmartPointer<ImageType> image;
-  itk::SmartPointer<GradientInterpolator> interpolator;
+ private:
+  itk::SmartPointer<ImageType> itk_image_;
+  itk::SmartPointer<GradientInterpolatorType> interpolator_;
 };
 
-} // shapeworks
+}  // namespace shapeworks

--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -270,7 +270,7 @@ Mesh& Mesh::coverage(const Mesh &otherMesh, bool allowBackIntersections, double 
 
 Mesh &Mesh::smooth(int iterations, double relaxation)
 {
-  vtkSmartPointer<vtkSmoothPolyDataFilter> smoother = vtkSmartPointer<vtkSmoothPolyDataFilter>::New();
+  auto smoother = vtkSmartPointer<vtkSmoothPolyDataFilter>::New();
 
   smoother->SetInputData(this->poly_data_);
   smoother->SetNumberOfIterations(iterations);
@@ -292,7 +292,7 @@ Mesh &Mesh::smooth(int iterations, double relaxation)
 
 Mesh& Mesh::smoothSinc(int iterations, double passband)
 {
-  vtkSmartPointer<vtkWindowedSincPolyDataFilter> smoother = vtkSmartPointer<vtkWindowedSincPolyDataFilter>::New();
+  auto smoother = vtkSmartPointer<vtkWindowedSincPolyDataFilter>::New();
   smoother->SetInputData(this->poly_data_);
   // minimum of 2.  See docs of vtkWindowedSincPolyDataFilter for explanation
   iterations = std::max<int>(iterations, 2);
@@ -353,7 +353,7 @@ Mesh& Mesh::remeshPercent(double percentage, double adaptivity)
 
 Mesh &Mesh::invertNormals()
 {
-  vtkSmartPointer<vtkReverseSense> reverseSense = vtkSmartPointer<vtkReverseSense>::New();
+  auto reverseSense = vtkSmartPointer<vtkReverseSense>::New();
 
   reverseSense->SetInputData(this->poly_data_);
   reverseSense->ReverseNormalsOff();
@@ -398,7 +398,7 @@ Mesh &Mesh::applyTransform(const MeshTransform transform)
 
 Mesh &Mesh::fillHoles()
 {
-  vtkSmartPointer<vtkFillHolesFilter> filter = vtkSmartPointer<vtkFillHolesFilter>::New();
+  auto filter = vtkSmartPointer<vtkFillHolesFilter>::New();
   filter->SetInputData(this->poly_data_);
   filter->SetHoleSize(1000.0);
   filter->Update();
@@ -418,7 +418,7 @@ Mesh &Mesh::fillHoles()
 
 Mesh &Mesh::probeVolume(const Image &image)
 {
-  vtkSmartPointer<vtkProbeFilter> probeFilter = vtkSmartPointer<vtkProbeFilter>::New();
+  auto probeFilter = vtkSmartPointer<vtkProbeFilter>::New();
   probeFilter->SetInputData(this->poly_data_);
   probeFilter->SetSourceData(image.getVTKImage());
   probeFilter->Update();
@@ -430,7 +430,7 @@ Mesh &Mesh::probeVolume(const Image &image)
 
 Mesh &Mesh::clip(const Plane plane)
 {
-  vtkSmartPointer<vtkClipPolyData> clipper = vtkSmartPointer<vtkClipPolyData>::New();
+  auto clipper = vtkSmartPointer<vtkClipPolyData>::New();
   clipper->SetInputData(this->poly_data_);
   clipper->SetClipFunction(plane);
   clipper->Update();
@@ -492,15 +492,16 @@ Mesh& Mesh::fixElement()
 
 std::vector<Field> Mesh::distance(const Mesh &target, const DistanceMethod method) const
 {
-  if (target.numPoints() == 0 || numPoints() == 0)
+  if (target.numPoints() == 0 || numPoints() == 0) {
     throw std::invalid_argument("meshes must have points");
+  }
 
   // allocate Arrays to store distances and ids from each point to target
-  vtkSmartPointer<vtkDoubleArray> distance = vtkSmartPointer<vtkDoubleArray>::New();
+  auto distance = vtkSmartPointer<vtkDoubleArray>::New();
   distance->SetNumberOfComponents(1);
   distance->SetNumberOfTuples(numPoints());
   distance->SetName("distance");
-  vtkSmartPointer<vtkDoubleArray> ids = vtkSmartPointer<vtkDoubleArray>::New();
+  auto ids = vtkSmartPointer<vtkDoubleArray>::New();
   ids->SetNumberOfComponents(1);
   ids->SetNumberOfTuples(numPoints());
   ids->SetName("ids");
@@ -513,12 +514,11 @@ std::vector<Field> Mesh::distance(const Mesh &target, const DistanceMethod metho
     case PointToPoint:
     {
       // build point locator for target mesh
-      vtkSmartPointer<vtkKdTreePointLocator> targetPointLocator = vtkSmartPointer<vtkKdTreePointLocator>::New();
+      auto targetPointLocator = vtkSmartPointer<vtkKdTreePointLocator>::New();
       targetPointLocator->SetDataSet(target.poly_data_);
       targetPointLocator->BuildLocator();
 
-      for (int i = 0; i < numPoints(); i++)
-      {
+      for (int i = 0; i < numPoints(); i++) {
         poly_data_->GetPoint(i, currentPoint.GetDataPointer());
         vtkIdType closestPointId = targetPointLocator->FindClosestPoint(currentPoint.GetDataPointer());
         target.poly_data_->GetPoint(closestPointId, closestPoint.GetDataPointer());
@@ -531,12 +531,12 @@ std::vector<Field> Mesh::distance(const Mesh &target, const DistanceMethod metho
     case PointToCell:
     {
       // build cell locator for target mesh
-      vtkSmartPointer<vtkCellLocator> targetCellLocator = vtkSmartPointer<vtkCellLocator>::New();
+      auto targetCellLocator = vtkSmartPointer<vtkCellLocator>::New();
       targetCellLocator->SetDataSet(target.poly_data_);
       targetCellLocator->BuildLocator();
 
       double dist2;
-      vtkSmartPointer<vtkGenericCell> cell = vtkSmartPointer<vtkGenericCell>::New();
+      auto cell = vtkSmartPointer<vtkGenericCell>::New();
       vtkIdType cellId;
       int subId;
 
@@ -564,10 +564,10 @@ std::vector<Field> Mesh::distance(const Mesh &target, const DistanceMethod metho
 
 Mesh& Mesh::clipClosedSurface(const Plane plane)
 {
-  vtkSmartPointer<vtkPlaneCollection> planeCollection = vtkSmartPointer<vtkPlaneCollection>::New();
+  auto planeCollection = vtkSmartPointer<vtkPlaneCollection>::New();
   planeCollection->AddItem(plane);
 
-  vtkSmartPointer<vtkClipClosedSurface> clipper = vtkSmartPointer<vtkClipClosedSurface>::New();
+  auto clipper = vtkSmartPointer<vtkClipClosedSurface>::New();
   clipper->SetClippingPlanes(planeCollection);
   clipper->SetInputData(this->poly_data_);
   clipper->SetGenerateFaces(1);
@@ -580,7 +580,7 @@ Mesh& Mesh::clipClosedSurface(const Plane plane)
 
 Mesh& Mesh::computeNormals()
 {
-  vtkSmartPointer<vtkPolyDataNormals> normal = vtkSmartPointer<vtkPolyDataNormals>::New();
+  auto normal = vtkSmartPointer<vtkPolyDataNormals>::New();
 
   normal->SetInputData(this->poly_data_);
   normal->ComputeCellNormalsOn();
@@ -625,7 +625,7 @@ Point3 Mesh::closestPoint(const Point3 point, bool& outside, double& distance, v
 
   double dist2;
   Point3 closestPoint;
-  vtkSmartPointer<vtkGenericCell> cell = vtkSmartPointer<vtkGenericCell>::New();
+  auto cell = vtkSmartPointer<vtkGenericCell>::New();
   int subId;
 
   cellLocator->FindClosestPoint(point.GetDataPointer(), closestPoint.GetDataPointer(),
@@ -672,7 +672,7 @@ double Mesh::geodesicDistance(int source, int target) const
 
 Field Mesh::geodesicDistance(const Point3 landmark) const
 {
-  vtkSmartPointer<vtkDoubleArray> distance = vtkSmartPointer<vtkDoubleArray>::New();
+  auto distance = vtkSmartPointer<vtkDoubleArray>::New();
   distance->SetNumberOfComponents(1);
   distance->SetNumberOfTuples(numPoints());
   distance->SetName("GeodesicDistanceToLandmark");
@@ -689,7 +689,7 @@ Field Mesh::geodesicDistance(const Point3 landmark) const
 
 Field Mesh::geodesicDistance(const std::vector<Point3> curve) const
 {
-  vtkSmartPointer<vtkDoubleArray> minDistance = vtkSmartPointer<vtkDoubleArray>::New();
+  auto minDistance = vtkSmartPointer<vtkDoubleArray>::New();
   minDistance->SetNumberOfComponents(1);
   minDistance->SetNumberOfTuples(numPoints());
   minDistance->SetName("GeodesicDistanceToCurve");
@@ -718,7 +718,7 @@ Field Mesh::curvature(const CurvatureType type) const
 
   Eigen::VectorXd C;
 
-  vtkSmartPointer<vtkDoubleArray> curv = vtkSmartPointer<vtkDoubleArray>::New();
+  auto curv = vtkSmartPointer<vtkDoubleArray>::New();
   curv->SetNumberOfComponents(1);
   curv->SetNumberOfTuples(numPoints());
 
@@ -777,7 +777,7 @@ Mesh& Mesh::applySubdivisionFilter(const SubdivisionType type, int subdivision)
 {
   if (type == Mesh::SubdivisionType::Loop)
   {
-    vtkSmartPointer<vtkLoopSubdivisionFilter> filter = vtkSmartPointer<vtkLoopSubdivisionFilter>::New();
+    auto filter = vtkSmartPointer<vtkLoopSubdivisionFilter>::New();
     filter->SetInputData(this->poly_data_);
     filter->SetNumberOfSubdivisions(subdivision);
     filter->Update();
@@ -785,7 +785,7 @@ Mesh& Mesh::applySubdivisionFilter(const SubdivisionType type, int subdivision)
   }
   else
   {
-    vtkSmartPointer<vtkButterflySubdivisionFilter> filter = vtkSmartPointer<vtkButterflySubdivisionFilter>::New();
+    auto filter = vtkSmartPointer<vtkButterflySubdivisionFilter>::New();
     filter->SetInputData(this->poly_data_);
     filter->SetNumberOfSubdivisions(subdivision);
     filter->Update();
@@ -811,7 +811,7 @@ Image Mesh::toImage(PhysicalRegion region, Point3 spacing) const
   // std::cout << "dims are " << dims << std::endl;
 
   // allocate output image
-  vtkSmartPointer<vtkImageData> whiteImage = vtkSmartPointer<vtkImageData>::New();
+  auto whiteImage = vtkSmartPointer<vtkImageData>::New();
   whiteImage->SetOrigin(region.origin()[0], region.origin()[1], region.origin()[2]);
   whiteImage->SetSpacing(spacing[0], spacing[1], spacing[2]);
   whiteImage->SetExtent(0, dims[0]-1, 0, dims[1]-1, 0, dims[2]-1);
@@ -823,13 +823,13 @@ Image Mesh::toImage(PhysicalRegion region, Point3 spacing) const
     whiteImage->GetPointData()->GetScalars()->SetTuple1(i, 1);
 
   // cut stencil from mesh silhouette (same size as output image)
-  vtkSmartPointer<vtkPolyDataToImageStencil> pol2stenc = vtkSmartPointer<vtkPolyDataToImageStencil>::New();
+  auto pol2stenc = vtkSmartPointer<vtkPolyDataToImageStencil>::New();
   pol2stenc->SetInputData(this->poly_data_);
   pol2stenc->SetInformationInput(whiteImage);
   pol2stenc->Update();
 
   // spray output using stencil (use dark paint)
-  vtkSmartPointer<vtkImageStencil> imgstenc = vtkSmartPointer<vtkImageStencil>::New();
+  auto imgstenc = vtkSmartPointer<vtkImageStencil>::New();
   imgstenc->SetInputData(whiteImage);
   imgstenc->SetStencilData(pol2stenc->GetOutput());
   imgstenc->ReverseStencilOff();
@@ -941,7 +941,7 @@ Eigen::MatrixXi Mesh::faces() const
   int num_faces = numFaces();
   Eigen::MatrixXi faces(num_faces, 3);
 
-  vtkSmartPointer<vtkIdList> cells = vtkSmartPointer<vtkIdList>::New();
+  auto cells = vtkSmartPointer<vtkIdList>::New();
 
   for (int j = 0; j < num_faces; j++) {
     poly_data_->GetCellPoints(j, cells);
@@ -970,12 +970,14 @@ Field Mesh::getField(const std::string& name, const FieldType type) const
 {
   if (type == Mesh::Point)
   {
-    if (poly_data_->GetPointData()->GetNumberOfArrays() < 1)
+    if (poly_data_->GetPointData()->GetNumberOfArrays() < 1) {
       throw std::invalid_argument("Mesh has no fields.");
+    }
 
     Field rawarr = poly_data_->GetPointData()->GetArray(name.c_str());
-    if (!rawarr)
+    if (!rawarr) {
       throw std::invalid_argument("Mesh does not contain a point field called " + name);
+    }
 
     return rawarr;
   }
@@ -983,18 +985,21 @@ Field Mesh::getField(const std::string& name, const FieldType type) const
   {
     return getFieldForFaces(name);
   }
-  else
+  else {
     throw std::invalid_argument("Incorrect Mesh::FieldType.");
+  }
 }
 
 Field Mesh::getFieldForFaces(const std::string& name) const
 {
-  if (poly_data_->GetCellData()->GetNumberOfArrays() < 1)
+  if (poly_data_->GetCellData()->GetNumberOfArrays() < 1) {
     throw std::invalid_argument("Mesh has no face fields.");
+  }
 
   Field rawarr = poly_data_->GetCellData()->GetArray(name.c_str());
-  if (!rawarr)
+  if (!rawarr) {
     throw std::invalid_argument("Mesh does not contain a cell field called " + name);
+  }
 
   return rawarr;
 }
@@ -1003,11 +1008,13 @@ Mesh& Mesh::setField(std::string name, Array array, const FieldType type)
 {
   if (type == Mesh::Point)
   {
-    if (!array)
-    throw std::invalid_argument("Invalid array.");
+    if (!array) {
+      throw std::invalid_argument("Invalid array.");
+    }
 
-    if (name.empty())
+    if (name.empty()) {
       throw std::invalid_argument("Provide name for the new field");
+    }
 
     int numVertices = numPoints();
     if (array->GetNumberOfTuples() != numVertices) {
@@ -1019,19 +1026,22 @@ Mesh& Mesh::setField(std::string name, Array array, const FieldType type)
 
     return *this;
   }
-  else if(type == Mesh::Face)
+  else if(type == Mesh::Face) {
     return setFieldForFaces(name, array);
-  else
+  } else {
     throw std::invalid_argument("Incorrect Mesh::FieldType.");
+  }
 }
 
 Mesh& Mesh::setFieldForFaces(std::string name, Array array)
 {
-  if (!array)
+  if (!array) {
     throw std::invalid_argument("Invalid array.");
+  }
 
-  if (name.empty())
+  if (name.empty()) {
     throw std::invalid_argument("Provide name for the new field");
+  }
 
   if (array->GetNumberOfTuples() != numFaces()) {
     std::cerr << "WARNING: Added a mesh field with a different number of elements than points\n";
@@ -1048,48 +1058,59 @@ Mesh& Mesh::setFieldForFaces(std::string name, Array array)
 
 void Mesh::setFieldValue(const std::string& name, int idx, double val)
 {
-  if (name.empty())
+  if (name.empty()) {
     throw std::invalid_argument("Provide name for the field");
+  }
 
-  if (poly_data_->GetPointData()->GetNumberOfArrays() < 1)
+  if (poly_data_->GetPointData()->GetNumberOfArrays() < 1) {
     throw std::invalid_argument("Mesh has no fields for which to set a value.");
+  }
 
   auto arr = poly_data_->GetPointData()->GetArray(name.c_str());
-  if (arr->GetNumberOfTuples() > idx)
+  if (arr->GetNumberOfTuples() > idx) {
     arr->SetTuple1(idx, val);
-  else
+  } else {
     throw std::invalid_argument("Intended index in field is out of range");
+  }
 }
 
 double Mesh::getFieldValue(const std::string& name, int idx) const
 {
-  if (name.empty())
+  if (name.empty()) {
     throw std::invalid_argument("Provide name for field");
+  }
 
-  if (poly_data_->GetPointData()->GetNumberOfArrays() < 1)
+  if (poly_data_->GetPointData()->GetNumberOfArrays() < 1) {
     throw std::invalid_argument("Mesh has no fields from which to retrieve a value.");
+  }
 
   auto arr = poly_data_->GetPointData()->GetArray(name.c_str());
-  if (!arr)
+  if (!arr) {
     throw std::invalid_argument("Field does not exist.");
+  }
 
-  if (arr->GetNumberOfTuples() > idx)
+  if (arr->GetNumberOfTuples() > idx) {
     return arr->GetTuple(idx)[0];
-  else
+  }
+  else {
     throw std::invalid_argument("Requested index in field is out of range");
+  }
 }
 
 Eigen::VectorXd Mesh::getMultiFieldValue(const std::string& name, int idx) const
 {
-  if (name.empty())
+  if (name.empty()) {
     throw std::invalid_argument("Provide name for field");
+  }
 
-  if (poly_data_->GetPointData()->GetNumberOfArrays() < 1)
+  if (poly_data_->GetPointData()->GetNumberOfArrays() < 1) {
     throw std::invalid_argument("Mesh has no fields from which to retrieve a value.");
+  }
 
   auto arr = poly_data_->GetPointData()->GetArray(name.c_str());
-  if (!arr)
+  if (!arr) {
     throw std::invalid_argument("Field does not exist.");
+  }
 
   if (arr->GetNumberOfTuples() > idx) {
     size_t compnum = arr->GetNumberOfComponents();
@@ -1099,14 +1120,16 @@ Eigen::VectorXd Mesh::getMultiFieldValue(const std::string& name, int idx) const
     }
     return vec;
   }
-  else
+  else {
     throw std::invalid_argument("Requested index in field is out of range");
+  }
 }
 
 bool Mesh::compareAllPoints(const Mesh &other_mesh) const
 {
-  if (!this->poly_data_ || !other_mesh.poly_data_)
+  if (!this->poly_data_ || !other_mesh.poly_data_) {
     throw std::invalid_argument("invalid meshes");
+  }
 
   if (this->numPoints() != other_mesh.numPoints())
   {
@@ -1131,8 +1154,9 @@ bool Mesh::compareAllPoints(const Mesh &other_mesh) const
 
 bool Mesh::compareAllFaces(const Mesh &other_mesh) const
 {
-  if (!this->poly_data_ || !other_mesh.poly_data_)
+  if (!this->poly_data_ || !other_mesh.poly_data_) {
     throw std::invalid_argument("invalid meshes");
+  }
 
   if (this->poly_data_->GetNumberOfCells() != other_mesh.poly_data_->GetNumberOfCells())
   {
@@ -1183,8 +1207,9 @@ bool Mesh::compareAllFaces(const Mesh &other_mesh) const
 
 bool Mesh::compareAllFields(const Mesh &other_mesh, const double eps) const
 {
-  if (!this->poly_data_ || !other_mesh.poly_data_)
+  if (!this->poly_data_ || !other_mesh.poly_data_) {
     throw std::invalid_argument("Invalid meshes");
+  }
 
   auto fields1 = getFieldNames();
   auto fields2 = other_mesh.getFieldNames();
@@ -1351,7 +1376,7 @@ bool Mesh::prepareFFCFields(std::vector<std::vector<Eigen::Vector3d>> boundaries
     std::vector<size_t> boundaryVerts;
 
     // the locator is continuously rebuilt during this function, so don't use the cached version
-    vtkSmartPointer<vtkKdTreePointLocator> tmp_locator = vtkSmartPointer<vtkKdTreePointLocator>::New();
+    auto tmp_locator = vtkSmartPointer<vtkKdTreePointLocator>::New();
     tmp_locator->SetDataSet(this->poly_data_);
     tmp_locator->BuildLocator();
 
@@ -1673,7 +1698,7 @@ Mesh::setGradientFieldForFFCs(vtkSmartPointer<vtkDoubleArray> absvalues, Eigen::
                               Eigen::MatrixXi F)
 {
   // Definition of gradient field
-  vtkSmartPointer<vtkDoubleArray> vf = vtkSmartPointer<vtkDoubleArray>::New();
+  auto vf = vtkSmartPointer<vtkDoubleArray>::New();
   vf->SetNumberOfComponents(3);
   vf->SetNumberOfTuples(this->poly_data_->GetNumberOfPoints());
   vf->SetName("vf");
@@ -1749,12 +1774,12 @@ Mesh::setGradientFieldForFFCs(vtkSmartPointer<vtkDoubleArray> absvalues, Eigen::
 Mesh& Mesh::operator+=(const Mesh& otherMesh)
 {
   // Append the two meshes
-  vtkSmartPointer<vtkAppendPolyData> appendFilter = vtkSmartPointer<vtkAppendPolyData>::New();
+  auto appendFilter = vtkSmartPointer<vtkAppendPolyData>::New();
   appendFilter->AddInputData(this->poly_data_);
   appendFilter->AddInputData(otherMesh.poly_data_);
 
   // Remove any duplicate points.
-  vtkSmartPointer<vtkCleanPolyData> cleanFilter= vtkSmartPointer<vtkCleanPolyData>::New();
+  auto cleanFilter= vtkSmartPointer<vtkCleanPolyData>::New();
   cleanFilter->SetInputConnection(appendFilter->GetOutputPort());
   cleanFilter->Update();
 

--- a/Libs/Mesh/Mesh.h
+++ b/Libs/Mesh/Mesh.h
@@ -29,33 +29,33 @@ public:
 
   Mesh(const std::string& pathname);
 
-  Mesh(MeshType meshPtr) : mesh(meshPtr) {
-    if (!mesh) throw std::invalid_argument("null meshPtr");
+  Mesh(MeshType meshPtr) : poly_data_(meshPtr) {
+    if (!poly_data_) throw std::invalid_argument("null meshPtr");
     invalidateLocators();
   }
 
-  Mesh(const Mesh& orig) : mesh(MeshType::New()) {
-    mesh->DeepCopy(orig.mesh);
+  Mesh(const Mesh& orig) : poly_data_(MeshType::New()) {
+    poly_data_->DeepCopy(orig.poly_data_);
     invalidateLocators();
   }
 
-  Mesh(Mesh&& orig) : mesh(orig.mesh) { orig.mesh = nullptr; }
+  Mesh(Mesh&& orig) : poly_data_(orig.poly_data_) { orig.poly_data_ = nullptr; }
 
   Mesh& operator=(const Mesh& orig) {
-    mesh = MeshType::New();
-    mesh->DeepCopy(orig.mesh);
+    poly_data_ = MeshType::New();
+    poly_data_->DeepCopy(orig.poly_data_);
     invalidateLocators();
     return *this; }
 
   Mesh(const Eigen::MatrixXd& points, const Eigen::MatrixXi& faces);
 
-  Mesh& operator=(Mesh&& orig) { mesh = orig.mesh; orig.mesh = nullptr; return *this; }
+  Mesh& operator=(Mesh&& orig) { poly_data_ = orig.poly_data_; orig.poly_data_ = nullptr; return *this; }
 
   /// append two meshes
   Mesh& operator+=(const Mesh& otherMesh);
 
   /// return the current mesh
-  MeshType getVTKMesh() const { return this->mesh; }
+  MeshType getVTKMesh() const { return this->poly_data_; }
 
   /// writes mesh, format specified by filename extension
   Mesh& write(const std::string &pathname, bool binaryFile = false);
@@ -162,10 +162,10 @@ public:
   Point3 centerOfMass() const;
 
   /// number of points
-  int numPoints() const { return mesh->GetNumberOfPoints(); }
+  int numPoints() const { return poly_data_->GetNumberOfPoints(); }
 
   /// number of faces
-  int numFaces() const { return mesh->GetNumberOfCells(); }
+  int numFaces() const { return poly_data_->GetNumberOfCells(); }
 
   /// matrix with number of points with (x,y,z) coordinates of each point
   Eigen::MatrixXd points() const;
@@ -243,12 +243,12 @@ public:
 
 private:
   friend struct SharedCommandData;
-  Mesh() : mesh(nullptr) {} // only for use by SharedCommandData since a Mesh should always be valid, never "empty"
+  Mesh() : poly_data_(nullptr) {} // only for use by SharedCommandData since a Mesh should always be valid, never "empty"
 
   /// Creates transform from source mesh to target using ICP registration
   MeshTransform createRegistrationTransform(const Mesh &target, AlignmentType align = Similarity, unsigned iterations = 10) const;
 
-  MeshType mesh;
+  MeshType poly_data_;
 
   /// sets the given field for faces with array (*does not copy array's values)
   Mesh& setFieldForFaces(const std::string name, Array array);

--- a/Libs/Mesh/Mesh.h
+++ b/Libs/Mesh/Mesh.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "Shapeworks.h"
 #include "ImageUtils.h"
+#include "Shapeworks.h"
 
 class vtkCellLocator;
 class vtkKdTreePointLocator;
@@ -15,9 +15,8 @@ namespace shapeworks {
  * This class encapsulates a Mesh and operations that can be performed on meshes
  *
  */
-class Mesh
-{
-public:
+class Mesh {
+ public:
   enum FieldType { Point, Face };
   enum AlignmentType { Rigid, Similarity, Affine };
   enum DistanceMethod { PointToPoint, PointToCell };
@@ -45,11 +44,16 @@ public:
     poly_data_ = MeshType::New();
     poly_data_->DeepCopy(orig.poly_data_);
     invalidateLocators();
-    return *this; }
+    return *this;
+  }
 
   Mesh(const Eigen::MatrixXd& points, const Eigen::MatrixXi& faces);
 
-  Mesh& operator=(Mesh&& orig) { poly_data_ = orig.poly_data_; orig.poly_data_ = nullptr; return *this; }
+  Mesh& operator=(Mesh&& orig) {
+    poly_data_ = orig.poly_data_;
+    orig.poly_data_ = nullptr;
+    return *this;
+  }
 
   /// append two meshes
   Mesh& operator+=(const Mesh& otherMesh);
@@ -58,11 +62,11 @@ public:
   MeshType getVTKMesh() const { return this->poly_data_; }
 
   /// writes mesh, format specified by filename extension
-  Mesh& write(const std::string &pathname, bool binaryFile = false);
+  Mesh& write(const std::string& pathname, bool binaryFile = false);
 
   /// determines coverage between current mesh and another mesh (e.g. acetabular cup / femoral head)
-  Mesh& coverage(const Mesh& otherMesh, bool allowBackIntersections = true,
-                 double angleThreshold = 0, double backSearchRadius = 0);
+  Mesh& coverage(const Mesh& otherMesh, bool allowBackIntersections = true, double angleThreshold = 0,
+                 double backSearchRadius = 0);
 
   /// applies laplacian smoothing
   Mesh& smooth(int iterations = 0, double relaxation = 0.0);
@@ -80,10 +84,11 @@ public:
   Mesh& invertNormals();
 
   /// reflect meshes with respect to a specified center and specific axis
-  Mesh& reflect(const Axis &axis, const Vector3 &origin = makeVector({ 0.0, 0.0, 0.0 }));
+  Mesh& reflect(const Axis& axis, const Vector3& origin = makeVector({0.0, 0.0, 0.0}));
 
-  /// creates transform to target mesh using specified AlignmentType (Mesh::Rigid, Mesh::Similarity, Mesh::Affine) for specified number of iterations
-  MeshTransform createTransform(const Mesh &target, AlignmentType align = Similarity, unsigned iterations = 10);
+  /// creates transform to target mesh using specified AlignmentType (Mesh::Rigid, Mesh::Similarity, Mesh::Affine) for
+  /// specified number of iterations
+  MeshTransform createTransform(const Mesh& target, AlignmentType align = Similarity, unsigned iterations = 10);
 
   /// applies the given transformation to the mesh
   Mesh& applyTransform(const MeshTransform transform);
@@ -92,16 +97,16 @@ public:
   Mesh& fillHoles();
 
   /// samples image data values at point locations specified by image
-  Mesh& probeVolume(const Image &image);
+  Mesh& probeVolume(const Image& image);
 
   /// clips a mesh using a cutting plane
   Mesh& clip(const Plane plane);
 
   /// helper to translate mesh
-  Mesh& translate(const Vector3 &v);
+  Mesh& translate(const Vector3& v);
 
   /// helper to scale mesh
-  Mesh& scale(const Vector3 &v);
+  Mesh& scale(const Vector3& v);
 
   /// computes bounding box of current mesh
   PhysicalRegion boundingBox() const;
@@ -112,7 +117,7 @@ public:
   /// Computes distance from each vertex to closest cell or point in target
   /// mesh, specified as PointToCell (default) or PointToPoint. Returns Fields
   /// containing distance to target and ids of the associated cells or points.
-  std::vector<Field> distance(const Mesh &target, const DistanceMethod method = PointToCell) const;
+  std::vector<Field> distance(const Mesh& target, const DistanceMethod method = PointToCell) const;
 
   /// clips a mesh using a cutting plane resulting in a closed surface
   Mesh& clipClosedSurface(const Plane plane);
@@ -149,8 +154,7 @@ public:
   Image toImage(PhysicalRegion region = PhysicalRegion(), Point3 spacing = Point3({1., 1., 1.})) const;
 
   /// converts specified region to distance transform image (default: unit spacing) with (logical) padding
-  Image toDistanceTransform(PhysicalRegion region = PhysicalRegion(),
-                            const Point3 spacing = Point3({1., 1., 1.}),
+  Image toDistanceTransform(PhysicalRegion region = PhysicalRegion(), const Point3 spacing = Point3({1., 1., 1.}),
                             const Dims padding = Dims({1, 1, 1})) const;
 
   // query functions //
@@ -208,15 +212,16 @@ public:
   bool compareAllFaces(const Mesh& other_mesh) const;
 
   /// compare if all fields in two meshes are (eps)equal
-  bool compareAllFields(const Mesh& other_mesh, const double eps=-1.0) const;
+  bool compareAllFields(const Mesh& other_mesh, const double eps = -1.0) const;
 
   /// compare field of meshes to be (eps)equal (same field for both if only one specified)
-  bool compareField(const Mesh& other_mesh, const std::string& name1, const std::string& name2="", const double eps=-1.0) const;
+  bool compareField(const Mesh& other_mesh, const std::string& name1, const std::string& name2 = "",
+                    const double eps = -1.0) const;
 
   // todo: add support for comparison of fields of mesh faces (ex: their normals)
 
   /// compare meshes
-  bool compare(const Mesh& other_mesh, const double eps=-1.0) const;
+  bool compare(const Mesh& other_mesh, const double eps = -1.0) const;
 
   /// compare meshes
   bool operator==(const Mesh& other) const { return compare(other); }
@@ -227,7 +232,8 @@ public:
   static std::vector<std::string> getSupportedTypes() { return {"vtk", "vtp", "ply", "stl", "obj"}; }
 
   /// Prepares the mesh for FFCs by setting scalar and vector fields
-  bool prepareFFCFields(std::vector<std::vector<Eigen::Vector3d>> boundaries, Eigen::Vector3d query, bool onlyGenerateInOut = false);
+  bool prepareFFCFields(std::vector<std::vector<Eigen::Vector3d>> boundaries, Eigen::Vector3d query,
+                        bool onlyGenerateInOut = false);
 
   /// Gets values for FFCs
   double getFFCValue(Eigen::Vector3d query) const;
@@ -236,17 +242,21 @@ public:
   Eigen::Vector3d getFFCGradient(Eigen::Vector3d query) const;
 
   /// Formats mesh into an IGL format
-  MeshPoints getIGLMesh(Eigen::MatrixXd& V, Eigen::MatrixXi& F) const; // Copied directly from VtkMeshWrapper. this->poly_data_ becomes this->mesh. // WARNING: Copied directly from Meshwrapper. TODO: When refactoring, take this into account.
+  MeshPoints getIGLMesh(Eigen::MatrixXd& V, Eigen::MatrixXi& F)
+      const;  // Copied directly from VtkMeshWrapper. this->poly_data_ becomes this->mesh. // WARNING: Copied directly
+              // from Meshwrapper. TODO: When refactoring, take this into account.
 
   /// Clips the mesh according to a field value
   vtkSmartPointer<vtkPolyData> clipByField(const std::string& name, double value);
 
-private:
+ private:
   friend struct SharedCommandData;
-  Mesh() : poly_data_(nullptr) {} // only for use by SharedCommandData since a Mesh should always be valid, never "empty"
+  Mesh()
+      : poly_data_(nullptr) {}  // only for use by SharedCommandData since a Mesh should always be valid, never "empty"
 
   /// Creates transform from source mesh to target using ICP registration
-  MeshTransform createRegistrationTransform(const Mesh &target, AlignmentType align = Similarity, unsigned iterations = 10) const;
+  MeshTransform createRegistrationTransform(const Mesh& target, AlignmentType align = Similarity,
+                                            unsigned iterations = 10) const;
 
   MeshType poly_data_;
 
@@ -269,21 +279,26 @@ private:
   void updatePointLocator() const;
 
   /// Computes the gradient vector field for FFCs w.r.t the boundary
-  std::vector<Eigen::Matrix3d> setGradientFieldForFFCs(vtkSmartPointer<vtkDoubleArray> absvalues, Eigen::MatrixXd V, Eigen::MatrixXi F);
+  std::vector<Eigen::Matrix3d> setGradientFieldForFFCs(vtkSmartPointer<vtkDoubleArray> absvalues, Eigen::MatrixXd V,
+                                                       Eigen::MatrixXi F);
 
   /// Computes scalar distance field w.r.t. the boundary
-  vtkSmartPointer<vtkDoubleArray> setDistanceToBoundaryValueFieldForFFCs(vtkSmartPointer<vtkDoubleArray> values, MeshPoints points, std::vector<size_t> boundaryVerts, vtkSmartPointer<vtkDoubleArray> inout, Eigen::MatrixXd V, Eigen::MatrixXi F);  // fixme: sets value, returns absvalues, not sure why
+  vtkSmartPointer<vtkDoubleArray> setDistanceToBoundaryValueFieldForFFCs(
+      vtkSmartPointer<vtkDoubleArray> values, MeshPoints points, std::vector<size_t> boundaryVerts,
+      vtkSmartPointer<vtkDoubleArray> inout, Eigen::MatrixXd V,
+      Eigen::MatrixXi F);  // fixme: sets value, returns absvalues, not sure why
 
   /// Computes whether point is inside or outside the boundary
-  vtkSmartPointer<vtkDoubleArray> computeInOutForFFCs(Eigen::Vector3d query, MeshType halfmesh); // similar issues to above
+  vtkSmartPointer<vtkDoubleArray> computeInOutForFFCs(Eigen::Vector3d query,
+                                                      MeshType halfmesh);  // similar issues to above
 
   /// Computes baricentric coordinates given a query point and a face number
-  Eigen::Vector3d computeBarycentricCoordinates(const Eigen::Vector3d& pt, int face) const; // // WARNING: Copied directly from Meshwrapper. TODO: When refactoring, take this into account.
-
+  Eigen::Vector3d computeBarycentricCoordinates(const Eigen::Vector3d& pt, int face)
+      const;  // // WARNING: Copied directly from Meshwrapper. TODO: When refactoring, take this into account.
 };
 
 /// stream insertion operators for Mesh
-std::ostream& operator<<(std::ostream &os, const Mesh& mesh);
+std::ostream& operator<<(std::ostream& os, const Mesh& mesh);
 
 /// reads mesh (used only by one of the Mesh constructors)
 class MeshReader {
@@ -291,4 +306,4 @@ class MeshReader {
   friend Mesh::Mesh(const std::string& pathname);
 };
 
-} // shapeworks
+}  // namespace shapeworks

--- a/Libs/Particles/ReconstructSurface.cpp
+++ b/Libs/Particles/ReconstructSurface.cpp
@@ -422,8 +422,8 @@ Eigen::MatrixXd ReconstructSurface<TransformType>::computeParticlesNormals(vtkSm
   VectorImage vectorImage(dt);
   dt.applyGradientFilter();
 
-  VectorImage::ImageIterator gradIter = vectorImage.setIterator();
-  Image::ImageIterator magIter = dt.setIterator();
+  VectorImage::ImageIterator gradIter = vectorImage.iterator();
+  Image::ImageIterator magIter = dt.iterator();
 
   Image::ImageType::Pointer nxImage = Image::ImageType::New();
   nxImage->SetRegions(dt.getITKImage()->GetLargestPossibleRegion());

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -639,6 +639,14 @@ PYBIND11_MODULE(shapeworks_py, m)
   .def("isolate",
        &Image::isolate,
        "isolate largest object")
+
+  .def("evaluate",
+       [](Image &image, std::vector<double> &pt) -> decltype(auto) {
+             return image.evaluate(Point({pt[0], pt[1], pt[2]}));
+           },
+           "evaluate the image at any given point in space",
+           "pt"_a)
+
   ;
 
   // PhysicalRegion

--- a/Testing/ImageTests/ImageTests.cpp
+++ b/Testing/ImageTests/ImageTests.cpp
@@ -1283,3 +1283,19 @@ TEST(ImageTests, isolateTest1)
   Image ground_truth(std::string(TEST_DATA_DIR) + "/isolate_output.nrrd");
   ASSERT_TRUE(image == ground_truth);
 }
+
+TEST(ImageTests, evaluateTest)
+{
+  Image image(std::string(TEST_DATA_DIR) + "/computedt2.nrrd");
+  Point pt1({37.0, 46.0, 50.0});  // outside close
+  Point pt2({60.0, 58.2, 62.5});  // outside other side
+  Point pt3({58.0, 44.0, 52.0});  // inside
+  Point pt4({12.0, 18.0, 20.0});  // outside far
+  Point pt5({-12.0, -18.0, 20.0});// outside original image's space!
+
+  EXPECT_TRUE(epsEqual(image.evaluate(pt1), -4.334231377, 1e-6));
+  EXPECT_TRUE(epsEqual(image.evaluate(pt2), -9.491417885, 1e-6));
+  EXPECT_TRUE(epsEqual(image.evaluate(pt3), -1.236827493, 1e-6));
+  EXPECT_TRUE(epsEqual(image.evaluate(pt4), -50.785587311, 1e-6));
+  EXPECT_TRUE(epsEqual(image.evaluate(pt5), -69.377281189, 1e-6));
+}


### PR DESCRIPTION
Address Image::evaluate part of:

* #1080 

This adds Image::evaluate using a similar approach as was done for VectorImage with the advantage/difference that the interpolator is created only when first used.

Also cleaned up Mesh and Image classes a little bit.  There's a lot of formatting change for the most part.