### PR TITLE
Fix #1933 - Conda environment

### DIFF
--- a/install_shapeworks.sh
+++ b/install_shapeworks.sh
@@ -46,7 +46,7 @@ done
 
 CONDAENV=shapeworks
 if [[ "${#POSITIONAL_ARGS[@]}" -eq 1 ]]; then
-   CONDAENV=${POSITIONAL_ARGS[1]}
+   CONDAENV=${POSITIONAL_ARGS[0]}
 fi
 
 echo "Creating new conda environment for ShapeWorks called \"$CONDAENV\"..."


### PR DESCRIPTION
Fixes:

* #1933 

Array access was working for zsh for some reason, but not bash.