### PR TITLE
Add Python API documentation

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - release_v*
+      - windows_conda
     tags:
     - '*'
   pull_request:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
 
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2.0.0
+      uses: conda-incubator/setup-miniconda@v2.1.1
       with:
           miniconda-version: 'latest'
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -99,7 +99,7 @@ jobs:
       shell: bash -l {0}
       env:
         PR_NUMBER: ${{ github.event.number }}
-      run: conda activate shapeworks && pwd ; ls ; cp docs/users/Windows_README.txt . ; cp Support/shapeworks.nsi . ; conda activate shapeworks && ./Support/package_windows.sh tag
+      run: conda activate shapeworks && source ${GITHUB_WORKSPACE}/devenv.sh ./bin/Release && pwd ; ls ; cp docs/users/Windows_README.txt . ; cp Support/shapeworks.nsi . ; conda activate shapeworks && source ${GITHUB_WORKSPACE}/devenv.sh ./bin/Release && ./Support/package_windows.sh tag
 
     - name: Check Disk Space3
       working-directory: ${{runner.workspace}}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release_v*
-      - windows_conda
     tags:
     - '*'
   pull_request:

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1409,26 +1409,32 @@ PYBIND11_MODULE(shapeworks_py, m)
 
   .def_static("ComputeCompactness",
               &ShapeEvaluation::ComputeCompactness,
+              "Computes the compactness measure for a particle system",
               "particleSystem"_a, "nModes"_a, "saveTo"_a="")
 
   .def_static("ComputeGeneralization",
               &ShapeEvaluation::ComputeGeneralization,
+              "Computes the generalization measure for a particle system",
               "particleSystem"_a, "nModes"_a, "saveTo"_a="")
 
   .def_static("ComputeSpecificity",
               &ShapeEvaluation::ComputeSpecificity,
+              "Computes the specificity measure for a particle system",
               "particleSystem"_a, "nModes"_a, "saveTo"_a="")
 
   .def_static("ComputeFullCompactness",
               &ShapeEvaluation::ComputeFullCompactness,
+              "Computes the compactness measure for a particle system, all modes",
               "particleSystem"_a,"progress_callback"_a=nullptr)
 
   .def_static("ComputeFullGeneralization",
               &ShapeEvaluation::ComputeFullGeneralization,
+              "Computes the generalization measure for a particle system, all modes",
               "particleSystem"_a,"progress_callback"_a=nullptr)
 
   .def_static("ComputeFullSpecificity",
               &ShapeEvaluation::ComputeFullSpecificity,
+              "Computes the specificity measure for a particle system, all modes",
               "particleSystem"_a,"progress_callback"_a=nullptr)
   ;
 

--- a/Support/package.sh
+++ b/Support/package.sh
@@ -110,7 +110,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     cd ..
 else
     # Copy libraries from anaconda
-    conda_libs="libboost_iostreams libboost_filesystem libbz2 liblzma liblz4 libtbb libHalf libpython libz"
+    conda_libs="libboost_iostreams libboost_filesystem libbz2 liblzma liblz4 libtbb libHalf libpython libz libspd"
     for clib in $conda_libs; do
         cp ${CONDA_PREFIX}/lib/${clib}* lib
     done

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -68,7 +68,10 @@ export PYTHONPATH
 echo "PATH = $PATH"
 echo "PYTHONPATH = $PYTHONPATH"
 echo "See if we can import shapeworks_py..."
-echo "import shapeworks_py ; print(dir(shapeworks_py))" | python
+
+echo "import os; print(os.environ)" | python
+
+echo "import shapeworks; import shapeworks_py ; print(dir(shapeworks_py))" | python
 
 echo "running mkdocs build"
 mkdocs build

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -88,6 +88,7 @@ cp -a Documentation bin/
 
 # Remove tests, they won't work for users anyway
 rm bin/*Tests.exe
+rm -rf docs
 
 windeployqt "bin/ShapeWorksStudio.exe"
 ../NSISPortable/App/NSIS/makensis.exe -V4 shapeworks.nsi 

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -63,10 +63,12 @@ else
 fi
 python Python/RunShapeWorksAutoDoc.py --md_filename docs/tools/ShapeWorksCommands.md
 pip list
+export PYTHONPATH
+
 echo "PATH = $PATH"
 echo "PYTHONPATH = $PYTHONPATH"
-echo "See if we can import shapeworks..."
-echo "import shapeworks ; print(dir(shapeworks))" | python
+echo "See if we can import shapeworks_py..."
+echo "import shapeworks_py ; print(dir(shapeworks_py))" | python
 
 echo "running mkdocs build"
 mkdocs build

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -62,8 +62,16 @@ python Python/RunShapeWorksAutoDoc.py --md_filename docs/tools/ShapeWorksCommand
 pip list
 export PYTHONPATH
 
+echo "PYTHONPATH before = $PYTHONPATH"
+
+# on windows, the PYTHONPATH should use semicolons
+if [[ $OSTYPE == "msys" ]]; then
+    PYTHONPATH=${PYTHONPATH//;/:}
+fi
+
+
 echo "PATH = $PATH"
-echo "PYTHONPATH = $PYTHONPATH"
+echo "PYTHONPATH after = $PYTHONPATH"
 echo "See if we can import shapeworks_py..."
 
 echo "import os; print(os.environ)" | python

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -45,7 +45,14 @@ rm -rf Post
 
 # Run auto-documentation
 cd $ROOT
-PATH=$BUILD/bin/Release:bin:$PATH
+PATH=$BUILD/bin/Release/bin:$PATH
+
+# add $PATH to $PYTHONPATH
+PYTHONPATH=$PYTHONPATH:$PATH
+
+# on windows, the PYTHONPATH should use semicolons
+PYTHONPATH=${PYTHONPATH//:/;}
+
 # check that 'shapeworks -h' is working
 shapeworks -h
 if [ $? -eq 0 ]; then
@@ -58,7 +65,9 @@ python Python/RunShapeWorksAutoDoc.py --md_filename docs/tools/ShapeWorksCommand
 pip list
 echo "PATH = $PATH"
 echo "PYTHONPATH = $PYTHONPATH"
-echo "import shapeworks" | python
+echo "See if we can import shapeworks..."
+echo "import shapeworks ; print(dir(shapeworks))" | python
+
 echo "running mkdocs build"
 mkdocs build
 mv site Documentation

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -66,7 +66,9 @@ echo "PYTHONPATH before = $PYTHONPATH"
 
 # on windows, the PYTHONPATH should use semicolons
 if [[ $OSTYPE == "msys" ]]; then
-    PYTHONPATH=${PYTHONPATH//;/:}
+    PYTHONPATH=${PYTHONPATH//:/;}
+    PYTHONPATH=${PYTHONPATH//\/d\//D:/}
+    PYTHONPATH=${PYTHONPATH//\/c\//C:/}
 fi
 
 

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -67,8 +67,9 @@ echo "PYTHONPATH before = $PYTHONPATH"
 # on windows, the PYTHONPATH should use semicolons
 if [[ $OSTYPE == "msys" ]]; then
     PYTHONPATH=${PYTHONPATH//:/;}
-    PYTHONPATH=${PYTHONPATH//\/d\//D:/}
-    PYTHONPATH=${PYTHONPATH//\/c\//C:/}
+    PYTHONPATH=${PYTHONPATH//;\/d\//;D:/}
+    PYTHONPATH=${PYTHONPATH//;\/c\//;C:/}
+    PYTHONPATH=${PYTHONPATH//\/d\/a/D:/a}
 fi
 
 

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -50,9 +50,6 @@ PATH=$BUILD/bin/Release/bin:$PATH
 # add $PATH to $PYTHONPATH
 PYTHONPATH=$PYTHONPATH:$PATH
 
-# on windows, the PYTHONPATH should use semicolons
-PYTHONPATH=${PYTHONPATH//:/;}
-
 # check that 'shapeworks -h' is working
 shapeworks -h
 if [ $? -eq 0 ]; then

--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -56,6 +56,9 @@ else
 fi
 python Python/RunShapeWorksAutoDoc.py --md_filename docs/tools/ShapeWorksCommands.md
 pip list
+echo "PATH = $PATH"
+echo "PYTHONPATH = $PYTHONPATH"
+echo "import shapeworks" | python
 echo "running mkdocs build"
 mkdocs build
 mv site Documentation

--- a/devenv.sh
+++ b/devenv.sh
@@ -41,6 +41,8 @@ if [[ $OSTYPE == "msys" ]]; then
     PYTHONPATH=${PYTHONPATH//:/;}
 fi
 
+echo "set PYTHONPATH to $PYTHONPATH"
+
 # Set the python path for studio
 mkdir -p $HOME/.shapeworks ; python -c "import sys; print('\n'.join(sys.path))" > $HOME/.shapeworks/python_path.txt
 

--- a/devenv.sh
+++ b/devenv.sh
@@ -36,6 +36,11 @@ for M in ${SOURCE}/Python/*/; do
     export PYTHONPATH=${M}:$PYTHONPATH
 done
 
+# on windows, the PYTHONPATH should use semicolons
+if [[ $OSTYPE == "msys" ]]; then
+    PYTHONPATH=${PYTHONPATH//:/;}
+fi
+
 # Set the python path for studio
 mkdir -p $HOME/.shapeworks ; python -c "import sys; print('\n'.join(sys.path))" > $HOME/.shapeworks/python_path.txt
 

--- a/devenv.sh
+++ b/devenv.sh
@@ -36,11 +36,6 @@ for M in ${SOURCE}/Python/*/; do
     export PYTHONPATH=${M}:$PYTHONPATH
 done
 
-# on windows, the PYTHONPATH should use semicolons
-if [[ $OSTYPE == "msys" ]]; then
-    PYTHONPATH=${PYTHONPATH//:/;}
-fi
-
 echo "set PYTHONPATH to $PYTHONPATH"
 
 # Set the python path for studio

--- a/docs/python/python-api.md
+++ b/docs/python/python-api.md
@@ -1,0 +1,12 @@
+# ShapeWorks Python API
+
+::: shapeworks_py
+    options:
+      filters: ["!^__[^__]"]
+
+
+
+
+
+
+

--- a/docs/python/python-api.md
+++ b/docs/python/python-api.md
@@ -1,5 +1,9 @@
 # ShapeWorks Python API
 
+::: shapeworks
+    options:
+      filters: ["!^__[^__]"]
+
 ::: shapeworks_py
     options:
       filters: ["!^__[^__]"]

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -102,6 +102,7 @@ function install_conda() {
     spdlog=1.10.0 \
     pkg-config=0.29.2 \
     openh264==2.3.0 \
+    libhwloc=2.8.0 \
     pip=22.1.2
   then return 1; fi
 

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -101,6 +101,7 @@ function install_conda() {
     nlohmann_json=3.10.5 \
     spdlog=1.10.0 \
     pkg-config=0.29.2 \
+    openh264==2.3.0 \
     pip=22.1.2
   then return 1; fi
 

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -112,6 +112,12 @@ function install_conda() {
     then return 1; fi
   fi
 
+  if [ -d ".git" ]; then  # don't invoke if not in a git clone directory
+    if ! pip install mkdocs-jupyter==0.21.0;              then return 1; fi # for adding notebooks to our documentation (supports toc and executation before deployment)
+    if ! pip install pyyaml==6.0;                         then return 1; fi # for mkdocs
+    if ! pip install markdown-it-py==2.1.0;               then return 1; fi # for mkdocs
+  fi
+
   if ! pip install notebook==6.1.5;                     then return 1; fi
   if ! pip install trimesh==3.12.6;                     then return 1; fi
   if ! pip install termcolor==1.1.0;                    then return 1; fi
@@ -177,10 +183,6 @@ function install_conda() {
   jupyter nbextension enable toc2/main
 
   if [ -d ".git" ]; then  # don't invoke if not in a git clone directory
-    if ! pip install mkdocs-jupyter==0.21.0;              then return 1; fi # for adding notebooks to our documentation (supports toc and executation before deployment)
-    if ! pip install pyyaml==6.0;                         then return 1; fi # for mkdocs
-    if ! pip install markdown-it-py==2.1.0;               then return 1; fi # for mkdocs
-
     # installing nbstripout to strip out notebooks cell outputs before committing 
     nbstripout --install
     nbstripout --install --attributes .gitattributes

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -100,7 +100,8 @@ function install_conda() {
     pybind11=2.9.2 \
     nlohmann_json=3.10.5 \
     spdlog=1.10.0 \
-    pkg-config=0.29.2
+    pkg-config=0.29.2 \
+    pip=22.1.2
   then return 1; fi
 
   # linux (only) deps
@@ -111,9 +112,6 @@ function install_conda() {
     then return 1; fi
   fi
 
-
-  # pip is needed in sub-environments or the base env's pip will silently install to base
-  if ! conda install --yes pip=22.1.2; then return 1; fi
   if ! pip install notebook==6.1.5;                     then return 1; fi
   if ! pip install trimesh==3.12.6;                     then return 1; fi
   if ! pip install termcolor==1.1.0;                    then return 1; fi

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -114,7 +114,6 @@ function install_conda() {
 
   # pip is needed in sub-environments or the base env's pip will silently install to base
   if ! conda install --yes pip=22.1.2; then return 1; fi
-
   if ! pip install notebook==6.1.5;                     then return 1; fi
   if ! pip install trimesh==3.12.6;                     then return 1; fi
   if ! pip install termcolor==1.1.0;                    then return 1; fi
@@ -180,6 +179,8 @@ function install_conda() {
   jupyter nbextension enable toc2/main
 
   if [ -d ".git" ]; then  # don't invoke if not in a git clone directory
+    conda uninstall nbconvert
+    if ! pip install nbconvert==6.5.3;                    then return 1; fi
     if ! pip install mkdocs-jupyter==0.21.0;              then return 1; fi # for adding notebooks to our documentation (supports toc and executation before deployment)
     if ! pip install pyyaml==6.0;                       then return 1; fi # for mkdocs
     if ! pip install markdown-it-py==2.1.0;               then return 1; fi # for mkdocs

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -132,6 +132,8 @@ function install_conda() {
   if ! pip install mdutils==1.4.0;                      then return 1; fi # lib for writing markdown files (auto-documentation)
   if ! pip install mkdocs==1.3.0;                       then return 1; fi # lib for generating documentation from markdown
   if ! pip install mkdocs-material==8.3.8;              then return 1; fi # theme for mkdocs
+  if ! pip install mkdocstrings==0.19.0;                then return 1; fi # needed for python api docs
+  if ! pip install mkdocstrings-python==0.7.1;          then return 1; fi # needed for python api docs
   if ! pip install mike==1.1.2;                         then return 1; fi # deploys versioned documentation to gh-pages
   if ! pip install jinja2==3.1.2;                       then return 1; fi # only version of jinja that works (needed by mkdocs)
   if ! pip install Pygments==2.12.0;                    then return 1; fi # Needed by mkdocs

--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -179,10 +179,8 @@ function install_conda() {
   jupyter nbextension enable toc2/main
 
   if [ -d ".git" ]; then  # don't invoke if not in a git clone directory
-    conda uninstall nbconvert
-    if ! pip install nbconvert==6.5.3;                    then return 1; fi
     if ! pip install mkdocs-jupyter==0.21.0;              then return 1; fi # for adding notebooks to our documentation (supports toc and executation before deployment)
-    if ! pip install pyyaml==6.0;                       then return 1; fi # for mkdocs
+    if ! pip install pyyaml==6.0;                         then return 1; fi # for mkdocs
     if ! pip install markdown-it-py==2.1.0;               then return 1; fi # for mkdocs
 
     # installing nbstripout to strip out notebooks cell outputs before committing 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,6 +172,9 @@ plugins:
             docstring_style: google
             docstring_options:
               ignore_init_summary: yes
+          setup_commands:
+            - "import sys"
+            - "print(sys.path)"
           rendering:
             merge_init_into_class: yes
   - mkdocs-jupyter:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,6 +175,7 @@ plugins:
           setup_commands:
             - "import sys"
             - "print(sys.path)"
+            - "import shapeworks"
           rendering:
             merge_init_into_class: yes
   - mkdocs-jupyter:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,7 +109,9 @@ nav:
    - 'Getting Started with Markdown':        'dev/markdown.md'
    - 'Adding to PATH Environment Variable':  'dev/paths.md'
 
-- API Reference:
+- Python API Reference: 'python/python-api.md'
+     
+- C++ API Reference:
    - Groups:     'api/Modules/index_groups.md'
    - Namespaces: 'api/Namespaces/index_namespaces.md'
    - Classes:    'api/Classes/index_classes.md'
@@ -163,6 +165,15 @@ extra_javascript:
 
 plugins:
   - search
+  - mkdocstrings:
+      handlers:
+        python:
+          selection:
+            docstring_style: google
+            docstring_options:
+              ignore_init_summary: yes
+          rendering:
+            merge_init_into_class: yes
   - mkdocs-jupyter:
       execute: False
       include_source: True


### PR DESCRIPTION
Adds Python API documentation to mkdocs site using [`mkdocstrings`](https://mkdocstrings.github.io/).

Addresses:

* #1864 

Adds two new pip dependencies, `mkdocstrings==0.19.0` and `mkdocstrings-python==0.7.1`.

Results can be seen with `mkdocs serve` after successful build.  Looks like this:

<img width="1255" alt="python_api" src="https://user-images.githubusercontent.com/1693349/191584573-88359fc1-c9a3-4d5c-9023-27c84cce8ba5.png">
