### PR TITLE
Fix #1834 - Studio crashes on XML multidomain

### DIFF
--- a/Studio/src/Visualization/Viewer.cpp
+++ b/Studio/src/Visualization/Viewer.cpp
@@ -636,6 +636,9 @@ void Viewer::display_shape(QSharedPointer<Shape> shape) {
   renderer_->RemoveAllViewProps();
 
   number_of_domains_ = session_->get_domains_per_shape();
+  if (meshes_.valid()) {
+    number_of_domains_ = std::max<int>(number_of_domains_, meshes_.meshes().size());
+  }
   initialize_surfaces();
 
   if (!meshes_.valid()) {


### PR DESCRIPTION
Fixes:

* #1834 

This is a stop-gap fix until the new Project support is ready which
will better support different project configurations.