### PR TITLE
Remove shortest path

### DIFF
--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -1304,10 +1304,7 @@ bool Mesh::prepareFFCFields(std::vector<std::vector<Eigen::Vector3d>> boundaries
     points = getIGLMesh(V, F);
   }
 
-  poly_data_->BuildLinks();
-
   for (size_t bound = 0; bound < boundaries.size(); bound++) {
-    // std::cout << "Boundaries " << bound << " size " << boundaries[bound].size() << std::endl;
 
     // Creating cutting loop
     vtkPoints* selectionPoints = vtkPoints::New();
@@ -1338,39 +1335,12 @@ bool Mesh::prepareFFCFields(std::vector<std::vector<Eigen::Vector3d>> boundaries
         boundaryVerts.push_back(ptid);
       }
 
-      bool connected = isVertexConnected(ptid, lastId);
-
-      //connected = true;
-      /* AKM: I'm not convinced this dijkstra stuff is necessary.  It's super slow with multiple dense boundaries.
-       * Assuming the free form constraint is defined by the user in Studio, it will be very dense already and there
-       * is no requirement of vtkSelectPolyData that a contigious set of vertices be supplied.  Indeed, they need not
-       * even be vertices */
-
       // If the current and last vertices are different, then add all vertices in the path to the boundaryVerts list
       if (lastId != ptid) {
-        if (connected) {
-          Point3 pathpt;
-          pathpt = getPoint(ptid);
-          selectionPoints->InsertNextPoint(pathpt[0], pathpt[1], pathpt[2]);
-          //std::cerr << "ADDING " << ptid << "\n";
-          boundaryVerts.push_back(ptid);
-        } else {
-          // Add points in path
-          //std::cerr << "Using DIJKSTRA to find path from " << lastId << " to " << ptid << "\n";
-          dijkstra->SetStartVertex(ptid);
-          dijkstra->SetEndVertex(lastId);
-          dijkstra->Update();
-          vtkSmartPointer<vtkIdList> idL = dijkstra->GetIdList();
-          // std::cerr << "DIJKSTRA PATH: " << idL << "\n";
-          for (size_t j = 1; j < idL->GetNumberOfIds(); j++) {
-            vtkIdType id = idL->GetId(j);
-            Point3 pathpt;
-            pathpt = getPoint(ptid);
-            selectionPoints->InsertNextPoint(pathpt[0], pathpt[1], pathpt[2]);
-            //std::cerr << "ADDING DIJKSTRA " << id << "\n";
-            boundaryVerts.push_back(id);
-          }
-        }
+        Point3 pathpt;
+        pathpt = getPoint(ptid);
+        selectionPoints->InsertNextPoint(pathpt[0], pathpt[1], pathpt[2]);
+        boundaryVerts.push_back(ptid);
       }
 
       lastId = ptid;

--- a/Libs/Mesh/Mesh.h
+++ b/Libs/Mesh/Mesh.h
@@ -295,6 +295,10 @@ class Mesh {
   /// Computes baricentric coordinates given a query point and a face number
   Eigen::Vector3d computeBarycentricCoordinates(const Eigen::Vector3d& pt, int face)
       const;  // // WARNING: Copied directly from Meshwrapper. TODO: When refactoring, take this into account.
+
+  //! Are two vertices connected
+  bool isVertexConnected(int v1, int v2);
+
 };
 
 /// stream insertion operators for Mesh


### PR DESCRIPTION
Addresses:

* #1817

Long path to get here.  First I discovered that the dijkstra path was inserting points in the wrong order and skipping the last one.  This was generating some really odd paths for the clip.  After fixing this, I also added a check to see if the next point was a neighboring vertex (e.g. one edge away), if it is, then the dijkstra part can be skipped.  This state can be seen here:

98bf22c191f965f531e2747f142232adebb14b31

After that, I tried skipping the dijkstra part altogether.  All of the OptimizeTests still pass and it's much faster using with studio, so I can't see any reason to keep it there.
