### PR TITLE
Fix #1387 by keeping a list of used filenames within a grooming operation and add a number increment if there is a clash.

### DIFF
--- a/Libs/Groom/Groom.cpp
+++ b/Libs/Groom/Groom.cpp
@@ -27,6 +27,7 @@ Groom::Groom(ProjectHandle project) { this->project_ = project; }
 
 //---------------------------------------------------------------------------
 bool Groom::run() {
+  used_names_.clear();
   this->progress_ = 0;
   this->progress_counter_ = 0;
   this->total_ops_ = this->get_total_ops();
@@ -641,7 +642,17 @@ std::string Groom::get_output_filename(std::string input, DomainType domain_type
     }
   }
 
-  auto output = path + "/" + StringUtils::getBaseFilenameWithoutExtension(input) + suffix;
+  auto name = path + "/" + StringUtils::getBaseFilenameWithoutExtension(input);
+
+  // check for and handle name clashes, e.g. a/foo.vtk, b/foo.vtk (see #1387)
+  auto base_name = name;
+  int count = 2;
+  while (used_names_.find(name) != used_names_.end()) {
+    name = base_name + std::to_string(count++);
+  }
+  used_names_.insert(name);
+
+  auto output = name + suffix;
 
   return output;
 }

--- a/Libs/Groom/Groom.h
+++ b/Libs/Groom/Groom.h
@@ -19,7 +19,6 @@ class Groom {
   //! Run the grooming
   bool run();
 
-
   //! Set abort as soon as possible
   void abort();
 
@@ -61,7 +60,7 @@ class Groom {
   //! Run the contour based pipeline on a single subject
   bool contour_pipeline(std::shared_ptr<Subject> subject, size_t domain);
 
-  //! Return the output filename for a given intpu tfile
+  //! Return the output filename for a given input file
   std::string get_output_filename(std::string input, DomainType domain_type);
 
   bool run_alignment();
@@ -95,5 +94,7 @@ class Groom {
   bool abort_ = false;
 
   std::mutex mutex_;
+
+  std::set<std::string> used_names_;
 };
 }  // namespace shapeworks


### PR DESCRIPTION
Fixes:
* #1387 