### PR TITLE
Update dev_env.sh script to check for presence of shapeworks executable

### DIFF
--- a/devenv.sh
+++ b/devenv.sh
@@ -14,12 +14,12 @@
 (return 0 2>/dev/null) && sourced=1 || sourced=0
 
 if [[ "$sourced" == "0" ]]; then
-    echo "ERROR: must call this script using \"source ./devenv.sh BUILD_BIN\""
+    echo "ERROR: must call this script using \"source ./devenv.sh <BUILD/BIN_DIR>\""
     exit 1
 fi
 
 if [[ "$#" -ne 1 ]]; then
-    echo "ERROR: must call this script using \"source ./devenv.sh BUILD_BIN\""
+    echo "ERROR: must call this script using \"source ./devenv.sh <BUILD/BIN_DIR>\""
     return 1
 fi    
 
@@ -38,3 +38,10 @@ done
 
 # Set the python path for studio
 mkdir -p $HOME/.shapeworks ; python -c "import sys; print('\n'.join(sys.path))" > $HOME/.shapeworks/python_path.txt
+
+if [ -f ${BUILD}/shapeworks ] ; then
+    echo "shapeworks executable found ${BUILD}"
+else
+    echo "\nWarning: shapeworks executable not present in ${BUILD}"
+    echo "\n\tDid you specify the correct build/bin dir?"
+fi


### PR DESCRIPTION
Print warning if not found, update usage.

no arguments given:

```
$ source devenv.sh
ERROR: must call this script using "source ./devenv.sh <BUILD/BIN_DIR>"
```

wrong path given:

```
$ source devenv.sh .
Source directory: /Users/amorris/sci/shapeworks/code
Binary directory: /Users/amorris/sci/shapeworks/code

Warning: shapeworks executable not present in /Users/amorris/sci/shapeworks/code

	Did you specify the correct build/bin dir?
```

correct:

```
$ source devenv.sh ../build/bin
Source directory: /Users/amorris/sci/shapeworks/code
Binary directory: /Users/amorris/sci/shapeworks/build/bin
shapeworks executable found /Users/amorris/sci/shapeworks/build/bin
```