### PR TITLE
Re-enable LD_LIBRARY_PATH, apparently linuxdeployqt can't find Qt

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -40,7 +40,7 @@ RUN curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
 
 # Get and decompress linuxdeployqt, it's complicated to use fuse with docker due to the kernel module
 RUN curl -L -o $HOME/linuxdeployqt.AppImage https://github.com/probonopd/linuxdeployqt/releases/download/5/linuxdeployqt-5-x86_64.AppImage && chmod +x $HOME/linuxdeployqt.AppImage ; cd $HOME ; ./linuxdeployqt.AppImage --appimage-extract
-RUN cp /root/squashfs-root/usr/bin/linuxdeployqt /usr/bin
+RUN ln -s /root/squashfs-root/usr/bin/linuxdeployqt /usr/bin
 
 # Set compresion for ccache
 RUN mkdir /root/.ccache && echo "compression = true" > /root/.ccache/ccache.conf

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,7 +14,7 @@ env:
   BUILD_TYPE: Release
   SW_PORTAL_LOGIN: ${{ secrets.PORTAL_LOGIN }}
   CACHE_HOST: ${{ secrets.SSH_HOST }}
-#  LD_LIBRARY_PATH: /opt/conda/envs/shapeworks/lib
+  LD_LIBRARY_PATH: /opt/conda/envs/shapeworks/lib
     
 jobs:
   build:
@@ -87,9 +87,6 @@ jobs:
       shell: bash -l {0}
       run: conda activate shapeworks && cd build && make install
       
-#    - name: Remove Qt SQL Stuff
-#      run: mv /usr/local/plugins/sqldrivers/libqsqlmysql.so /usr/local/plugins/sqldrivers/libqsqlpsql.so /tmp
-
     - name: Build Binary Package
       shell: bash -l {0}
       env:
@@ -100,9 +97,6 @@ jobs:
       shell: bash -l {0}
       run: conda activate shapeworks && source ./devenv.sh ./build/bin && cd build && ctest -VV
   
-#    - name: Replace Qt SQL Stuff
-#      run: mv /tmp/lib*.so /usr/local/plugins/sqldrivers
-
     - name: Copy artifact
       shell: bash -l {0}
       run: cd  /__w/ShapeWorks/ShapeWorks/artifacts && ${GITHUB_WORKSPACE}/.github/workflows/copy_artifact.sh artifact-${{github.sha}}-linux *

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,7 +14,6 @@ env:
   BUILD_TYPE: Release
   SW_PORTAL_LOGIN: ${{ secrets.PORTAL_LOGIN }}
   CACHE_HOST: ${{ secrets.SSH_HOST }}
-  LD_LIBRARY_PATH: /opt/conda/envs/shapeworks/lib
     
 jobs:
   build:


### PR DESCRIPTION
Re-enable LD_LIBRARY_PATH, apparently linuxdeployqt can't find Qt despite conda being activated.

```
2022-11-03T02:31:04.1170164Z + linuxdeployqt ShapeWorksStudio -verbose=2
2022-11-03T02:31:04.1224745Z linuxdeployqt: error while loading shared libraries: libQt5Core.so.5: cannot open shared object file: No such file or directory
```