### PR TITLE
Fix #1853 by switching to boost normal_distribution that gives us a consistent implementation across platforms

### DIFF
--- a/Libs/Particles/EvaluationUtil.h
+++ b/Libs/Particles/EvaluationUtil.h
@@ -1,8 +1,10 @@
 #pragma once
 
-#include <random>
 #include <Eigen/Core>
 #include <Eigen/Dense>
+
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/normal_distribution.hpp>
 
 namespace shapeworks {
 struct MultiVariateNormalRandom
@@ -11,8 +13,8 @@ struct MultiVariateNormalRandom
   Eigen::MatrixXd transform;
 
   // seed set as constant 42 for test repeatability
-  std::mt19937 gen{42};
-  std::normal_distribution<> dist;
+  boost::mt19937 gen{42};
+  boost::normal_distribution<> dist;
 
   MultiVariateNormalRandom(Eigen::MatrixXd const &covar)
           : MultiVariateNormalRandom(Eigen::VectorXd::Zero(covar.rows()), covar)


### PR DESCRIPTION
The spec for std::normal_distribution allows for significant variation, which causes our specificity calculation to differ based on platform differences.  This PR switches to boost::normal_distribution to give us a consistent implementation across platforms.

Addresses:

* #1853 
