### PR TITLE
MeshWarper: add Python method MeshWarper.getGoodParticlesIndices() to…

### DIFF
--- a/Libs/Mesh/MeshWarper.h
+++ b/Libs/Mesh/MeshWarper.h
@@ -49,7 +49,10 @@ class MeshWarper {
   bool is_contour() { return this->is_contour_; }
 
   //! Return the map of landmarks id (Key) to vertice index (Value)
-  std::map<int, int> get_landmarks_map() { return landmarks_map_; }
+  std::map<int, int> get_landmarks_map() const { return landmarks_map_; }
+
+  //! Return the indexes of good particles (those that really control the warping)
+  std::vector<int> get_good_particle_indices() const { return good_particles_; }
 
   //! Return the warp matrix
   const Eigen::MatrixXd& get_warp_matrix() const { return this->warp_; }

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1292,6 +1292,12 @@ PYBIND11_MODULE(shapeworks_py, m)
       },
       "Return the map of landmarks to vertices.")
 
+  .def("getGoodParticlesIndices",
+      [](MeshWarper &w) -> decltype(auto) {
+        return w.get_good_particle_indices();
+      },
+      "Return the indexes of good particles.")
+
   .def("buildMesh",
       [](MeshWarper &w, const Eigen::MatrixXd &particles) -> decltype(auto) {
           return Mesh(w.build_mesh(particles));


### PR DESCRIPTION
… return the indexes of good particles.