### PR TITLE
Disable auto shape evaluation

### DIFF
--- a/Libs/Common/Logging.cpp
+++ b/Libs/Common/Logging.cpp
@@ -29,19 +29,19 @@ Logging::Logging() {
 }
 
 //-----------------------------------------------------------------------------
-Logging &Logging::Instance() {
+Logging& Logging::Instance() {
   static Logging instance;
   return instance;
 }
 
 //-----------------------------------------------------------------------------
-void Logging::open_file_log(std::string filename) {
+void Logging::open_file_log(const std::string& filename) {
   try {
     auto logger = spd::basic_logger_mt("file", filename);
     logger->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%l] %v");
     logger->set_level(spd::get_level());
     log_open_ = true;
-  } catch (const spd::spdlog_ex &ex) {
+  } catch (const spd::spdlog_ex& ex) {
     spd::error(std::string("Log file init failed: ") + ex.what());
   }
 
@@ -49,13 +49,13 @@ void Logging::open_file_log(std::string filename) {
 }
 
 //-----------------------------------------------------------------------------
-bool Logging::check_log_open() { return log_open_; }
+bool Logging::check_log_open() const { return log_open_; }
 
 //-----------------------------------------------------------------------------
-std::string Logging::get_log_filename() { return log_filename_; }
+std::string Logging::get_log_filename() const { return log_filename_; }
 
 //-----------------------------------------------------------------------------
-void Logging::log_message(std::string message, const int line, const char *file) {
+void Logging::log_message(const std::string& message, const int line, const char *file) const {
   spd::info(message);
   if (log_open_) {
     spd::get("file")->info(message);
@@ -66,7 +66,7 @@ void Logging::log_message(std::string message, const int line, const char *file)
 }
 
 //-----------------------------------------------------------------------------
-void Logging::log_stack(std::string message) {
+void Logging::log_stack(const std::string& message) const {
   spd::error(message);
   if (log_open_) {
     spd::get("file")->error(message);
@@ -74,7 +74,7 @@ void Logging::log_stack(std::string message) {
 }
 
 //-----------------------------------------------------------------------------
-void Logging::log_error(std::string message, const int line, const char *file) {
+void Logging::log_error(const std::string& message, const int line, const char *file) const {
   spd::error(message);
   if (log_open_) {
     spd::get("file")->error(message);
@@ -85,7 +85,7 @@ void Logging::log_error(std::string message, const int line, const char *file) {
 }
 
 //-----------------------------------------------------------------------------
-void Logging::show_message(std::string message, const int line, const char *file) {
+void Logging::show_message(const std::string& message, const int line, const char *file) const {
   log_message(message, line, file);
   if (message_callback_) {
     message_callback_(message);
@@ -93,7 +93,7 @@ void Logging::show_message(std::string message, const int line, const char *file
 }
 
 //-----------------------------------------------------------------------------
-void Logging::show_status(std::string message, const int line, const char *file) {
+void Logging::show_status(const std::string& message, const int line, const char *file) const {
   log_message(message, line, file);
   if (message_callback_) {
     message_callback_(message);
@@ -101,19 +101,19 @@ void Logging::show_status(std::string message, const int line, const char *file)
 }
 
 //-----------------------------------------------------------------------------
-void Logging::log_debug(std::string message, const int line, const char *file) {
+void Logging::log_debug(const std::string& message, const int line, const char *file) const {
   std::string str = create_header(line, file) + " " + message;
   spd::debug(str);
   if (log_open_) {
     spd::get("file")->debug(str);
   }
   if (debug_callback_) {
-    debug_callback_(message);
+    debug_callback_(str);
   }
 }
 
 //-----------------------------------------------------------------------------
-void Logging::log_warning(std::string message, const int line, const char *file) {
+void Logging::log_warning(const std::string& message, const int line, const char *file) const {
   spd::warn(message);
   if (log_open_) {
     spd::get("file")->warn(message);
@@ -134,15 +134,15 @@ void Logging::close_log() {
 }
 
 //-----------------------------------------------------------------------------
-void Logging::set_error_callback(std::function<void(std::string)> callback) { error_callback_ = callback; }
+void Logging::set_error_callback(const std::function<void(std::string)>& callback) { error_callback_ = callback; }
 
 //-----------------------------------------------------------------------------
-void Logging::set_message_callback(std::function<void(std::string)> callback) { message_callback_ = callback; }
+void Logging::set_message_callback(const std::function<void(std::string)>& callback) { message_callback_ = callback; }
 
 //-----------------------------------------------------------------------------
-void Logging::set_warning_callback(std::function<void(std::string)> callback) { warning_callback_ = callback; }
+void Logging::set_warning_callback(const std::function<void(std::string)>& callback) { warning_callback_ = callback; }
 
 //-----------------------------------------------------------------------------
-void Logging::set_debug_callback(std::function<void(std::string)> callback) { debug_callback_ = callback; }
+void Logging::set_debug_callback(const std::function<void(std::string)>& callback) { debug_callback_ = callback; }
 
 }  // namespace shapeworks

--- a/Libs/Common/Logging.h
+++ b/Libs/Common/Logging.h
@@ -67,49 +67,49 @@ class Logging {
   static Logging& Instance();
 
   //! Create a file log
-  void open_file_log(std::string filename);
+  void open_file_log(const std::string& filename);
 
   //! Return if the log is open
-  bool check_log_open();
+  bool check_log_open() const;
 
   //! Return the log filename
-  std::string get_log_filename();
+  std::string get_log_filename() const;
 
   //! Log a message, use SW_LOG macro
-  void log_message(std::string message, const int line, const char* file);
+  void log_message(const std::string& message, const int line, const char *file) const;
 
   //! Log a stack trace message, use SW_LOG_STACK macro
-  void log_stack(std::string message);
+  void log_stack(const std::string& message) const;
 
   //! Log an error, use SW_ERROR macro
-  void log_error(std::string message, const int line, const char* file);
+  void log_error(const std::string& message, const int line, const char *file) const;
 
   //! Log a message, use SW_MESSAGE macro
-  void show_message(std::string message, const int line, const char* file);
+  void show_message(const std::string& message, const int line, const char *file) const;
 
   //! Log a message, use SW_STATUS macro
-  void show_status(std::string message, const int line, const char* file);
+  void show_status(const std::string& message, const int line, const char *file) const;
 
   //! Log a debug message, use SW_DEBUG macro
-  void log_debug(std::string message, const int line, const char* file);
+  void log_debug(const std::string& message, const int line, const char *file) const;
 
   //! Log a warning message, use SW_WARN macro
-  void log_warning(std::string message, const int line, const char* file);
+  void log_warning(const std::string& message, const int line, const char *file) const;
 
   //! Close the log, use SW_CLOSE_LOG macro
   void close_log();
 
   //! Set an error callback function to be called whenever an error is raised
-  void set_error_callback(std::function<void(std::string)> callback);
+  void set_error_callback(const std::function<void(std::string)>& callback);
 
   //! Set a message callback function to be called whenever an message is posted
-  void set_message_callback(std::function<void(std::string)> callback);
+  void set_message_callback(const std::function<void(std::string)>& callback);
 
   //! Set a warning callback function to be called whenever a warning is posted
-  void set_warning_callback(std::function<void(std::string)> callback);
+  void set_warning_callback(const std::function<void(std::string)>& callback);
 
   //! Set a debug messagecallback function to be called whenever a debug message is posted
-  void set_debug_callback(std::function<void(std::string)> callback);
+  void set_debug_callback(const std::function<void(std::string)>& callback);
 
  private:
   //! Constructor

--- a/Libs/Particles/ParticleShapeStatistics.cpp
+++ b/Libs/Particles/ParticleShapeStatistics.cpp
@@ -2,6 +2,7 @@
 #include "ParticleShapeStatistics.h"
 #include "ShapeEvaluation.h"
 #include <Project/Project.h>
+#include <Logging.h>
 
 
 #include <vnl/algo/vnl_symmetric_eigensystem.h>

--- a/Libs/Particles/ParticleShapeStatistics.h
+++ b/Libs/Particles/ParticleShapeStatistics.h
@@ -131,6 +131,8 @@ public:
   Eigen::MatrixXd get_group1_matrix();
   Eigen::MatrixXd get_group2_matrix();
 
+  Eigen::MatrixXd& matrix() { return m_Matrix; };
+
 private:
 
   void compute_good_bad_points();

--- a/Libs/Project/ProjectReader.cpp
+++ b/Libs/Project/ProjectReader.cpp
@@ -17,7 +17,6 @@ ProjectReader::ProjectReader(Project& project) : project_(project) {}
 void ProjectReader::load_subjects(StringMapList list) {
   std::vector<std::shared_ptr<Subject>> subjects;
   bool first = true;
-  std::vector<std::string> original_keys;
   for (auto& item : list) {
     auto subject = std::make_shared<Subject>();
 
@@ -28,7 +27,6 @@ void ProjectReader::load_subjects(StringMapList list) {
       auto domain_names = ProjectUtils::determine_domain_names(keys);
       project_.set_domain_names(domain_names);
       ProjectUtils::determine_domain_types(&project_, key_map);
-      original_keys = ProjectUtils::get_original_keys(domain_names, key_map);
     }
 
     auto domains = project_.get_domain_names();

--- a/Studio/src/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Analysis/AnalysisTool.cpp
@@ -439,7 +439,9 @@ bool AnalysisTool::compute_stats() {
 
   update_difference_particles();
 
-  compute_shape_evaluations();
+  if (ui_->metrics_open_button->isChecked()) {
+    compute_shape_evaluations();
+  }
 
   stats_ready_ = true;
   std::vector<double> vals;
@@ -607,7 +609,7 @@ void AnalysisTool::compute_shape_evaluations() {
   ui_->specificity_progress->setValue(0);
 
   auto job_types = {ShapeEvaluationJob::JobType::CompactnessType, ShapeEvaluationJob::JobType::GeneralizationType,
-                    ShapeEvaluationJob::JobType::SpecificityType};
+                      ShapeEvaluationJob::JobType::SpecificityType};
   for (auto job_type : job_types) {
     auto worker = Worker::create_worker();
     auto job = QSharedPointer<ShapeEvaluationJob>::create(job_type, stats_);
@@ -1040,7 +1042,7 @@ void AnalysisTool::on_metrics_open_button_toggled() {
   ui_->metrics_content->setVisible(show);
 
   if (show) {
-    compute_stats();
+    compute_shape_evaluations();
   }
 }
 

--- a/Studio/src/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Analysis/AnalysisTool.cpp
@@ -608,9 +608,45 @@ void AnalysisTool::compute_shape_evaluations() {
   ui_->generalization_progress->setValue(0);
   ui_->specificity_progress->setValue(0);
 
-  auto job_types = {ShapeEvaluationJob::JobType::CompactnessType, ShapeEvaluationJob::JobType::GeneralizationType,
-                      ShapeEvaluationJob::JobType::SpecificityType};
+
+  if ((stats_.matrix().rows() > 10000 || stats_.matrix().cols() > 10000) && !large_particle_disclaimer_waived_) {
+    QMessageBox::StandardButton reply;
+    reply = QMessageBox::question(this, "Are you sure?",
+                                  "Shape evaluation on large numbers of particles or samples may exhaust "
+                                  "system memory and cause ShapeWorksStudio to become unresponsive, "
+                                  "are you sure you want to continue?",
+                                  QMessageBox::Yes | QMessageBox::No);
+    if (reply == QMessageBox::No) {
+      skip_evals_ = true;
+    }
+    large_particle_disclaimer_waived_ = true;
+  }
+
+  std::vector<ShapeEvaluationJob::JobType> job_types = {ShapeEvaluationJob::JobType::CompactnessType, ShapeEvaluationJob::JobType::GeneralizationType,
+                    ShapeEvaluationJob::JobType::SpecificityType};
+
+  if (skip_evals_) {
+    // compactness isn't ever a problem.
+    job_types = {ShapeEvaluationJob::JobType::CompactnessType};
+  }
+
   for (auto job_type : job_types) {
+
+    switch (job_type) {
+      case ShapeEvaluationJob::JobType::CompactnessType:
+        SW_DEBUG("job type: compactness");
+        break;
+      case ShapeEvaluationJob::JobType::GeneralizationType:
+        SW_DEBUG("job type: gen job");
+        break;
+      case ShapeEvaluationJob::JobType::SpecificityType:
+        SW_DEBUG("job type: spec job");
+        break;
+      default:
+        SW_DEBUG("job type: wtf");
+    }
+
+
     auto worker = Worker::create_worker();
     auto job = QSharedPointer<ShapeEvaluationJob>::create(job_type, stats_);
     connect(job.data(), &ShapeEvaluationJob::result_ready, this, &AnalysisTool::handle_eval_thread_complete);
@@ -1120,8 +1156,11 @@ void AnalysisTool::initialize_mesh_warper() {
 
 //---------------------------------------------------------------------------
 void AnalysisTool::handle_eval_thread_complete(ShapeEvaluationJob::JobType job_type, Eigen::VectorXd data) {
+  SW_DEBUG("eval thread is complete");
+
   switch (job_type) {
     case ShapeEvaluationJob::JobType::CompactnessType:
+      SW_DEBUG("compactness go");
       eval_compactness_ = data;
       create_plot(ui_->compactness_graph, data, "Compactness", "Number of Modes", "Explained Variance");
       ui_->compactness_graph->show();

--- a/Studio/src/Analysis/AnalysisTool.h
+++ b/Studio/src/Analysis/AnalysisTool.h
@@ -215,6 +215,8 @@ class AnalysisTool : public QWidget {
   ParticleShapeStatistics stats_;
   bool stats_ready_ = false;
   bool evals_ready_ = false;
+  bool large_particle_disclaimer_waived_ = false;
+  bool skip_evals_ = false;
 
   Eigen::VectorXd eval_specificity_;
   Eigen::VectorXd eval_compactness_;

--- a/Studio/src/Analysis/ShapeEvaluationJob.cpp
+++ b/Studio/src/Analysis/ShapeEvaluationJob.cpp
@@ -1,5 +1,6 @@
-#include <iostream>
 
+
+#include <Logging.h>
 #include "ShapeEvaluationJob.h"
 namespace shapeworks {
 

--- a/Studio/src/Data/Session.cpp
+++ b/Studio/src/Data/Session.cpp
@@ -124,7 +124,7 @@ bool Session::save_project(QString filename) {
       // open file
       QFile file(filename);
       if (!file.open(QIODevice::WriteOnly)) {
-        QMessageBox::warning(0, "Read only", "The file is in read only mode");
+        QMessageBox::warning(nullptr, "Read only", "The file is in read only mode");
         return false;
       }
     }
@@ -179,7 +179,7 @@ bool Session::save_project(QString filename) {
     // JsonProjectReader::read_project(proj, "/tmp/project.json");
 
   } catch (std::exception& e) {
-    QMessageBox::warning(0, "Error saving project", QString("Error saving project: ") + e.what());
+    QMessageBox::warning(nullptr, "Error saving project", QString("Error saving project: ") + e.what());
     return false;
   }
 
@@ -394,6 +394,10 @@ bool Session::load_xl_project(QString filename) {
 
   auto subjects = project_->get_subjects();
 
+  QProgressDialog progress("Loading Project...", "Abort", 0, num_subjects, parent_);
+  progress.setWindowModality(Qt::WindowModal);
+  progress.setMinimumDuration(2000);
+
   for (int i = 0; i < num_subjects; i++) {
     auto shape = std::make_shared<Shape>();
     shape->set_mesh_manager(mesh_manager_);
@@ -429,6 +433,11 @@ bool Session::load_xl_project(QString filename) {
       }
     }
     shapes_.push_back(shape);
+    if (progress.wasCanceled()) {
+      break;
+    }
+    progress.setValue(progress.value() + 1);
+
   }
 
   groups_available_ = project_->get_group_names().size() > 0;

--- a/Studio/src/Interface/StatusBarWidget.cpp
+++ b/Studio/src/Interface/StatusBarWidget.cpp
@@ -40,6 +40,9 @@ void StatusBarWidget::set_message(MessageType message_type, QString message) {
     ui_->log_button->setIcon(normal_message_icon_);
   } else if (message_type == MessageType::warning) {
     ui_->log_button->setIcon(warning_message_icon_);
+  } else if (message_type == MessageType::debug) {
+    ui_->log_button->setIcon(normal_message_icon_);
+    message = "<font color=#800080>" + message + "</font>";
   } else {
     ui_->log_button->setIcon(error_message_icon_);
     message = "<font color=#CC0000>" + message + "</font>";


### PR DESCRIPTION
This PR addresses:

* #1774 

It also adds a progress bar to project loading and asks the user if they really want to run the shape evaluation for large numbers of particles/shapes (any time the SVD is going to use more than about 4GB of memory).

<img width="420" alt="image" src="https://user-images.githubusercontent.com/1693349/197009863-6e5817e2-188c-4649-b5ea-a0d6d732501a.png">
