### PR TITLE
Fix python path and python home for Studio

### DIFF
--- a/Python/shapeworks/shapeworks/utils.py
+++ b/Python/shapeworks/shapeworks/utils.py
@@ -162,7 +162,7 @@ def compute_line_indices(n, is_closed=True):
     return lines
 
 def get_api_version():
-    return "6.2"
+    return "6.3"
 
 def set_sw_logger(log_object):
     """Set the shapeworks logger object"""

--- a/Studio/src/Python/PythonWorker.h
+++ b/Studio/src/Python/PythonWorker.h
@@ -18,7 +18,7 @@ class PythonWorker : public QObject {
   Q_OBJECT
 
  public:
-  constexpr static const char* python_api_version = "6.2";
+  constexpr static const char* python_api_version = "6.3";
 
   PythonWorker();
   ~PythonWorker();

--- a/Studio/src/Resources/Info.plist.in
+++ b/Studio/src/Resources/Info.plist.in
@@ -40,5 +40,7 @@
 	<string>False</string>
         <key>NSRequiresAquaSystemAppearance</key>
         <string>true</string>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>

--- a/install_shapeworks.bat
+++ b/install_shapeworks.bat
@@ -76,5 +76,6 @@ call jupyter nbextension enable toc2/main
 
 md %USERPROFILE%\.shapeworks
 python -c "import sys; print('\n'.join(sys.path))" > %USERPROFILE%\.shapeworks\python_path.txt
+python -c "import sys; print(sys.prefix)" > %USERPROFILE%\.shapeworks\python_home.txt
 echo %PATH% > %USERPROFILE%\.shapeworks\path.txt
 call conda info

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -97,7 +97,6 @@ function install_conda() {
     boost=1.72.0 \
     openexr=2.5.3 \
     pybind11=2.5.0 \
-    notebook=6.1.5 \
     nlohmann_json=3.10.5 \
     pkg-config=0.29.2
   then return 1; fi
@@ -121,7 +120,9 @@ function install_conda() {
 
   # pip is needed in sub-environments or the base env's pip will silently install to base
   if ! conda install --yes pip=21.2.4; then return 1; fi
-  
+
+  which pip
+  if ! pip install notebook==6.1.5;                     then return 1; fi
   if ! pip install trimesh==3.9.28;                     then return 1; fi
   if ! pip install termcolor==1.1.0;                    then return 1; fi
   if ! pip install grip==4.5.2;                         then return 1; fi

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -98,7 +98,6 @@ function install_conda() {
     openexr=2.5.3 \
     pybind11=2.5.0 \
     notebook=6.1.5 \
-    nbformat=4.4.0 \
     nlohmann_json=3.10.5 \
     pkg-config=0.29.2
   then return 1; fi

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -196,7 +196,9 @@ function install_conda() {
   fi
 
   # Set the python path for studio
+  conda activate $CONDAENV
   mkdir -p $HOME/.shapeworks ; python -c "import sys; print('\n'.join(sys.path))" > $HOME/.shapeworks/python_path.txt
+  python -c "import sys; print(sys.prefix)" > $HOME/.shapeworks/python_home.txt
   
   return 0
 }

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -140,9 +140,7 @@ function install_conda() {
   if ! pip install mkdocs-material==8.2.8;              then return 1; fi # theme for mkdocs
   if ! pip install mike==1.1.2;                         then return 1; fi # deploys versioned documentation to gh-pages
   if ! pip install jinja2==3.0.3;                       then return 1; fi # only version of jinja that works (needed by mkdocs)
-  if [[ "$(uname)" == "Darwin" ]]; then
-      if ! pip install Pygments==2.11.2;                    then return 1; fi # Needed by mkdocs
-  fi
+  if ! pip install Pygments==2.11.2;                    then return 1; fi # Needed by mkdocs
   if ! pip install python-markdown-math==0.8;           then return 1; fi # lib for rendering equations in docs
   if ! pip install fontawesome-markdown==0.2.6;         then return 1; fi # lib for icons in documentation
   if ! pip install pymdown-extensions==8.0.1;           then return 1; fi # lib to support checkbox lists in documentation

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -180,7 +180,7 @@ function install_conda() {
 
 
   # for spell check markdown cells in jupyter notebooks and table of contents (toc2)
-  conda install --yes jupyter_contrib_nbextensions=0.5.1
+  if ! pip install jupyter_contrib_nbextensions==0.5.1;   then return 1; fi
   jupyter contrib nbextension install --user
   jupyter nbextension enable spellchecker/main
   jupyter nbextension enable toc2/main

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -141,7 +141,9 @@ function install_conda() {
   if ! pip install mkdocs-material==8.2.8;              then return 1; fi # theme for mkdocs
   if ! pip install mike==1.1.2;                         then return 1; fi # deploys versioned documentation to gh-pages
   if ! pip install jinja2==3.0.3;                       then return 1; fi # only version of jinja that works (needed by mkdocs)
-  if ! pip install Pygments==2.11.2;                    then return 1; fi # Needed by mkdocs
+  if [[ "$(uname)" == "Darwin" ]]; then
+      if ! pip install Pygments==2.11.2;                    then return 1; fi # Needed by mkdocs
+  fi
   if ! pip install python-markdown-math==0.8;           then return 1; fi # lib for rendering equations in docs
   if ! pip install fontawesome-markdown==0.2.6;         then return 1; fi # lib for icons in documentation
   if ! pip install pymdown-extensions==8.0.1;           then return 1; fi # lib to support checkbox lists in documentation


### PR DESCRIPTION
This PR fixes the python home and path issues for loading Studio.  Depending on the user's system, the wrong python home may get loaded and python will be unable to find the filesystem codec and unhelpfully calls "abort()" giving us no opportunity to even show and error message that python failed to load.