### PR TITLE
Per domain particle display control and alternate color support

### DIFF
--- a/Libs/Analyze/Particles.cpp
+++ b/Libs/Analyze/Particles.cpp
@@ -5,16 +5,14 @@
 
 namespace shapeworks {
 
-//---------------------------------------------------------------------------
-Particles::Particles() {}
 
 //---------------------------------------------------------------------------
-void Particles::set_local_particles(int domain, std::vector<itk::Point<double>> particles) {
+void Particles::set_local_particles(int domain, const std::vector<itk::Point<double>>& particles) {
   set_particles(domain, particles, true);
 }
 
 //---------------------------------------------------------------------------
-void Particles::set_world_particles(int domain, std::vector<itk::Point<double>> particles) {
+void Particles::set_world_particles(int domain, const std::vector<itk::Point<double>>& particles) {
   set_particles(domain, particles, false);
 }
 
@@ -39,10 +37,10 @@ void Particles::set_particles(int domain, std::vector<itk::Point<double>> partic
 }
 
 //---------------------------------------------------------------------------
-std::vector<Eigen::VectorXd> Particles::get_local_particles() { return local_particles_; }
+std::vector<Eigen::VectorXd> Particles::get_local_particles() const { return local_particles_; }
 
 //---------------------------------------------------------------------------
-std::vector<Eigen::VectorXd> Particles::get_world_particles() { return transformed_global_particles_; }
+std::vector<Eigen::VectorXd> Particles::get_world_particles() const { return transformed_global_particles_; }
 
 //---------------------------------------------------------------------------
 std::vector<itk::Point<double>> Particles::get_local_points(int domain) {
@@ -55,7 +53,7 @@ std::vector<itk::Point<double>> Particles::get_world_points(int domain) {
 }
 
 //---------------------------------------------------------------------------
-std::vector<itk::Point<double>> Particles::eigen_to_point_vector(const Eigen::VectorXd& particles) {
+std::vector<itk::Point<double>> Particles::eigen_to_point_vector(const Eigen::VectorXd& particles) const {
   std::vector<itk::Point<double>> points;
 
   for (size_t i = 0; i < particles.size(); i += 3) {
@@ -102,20 +100,15 @@ void Particles::set_world_particles(int domain, Eigen::VectorXd particles) {
 }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd Particles::get_combined_local_particles(std::vector<bool> domains) const {
-  return combine(local_particles_, domains);
-}
+Eigen::VectorXd Particles::get_combined_local_particles() const { return combine(local_particles_); }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd Particles::get_combined_global_particles(std::vector<bool> domains) const {
-  return combine(transformed_global_particles_, domains);
-}
+Eigen::VectorXd Particles::get_combined_global_particles() const { return combine(transformed_global_particles_); }
 
 //---------------------------------------------------------------------------
 void Particles::set_combined_global_particles(const Eigen::VectorXd& particles) {
   int num_domains = global_particles_.size();
   if (num_domains == 0) {  // nothing set, assume one domain
-    num_domains = 1;
     global_particles_ = {particles};
     return;
   }
@@ -130,25 +123,17 @@ void Particles::set_combined_global_particles(const Eigen::VectorXd& particles) 
 }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd Particles::combine(const std::vector<Eigen::VectorXd>& particles, std::vector<bool> domains) const {
-  if (domains.size() != particles.size()) {
-    domains.resize(particles.size(), true);
-  }
-
+Eigen::VectorXd Particles::combine(const std::vector<Eigen::VectorXd>& particles) const {
   Eigen::VectorXd points;
   int size = 0;
   for (int i = 0; i < particles.size(); i++) {
-    if (domains[i]) {
-      size += particles[i].size();
-    }
+    size += particles[i].size();
   }
   points.resize(size);
   int idx = 0;
   for (int i = 0; i < particles.size(); i++) {
-    if (domains[i]) {
-      for (int j = 0; j < particles[i].size(); j++) {
-        points[idx++] = particles[i][j];
-      }
+    for (int j = 0; j < particles[i].size(); j++) {
+      points[idx++] = particles[i][j];
     }
   }
 
@@ -174,12 +159,12 @@ void Particles::set_transform(vtkSmartPointer<vtkTransform> transform) {
 }
 
 //---------------------------------------------------------------------------
-void Particles::set_procrustes_transforms(std::vector<vtkSmartPointer<vtkTransform>> transforms) {
+void Particles::set_procrustes_transforms(const std::vector<vtkSmartPointer<vtkTransform>>& transforms) {
   procrustes_transforms_ = transforms;
 }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd Particles::get_difference_vectors(const Particles& other) {
+Eigen::VectorXd Particles::get_difference_vectors(const Particles& other) const {
   auto combined = get_combined_global_particles();
   auto other_combined = other.get_combined_global_particles();
   if (combined.size() != other_combined.size()) {
@@ -203,7 +188,7 @@ void Particles::transform_global_particles() {
         pt[1] = eigen[i + 1];
         pt[2] = eigen[i + 2];
 
-        double *new_point = transform_->TransformPoint(pt);
+        const double* new_point = transform_->TransformPoint(pt);
         eigen[i] = new_point[0];
         eigen[i + 1] = new_point[1];
         eigen[i + 2] = new_point[2];
@@ -212,10 +197,10 @@ void Particles::transform_global_particles() {
           pt[0] = eigen[i];
           pt[1] = eigen[i + 1];
           pt[2] = eigen[i + 2];
-          double *new_point = procrustes_transforms_[d]->TransformPoint(pt);
-          eigen[i] = new_point[0];
-          eigen[i + 1] = new_point[1];
-          eigen[i + 2] = new_point[2];
+          const double* new_point2 = procrustes_transforms_[d]->TransformPoint(pt);
+          eigen[i] = new_point2[0];
+          eigen[i + 1] = new_point2[1];
+          eigen[i + 2] = new_point2[2];
         }
       }
 

--- a/Libs/Analyze/Particles.h
+++ b/Libs/Analyze/Particles.h
@@ -28,16 +28,16 @@ class Particles {
   void set_local_particles(int domain, Eigen::VectorXd particles);
   void set_world_particles(int domain, Eigen::VectorXd particles);
 
-  std::vector<Eigen::VectorXd> get_local_particles();
-  std::vector<Eigen::VectorXd> get_world_particles();
+  std::vector<Eigen::VectorXd> get_local_particles(); // one Eigen::VectorXd per domain
+  std::vector<Eigen::VectorXd> get_world_particles(); // one Eigen::VectorXd per domain
 
   Eigen::VectorXd get_local_particles(int domain);
   Eigen::VectorXd get_world_particles(int domain);
   //! Get untransformed original world particles from optimizer
   Eigen::VectorXd get_raw_world_particles(int domain);
 
-  Eigen::VectorXd get_combined_local_particles() const;
-  Eigen::VectorXd get_combined_global_particles() const;
+  Eigen::VectorXd get_combined_local_particles(std::vector<bool> domains = {}) const;
+  Eigen::VectorXd get_combined_global_particles(std::vector<bool> domains = {}) const;
   void set_combined_global_particles(const Eigen::VectorXd &particles);
 
   std::vector<itk::Point<double>> get_local_points(int domain);
@@ -59,7 +59,7 @@ class Particles {
 
   std::vector<itk::Point<double>> eigen_to_point_vector(const Eigen::VectorXd& particles);
 
-  Eigen::VectorXd combine(const std::vector<Eigen::VectorXd>& particles) const;
+  Eigen::VectorXd combine(const std::vector<Eigen::VectorXd>& particles, std::vector<bool> domains = {}) const;
 
   void set_particles(int domain, std::vector<itk::Point<double>> particles, bool local);
   std::vector<Eigen::VectorXd> local_particles_;               // one for each domain

--- a/Libs/Analyze/Particles.h
+++ b/Libs/Analyze/Particles.h
@@ -20,24 +20,24 @@ namespace shapeworks {
  */
 class Particles {
  public:
-  Particles();
+  Particles() = default;
 
-  void set_local_particles(int domain, std::vector<itk::Point<double>> particles);
-  void set_world_particles(int domain, std::vector<itk::Point<double>> particles);
+  void set_local_particles(int domain, const std::vector<itk::Point<double>>& particles);
+  void set_world_particles(int domain, const std::vector<itk::Point<double>>& particles);
 
   void set_local_particles(int domain, Eigen::VectorXd particles);
   void set_world_particles(int domain, Eigen::VectorXd particles);
 
-  std::vector<Eigen::VectorXd> get_local_particles(); // one Eigen::VectorXd per domain
-  std::vector<Eigen::VectorXd> get_world_particles(); // one Eigen::VectorXd per domain
+  std::vector<Eigen::VectorXd> get_local_particles() const; // one Eigen::VectorXd per domain
+  std::vector<Eigen::VectorXd> get_world_particles() const; // one Eigen::VectorXd per domain
 
   Eigen::VectorXd get_local_particles(int domain);
   Eigen::VectorXd get_world_particles(int domain);
   //! Get untransformed original world particles from optimizer
   Eigen::VectorXd get_raw_world_particles(int domain);
 
-  Eigen::VectorXd get_combined_local_particles(std::vector<bool> domains = {}) const;
-  Eigen::VectorXd get_combined_global_particles(std::vector<bool> domains = {}) const;
+  Eigen::VectorXd get_combined_local_particles() const;
+  Eigen::VectorXd get_combined_global_particles() const;
   void set_combined_global_particles(const Eigen::VectorXd &particles);
 
   std::vector<itk::Point<double>> get_local_points(int domain);
@@ -47,9 +47,9 @@ class Particles {
   int get_domain_for_combined_id(int id);
 
   void set_transform(vtkSmartPointer<vtkTransform> transform);
-  void set_procrustes_transforms(std::vector<vtkSmartPointer<vtkTransform>> transforms);
+  void set_procrustes_transforms(const std::vector<vtkSmartPointer<vtkTransform>>& transforms);
 
-  Eigen::VectorXd get_difference_vectors(const Particles& other);
+  Eigen::VectorXd get_difference_vectors(const Particles& other) const;
 
   static void save_particles_file(std::string filename, const Eigen::VectorXd& points);
 
@@ -57,9 +57,9 @@ class Particles {
  private:
   void transform_global_particles();
 
-  std::vector<itk::Point<double>> eigen_to_point_vector(const Eigen::VectorXd& particles);
+  std::vector<itk::Point<double>> eigen_to_point_vector(const Eigen::VectorXd& particles) const;
 
-  Eigen::VectorXd combine(const std::vector<Eigen::VectorXd>& particles, std::vector<bool> domains = {}) const;
+  Eigen::VectorXd combine(const std::vector<Eigen::VectorXd>& particles) const;
 
   void set_particles(int domain, std::vector<itk::Point<double>> particles, bool local);
   std::vector<Eigen::VectorXd> local_particles_;               // one for each domain

--- a/Libs/Analyze/Shape.cpp
+++ b/Libs/Analyze/Shape.cpp
@@ -306,8 +306,8 @@ bool Shape::store_constraints() {
 Eigen::VectorXd Shape::get_global_correspondence_points() { return particles_.get_combined_global_particles(); }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd Shape::get_local_correspondence_points(std::vector<bool> domains) {
-  return particles_.get_combined_local_particles(domains);
+Eigen::VectorXd Shape::get_local_correspondence_points() {
+  return particles_.get_combined_local_particles();
 }
 
 //---------------------------------------------------------------------------
@@ -707,48 +707,6 @@ vtkSmartPointer<vtkTransform> Shape::get_reconstruction_transform(int domain) {
   vtkSmartPointer<vtkTransform> transform = vtkSmartPointer<vtkTransform>::New();
   transform->Identity();
   return transform;
-}
-
-//---------------------------------------------------------------------------
-Eigen::VectorXd Shape::get_correspondence_points_for_display(std::vector<bool> domains) {
-  auto locals = particles_.get_local_particles();
-
-  if (domains.size() != locals.size()) {  // if an array of bools was not provided, return all
-    domains.resize(locals.size(), true);
-  }
-
-  int size = 0;
-  for (int i = 0; i < locals.size(); i++) {
-    if (domains[i]) {
-      size += locals[i].size();
-    }
-  }
-  Eigen::VectorXd points;
-  points.resize(size);
-
-  int idx = 0;
-  for (int i = 0; i < locals.size(); i++) {
-    if (domains[i]) {
-      for (int j = 0; j < locals[i].size(); j += 3) {
-        double p[3];
-        p[0] = locals[i][j + 0];
-        p[1] = locals[i][j + 1];
-        p[2] = locals[i][j + 2];
-        if (reconstruction_transforms_.size() > i && !subject_) {  // only computed shapes
-          double* pt = reconstruction_transforms_[i]->TransformPoint(p);
-          points[idx++] = pt[0];
-          points[idx++] = pt[1];
-          points[idx++] = pt[2];
-        } else {
-          points[idx++] = p[0];
-          points[idx++] = p[1];
-          points[idx++] = p[2];
-        }
-      }
-    }
-  }
-
-  return points;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Analyze/Shape.cpp
+++ b/Libs/Analyze/Shape.cpp
@@ -308,7 +308,7 @@ bool Shape::store_constraints() {
 Eigen::VectorXd Shape::get_global_correspondence_points() { return particles_.get_combined_global_particles(); }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd Shape::get_local_correspondence_points() { return particles_.get_combined_local_particles(); }
+Eigen::VectorXd Shape::get_local_correspondence_points(std::vector<bool> domains) { return particles_.get_combined_local_particles(domains); }
 
 //---------------------------------------------------------------------------
 int Shape::get_id() { return id_; }
@@ -571,7 +571,7 @@ void Shape::apply_feature_to_points(std::string feature, ImageType::Pointer imag
     p[1] = all_locals[idx++];
     p[2] = all_locals[idx++];
 
-    double* pt = p;
+    double *pt = p;
 
     ImageType::PointType pitk;
     pitk[0] = pt[0];
@@ -607,7 +607,7 @@ void Shape::load_feature_from_mesh(std::string feature, MeshHandle mesh) {
 
   Eigen::VectorXf values(num_points);
 
-  vtkDataArray* from_array = from_mesh->GetPointData()->GetArray(feature.c_str());
+  vtkDataArray *from_array = from_mesh->GetPointData()->GetArray(feature.c_str());
   if (!from_array) {
     return;
   }
@@ -710,31 +710,40 @@ vtkSmartPointer<vtkTransform> Shape::get_reconstruction_transform(int domain) {
 }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd Shape::get_correspondence_points_for_display() {
+Eigen::VectorXd Shape::get_correspondence_points_for_display(std::vector<bool> domains) {
   auto locals = particles_.get_local_particles();
+
+  if (domains.size() != locals.size()) { // if an array of bools was not provided, return all
+    domains.resize(locals.size(), true);
+  }
+
   int size = 0;
   for (int i = 0; i < locals.size(); i++) {
-    size += locals[i].size();
+    if (domains[i]) {
+      size += locals[i].size();
+    }
   }
   Eigen::VectorXd points;
   points.resize(size);
 
   int idx = 0;
   for (int i = 0; i < locals.size(); i++) {
-    for (int j = 0; j < locals[i].size(); j += 3) {
-      double p[3];
-      p[0] = locals[i][j + 0];
-      p[1] = locals[i][j + 1];
-      p[2] = locals[i][j + 2];
-      if (reconstruction_transforms_.size() > i && !subject_) {  // only computed shapes
-        double* pt = reconstruction_transforms_[i]->TransformPoint(p);
-        points[idx++] = pt[0];
-        points[idx++] = pt[1];
-        points[idx++] = pt[2];
-      } else {
-        points[idx++] = p[0];
-        points[idx++] = p[1];
-        points[idx++] = p[2];
+    if (domains[i]) {
+      for (int j = 0; j < locals[i].size(); j += 3) {
+        double p[3];
+        p[0] = locals[i][j + 0];
+        p[1] = locals[i][j + 1];
+        p[2] = locals[i][j + 2];
+        if (reconstruction_transforms_.size() > i && !subject_) {  // only computed shapes
+          double *pt = reconstruction_transforms_[i]->TransformPoint(p);
+          points[idx++] = pt[0];
+          points[idx++] = pt[1];
+          points[idx++] = pt[2];
+        } else {
+          points[idx++] = p[0];
+          points[idx++] = p[1];
+          points[idx++] = p[2];
+        }
       }
     }
   }

--- a/Libs/Analyze/Shape.h
+++ b/Libs/Analyze/Shape.h
@@ -98,6 +98,9 @@ class Shape {
   /// Get the global correspondence points for display
   Eigen::VectorXd get_correspondence_points_for_display(std::vector<bool> domains = {});
 
+  /// Get the global correspondence points for display
+  std::vector<Eigen::VectorXd> get_particles_for_display();
+
   /// Get the local correspondence points
   Eigen::VectorXd get_local_correspondence_points(std::vector<bool> domains = {});
 

--- a/Libs/Analyze/Shape.h
+++ b/Libs/Analyze/Shape.h
@@ -96,10 +96,10 @@ class Shape {
   Eigen::VectorXd get_global_correspondence_points();
 
   /// Get the global correspondence points for display
-  Eigen::VectorXd get_correspondence_points_for_display();
+  Eigen::VectorXd get_correspondence_points_for_display(std::vector<bool> domains = {});
 
   /// Get the local correspondence points
-  Eigen::VectorXd get_local_correspondence_points();
+  Eigen::VectorXd get_local_correspondence_points(std::vector<bool> domains = {});
 
   void clear_reconstructed_mesh();
 

--- a/Libs/Analyze/Shape.h
+++ b/Libs/Analyze/Shape.h
@@ -96,13 +96,10 @@ class Shape {
   Eigen::VectorXd get_global_correspondence_points();
 
   /// Get the global correspondence points for display
-  Eigen::VectorXd get_correspondence_points_for_display(std::vector<bool> domains = {});
-
-  /// Get the global correspondence points for display
   std::vector<Eigen::VectorXd> get_particles_for_display();
 
   /// Get the local correspondence points
-  Eigen::VectorXd get_local_correspondence_points(std::vector<bool> domains = {});
+  Eigen::VectorXd get_local_correspondence_points();
 
   void clear_reconstructed_mesh();
 

--- a/Libs/Common/Logging.h
+++ b/Libs/Common/Logging.h
@@ -146,6 +146,9 @@ class Logging {
 #define SW_DEBUG(message, ...) \
   shapeworks::Logging::Instance().log_debug(fmt::format(message, ##__VA_ARGS__), __LINE__, __FILE__)
 
+//! Variable trace macro (e.g. output variable name = <variable value>)
+#define SW_TRACE(x) SW_DEBUG(#x" = {}",x);
+
 //! Log show message macro
 #define SW_MESSAGE(message, ...) \
   shapeworks::Logging::Instance().show_message(fmt::format(message, ##__VA_ARGS__), __LINE__, __FILE__)

--- a/Studio/src/CMakeLists.txt
+++ b/Studio/src/CMakeLists.txt
@@ -196,6 +196,7 @@ SET(STUDIO_VISUALIZATION_SRCS
   Visualization/LandmarkWidget.cpp
   Visualization/PlaneWidget.cpp
   Visualization/PaintWidget.cpp
+  Visualization/ParticleColors.cpp
   Visualization/StudioInteractorStyle.cpp
   Visualization/StudioSliceInteractorStyle.cpp
   Visualization/SliceView.cpp
@@ -208,8 +209,9 @@ SET(STUDIO_VISUALIZATION_SRCS
 
 SET(STUDIO_VISUALIZATION_MOC_HDRS
   Visualization/Lightbox.h
-  Visualization/Visualizer.h
+  Visualization/ParticleColors.h
   Visualization/StudioVtkOutputWindow.h
+  Visualization/Visualizer.h
 )
 
 SET(STUDIO_SRCS

--- a/Studio/src/Data/Preferences.cpp
+++ b/Studio/src/Data/Preferences.cpp
@@ -103,6 +103,12 @@ void Preferences::set_color_scheme(int value) { settings_.setValue("Studio/color
 int Preferences::get_color_scheme() { return settings_.value("Studio/color_scheme", 0).toInt(); }
 
 //-----------------------------------------------------------------------------
+void Preferences::set_particle_colors(int value) { settings_.setValue("Studio/particle_colors", value); }
+
+//-----------------------------------------------------------------------------
+int Preferences::get_particle_colors() { return settings_.value("Studio/particle_colors", 0).toInt(); }
+
+//-----------------------------------------------------------------------------
 void Preferences::set_color_map(int value) { settings_.setValue("Studio/color_map", value); }
 
 //-----------------------------------------------------------------------------

--- a/Studio/src/Data/Preferences.h
+++ b/Studio/src/Data/Preferences.h
@@ -71,6 +71,9 @@ class Preferences : public QObject {
   void set_color_scheme(int value);
   int get_color_scheme();
 
+  void set_particle_colors(int value);
+  int get_particle_colors();
+
   void set_color_map(int value);
   int get_color_map();
 

--- a/Studio/src/Data/PreferencesWindow.cpp
+++ b/Studio/src/Data/PreferencesWindow.cpp
@@ -1,7 +1,9 @@
 // qt
 #include <Data/Preferences.h>
 #include <Data/PreferencesWindow.h>
+#include <Logging.h>
 #include <Visualization/ColorMap.h>
+#include <Visualization/ParticleColors.h>
 #include <vtkColorSeries.h>
 #include <vtkNew.h>
 
@@ -9,8 +11,6 @@
 #include <cmath>
 #include <iostream>
 
-// The interface from the designer
-#include <Logging.h>
 #include "ui_PreferencesWindow.h"
 
 namespace shapeworks {
@@ -30,7 +30,15 @@ PreferencesWindow::PreferencesWindow(QWidget* parent, Preferences& prefs) : pref
 
   ui_->color_map->clear();
   ColorMaps maps;
-  Q_FOREACH (auto color_map, maps) { ui_->color_map->addItem(color_map.name_); }
+  Q_FOREACH (auto color_map, maps) {
+    ui_->color_map->addItem(color_map.name_);
+  }
+
+  ui_->particle_colors->clear();
+  QMetaEnum e = QMetaEnum::fromType<shapeworks::ParticleColors::ParticleColorsType>();
+  for (int i = 0; i < e.keyCount(); i++) {
+    ui_->particle_colors->addItem(e.key(i));
+  }
 
   set_values_from_preferences();
 
@@ -40,6 +48,8 @@ PreferencesWindow::PreferencesWindow(QWidget* parent, Preferences& prefs) : pref
           &PreferencesWindow::save_to_preferences);
   connect(ui_->geodesic_cache_multiplier, &QSlider::valueChanged, this, &PreferencesWindow::save_to_preferences);
   connect(ui_->color_map, qOverload<int>(&QComboBox::currentIndexChanged), this,
+          &PreferencesWindow::save_to_preferences);
+  connect(ui_->particle_colors, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &PreferencesWindow::save_to_preferences);
   connect(ui_->discrete_color_mode, &QCheckBox::toggled, this, &PreferencesWindow::save_to_preferences);
   connect(ui_->reverse_color_map, &QCheckBox::toggled, this, &PreferencesWindow::save_to_preferences);
@@ -91,6 +101,7 @@ void PreferencesWindow::set_values_from_preferences() {
   ui_->mesh_cache_memory->setValue(preferences_.get_memory_cache_percent());
   ui_->color_scheme->setCurrentIndex(preferences_.get_color_scheme());
   ui_->color_map->setCurrentIndex(preferences_.get_color_map());
+  ui_->particle_colors->setCurrentIndex(preferences_.get_particle_colors());
   ui_->reverse_color_map->setChecked(preferences_.get_reverse_color_map());
   ui_->discrete_color_mode->setChecked(preferences_.get_discrete_color_mode());
   ui_->num_threads->setValue(preferences_.get_num_threads());
@@ -129,6 +140,7 @@ void PreferencesWindow::save_to_preferences() {
   preferences_.set_optimize_file_template(ui_->optimize_file_template->text());
   preferences_.set_geodesic_cache_multiplier(ui_->geodesic_cache_multiplier->value());
   preferences_.set_color_map(ui_->color_map->currentIndex());
+  preferences_.set_particle_colors(ui_->particle_colors->currentIndex());
   preferences_.set_discrete_color_mode(ui_->discrete_color_mode->isChecked());
   preferences_.set_reverse_color_map(ui_->reverse_color_map->isChecked());
   update_labels();

--- a/Studio/src/Data/PreferencesWindow.ui
+++ b/Studio/src/Data/PreferencesWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>756</width>
-    <height>570</height>
+    <height>616</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -398,23 +398,6 @@
       <string>Colors</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_7">
-      <item row="1" column="1">
-       <widget class="QComboBox" name="color_map"/>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Color Scheme</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QCheckBox" name="reverse_color_map">
-        <property name="text">
-         <string>Reverse Color Map</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="color_scheme">
         <item>
@@ -469,19 +452,46 @@
         </item>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_14">
         <property name="text">
          <string>Color Map</string>
         </property>
        </widget>
       </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Color Scheme</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="color_map"/>
+      </item>
       <item row="4" column="1">
+       <widget class="QCheckBox" name="reverse_color_map">
+        <property name="text">
+         <string>Reverse Color Map</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
        <widget class="QCheckBox" name="discrete_color_mode">
         <property name="text">
          <string>Discrete Color Mode</string>
         </property>
        </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_particle_colors">
+        <property name="text">
+         <string>Particle Colors</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="particle_colors"/>
       </item>
      </layout>
     </widget>

--- a/Studio/src/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Interface/ShapeWorksStudioApp.cpp
@@ -209,10 +209,7 @@ ShapeWorksStudioApp::ShapeWorksStudioApp() {
   // glyph options signals/slots
   connect(ui_->glyphs_visible_button, SIGNAL(clicked()), this, SLOT(handle_glyph_changed()));
   connect(ui_->surface_visible_button, SIGNAL(clicked()), this, SLOT(handle_glyph_changed()));
-  connect(glyph_size_slider_, SIGNAL(valueChanged(int)), this, SLOT(handle_glyph_changed()));
-  connect(glyph_quality_slider_, SIGNAL(valueChanged(int)), this, SLOT(handle_glyph_changed()));
-  connect(glyph_auto_size_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
-  connect(glyph_arrow_scale_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
+
   preferences_.set_saved();
   enable_possible_actions();
 
@@ -736,6 +733,13 @@ void ShapeWorksStudioApp::create_glyph_submenu() {
   layout->addWidget(glyph_arrow_scale_, 2, 0, 1, 1);
   widget->setLayout(layout);
 
+
+  connect(glyph_size_slider_, &QSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed);
+  connect(glyph_quality_slider_, &QSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed );
+  connect(glyph_auto_size_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
+  connect(glyph_arrow_scale_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
+
+
   if (!session_) {
     return;
   }
@@ -754,6 +758,9 @@ void ShapeWorksStudioApp::create_glyph_submenu() {
     int row = 4;
     for (const auto& name : domain_names) {
       auto checkbox = new QCheckBox("Show " + QString::fromStdString(name), widget);
+      checkbox->setChecked(true);
+      connect(checkbox, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
+      domain_particle_checkboxes_.push_back(checkbox);
       layout->addWidget(checkbox, row, 0);
       row++;
     }
@@ -1215,6 +1222,13 @@ void ShapeWorksStudioApp::handle_glyph_changed() {
   glyph_quality_label_->setText(QString::number(preferences_.get_glyph_quality()));
   glyph_size_label_->setText(QString::number(preferences_.get_glyph_size()));
   // update_display(true);
+
+  std::vector<bool> domains_to_display;
+  for (auto& checkbox : domain_particle_checkboxes_) {
+    domains_to_display.push_back(checkbox->isChecked());
+  }
+  visualizer_->set_domain_particle_visibilities(domains_to_display);
+
   visualizer_->update_viewer_properties();
 }
 

--- a/Studio/src/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/src/Interface/ShapeWorksStudioApp.cpp
@@ -514,14 +514,6 @@ void ShapeWorksStudioApp::enable_possible_actions() {
 
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::update_from_preferences() {
-  glyph_quality_slider_->setValue(preferences_.get_glyph_quality());
-  glyph_size_slider_->setValue(preferences_.get_glyph_size() * 10.0);
-  glyph_auto_size_->setChecked(preferences_.get_glyph_auto_size());
-  glyph_arrow_scale_->setChecked(preferences_.get_glyph_scale_arrows());
-  glyph_size_slider_->setEnabled(!glyph_auto_size_->isChecked());
-
-  glyph_quality_label_->setText(QString::number(preferences_.get_glyph_quality()));
-  glyph_size_label_->setText(QString::number(preferences_.get_glyph_size()));
 
   ui_->center_checkbox->setChecked(preferences_.get_center_checked());
 
@@ -734,10 +726,23 @@ void ShapeWorksStudioApp::create_glyph_submenu() {
   widget->setLayout(layout);
 
 
+  glyph_quality_slider_->setValue(preferences_.get_glyph_quality());
+  glyph_size_slider_->setValue(preferences_.get_glyph_size() * 10.0);
+  glyph_auto_size_->setChecked(preferences_.get_glyph_auto_size());
+  glyph_arrow_scale_->setChecked(preferences_.get_glyph_scale_arrows());
+  glyph_size_slider_->setEnabled(!glyph_auto_size_->isChecked());
+
+  glyph_quality_label_->setText(QString::number(preferences_.get_glyph_quality()));
+  glyph_size_label_->setText(QString::number(preferences_.get_glyph_size()));
+
+
+
   connect(glyph_size_slider_, &QSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed);
   connect(glyph_quality_slider_, &QSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed );
   connect(glyph_auto_size_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
   connect(glyph_arrow_scale_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
+
+
 
 
   if (!session_) {
@@ -1446,7 +1451,6 @@ void ShapeWorksStudioApp::open_project(QString filename) {
   }
 
   session_->update_auto_glyph_size();
-  handle_glyph_changed();
 
   setWindowTitle(session_->get_display_name());
 
@@ -1457,8 +1461,11 @@ void ShapeWorksStudioApp::open_project(QString filename) {
 
   update_display(true);
 
+
+
   create_glyph_submenu();
   create_iso_submenu();
+  handle_glyph_changed();
   handle_progress(100);
   SW_LOG("Project loaded: " + filename.toStdString());
 }

--- a/Studio/src/Interface/ShapeWorksStudioApp.h
+++ b/Studio/src/Interface/ShapeWorksStudioApp.h
@@ -243,6 +243,7 @@ class ShapeWorksStudioApp : public QMainWindow {
   QSharedPointer<shapeworks::SplashScreen> splash_screen_;
   QErrorMessage error_message_dialog_;
   std::vector<QSlider*> iso_opacity_sliders_;
+  std::vector<QCheckBox*> domain_particle_checkboxes_;
 
   QString current_message_;
 

--- a/Studio/src/Visualization/Lightbox.cpp
+++ b/Studio/src/Visualization/Lightbox.cpp
@@ -337,7 +337,7 @@ void Lightbox::handle_key(int* click_pos, std::string key) {
 
 //-----------------------------------------------------------------------------
 void Lightbox::set_glyph_lut(vtkSmartPointer<vtkLookupTable> lut) {
-  Q_FOREACH (ViewerHandle viewer, viewers_) { viewer->set_lut(lut); }
+  Q_FOREACH (ViewerHandle viewer, viewers_) { viewer->set_glyph_lut(lut); }
 }
 
 //-----------------------------------------------------------------------------

--- a/Studio/src/Visualization/ParticleColors.cpp
+++ b/Studio/src/Visualization/ParticleColors.cpp
@@ -1,0 +1,12 @@
+#include "ParticleColors.h"
+
+namespace shapeworks {
+
+vtkSmartPointer<vtkLookupTable> ParticleColors::construct(ParticleColorsType type, int num) {
+  auto lut = vtkSmartPointer<vtkLookupTable>::New();
+  lut->SetNumberOfTableValues(21);
+
+  return lut;
+}
+
+}  // namespace shapeworks

--- a/Studio/src/Visualization/ParticleColors.h
+++ b/Studio/src/Visualization/ParticleColors.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <qobjectdefs.h>
+#include <vtkLookupTable.h>
+
+namespace shapeworks {
+
+class ParticleColors : public QObject {
+  Q_OBJECT;
+
+ public:
+  enum ParticleColorsType { Distinct = 0, Original = 1 };
+  Q_ENUM(ParticleColorsType);
+
+  static vtkSmartPointer<vtkLookupTable> construct(ParticleColorsType type, int num);
+};
+
+}  // namespace shapeworks

--- a/Studio/src/Visualization/ParticleColors.h
+++ b/Studio/src/Visualization/ParticleColors.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <qobjectdefs.h>
+#include <QObject>
 #include <vtkLookupTable.h>
 
 namespace shapeworks {

--- a/Studio/src/Visualization/Viewer.cpp
+++ b/Studio/src/Visualization/Viewer.cpp
@@ -847,14 +847,17 @@ void Viewer::update_points() {
     return;
   }
 
-  Eigen::VectorXd correspondence_points;
+  std::vector<Eigen::VectorXd> correspondence_points; // one set per domain
   if (session_->get_display_mode() == DisplayMode::Reconstructed) {
-    correspondence_points = shape_->get_correspondence_points_for_display(visualizer_->get_domain_particle_visibilities());
+    correspondence_points = shape_->get_particles_for_display();
   } else {
-    correspondence_points = shape_->get_local_correspondence_points(visualizer_->get_domain_particle_visibilities());
+    correspondence_points = shape_->get_particles().get_local_particles();
   }
 
-  int num_points = correspondence_points.size() / 3;
+  int num_points = 0;
+  for (int i = 0; i < correspondence_points.size(); i++) {
+    num_points += correspondence_points[i].size() / 3;
+  }
 
   vtkFloatArray *scalars = (vtkFloatArray *) (glyph_point_set_->GetPointData()->GetScalars());
 
@@ -865,6 +868,12 @@ void Viewer::update_points() {
     scalar_values = shape_->get_point_features(feature_map);
   }
 
+
+  auto domain_visibility = visualizer_->get_domain_particle_visibilities();
+  if (domain_visibility.size() != correspondence_points.size()) {
+    domain_visibility.resize(correspondence_points.size(), true);
+  }
+
   if (num_points > 0) {
     viewer_ready_ = true;
     glyphs_->SetRange(0.0, (double) num_points + 1);
@@ -873,19 +882,26 @@ void Viewer::update_points() {
     glyph_points_->Reset();
     scalars->Reset();
 
+    int point_index = 0;
     unsigned int idx = 0;
-    for (int i = 0; i < num_points; i++) {
-      double x = correspondence_points[idx++];
-      double y = correspondence_points[idx++];
-      double z = correspondence_points[idx++];
+    for (int d = 0; d < correspondence_points.size(); d++) {
+      int num_points_this_domain = correspondence_points[d].size() / 3;
 
-      if (slice_view_.should_point_show(x, y, z)) {
-        if (scalar_values.size() > i) {
-          scalars->InsertNextValue(scalar_values[i]);
-        } else {
-          scalars->InsertNextValue(i);
+      int d_index = 0;
+      for (int j = 0; j < num_points_this_domain; j++) {
+        double x = correspondence_points[d][d_index++];
+        double y = correspondence_points[d][d_index++];
+        double z = correspondence_points[d][d_index++];
+
+        if (slice_view_.should_point_show(x, y, z) && domain_visibility[d]) {
+          if (scalar_values.size() > point_index) {
+            scalars->InsertNextValue(scalar_values[point_index]);
+          } else {
+            scalars->InsertNextValue(point_index);
+          }
+          glyph_points_->InsertNextPoint(x, y, z);
         }
-        glyph_points_->InsertNextPoint(x, y, z);
+        point_index++;
       }
     }
   } else {

--- a/Studio/src/Visualization/Viewer.cpp
+++ b/Studio/src/Visualization/Viewer.cpp
@@ -849,9 +849,9 @@ void Viewer::update_points() {
 
   Eigen::VectorXd correspondence_points;
   if (session_->get_display_mode() == DisplayMode::Reconstructed) {
-    correspondence_points = shape_->get_correspondence_points_for_display();
+    correspondence_points = shape_->get_correspondence_points_for_display(visualizer_->get_domain_particle_visibilities());
   } else {
-    correspondence_points = shape_->get_local_correspondence_points();
+    correspondence_points = shape_->get_local_correspondence_points(visualizer_->get_domain_particle_visibilities());
   }
 
   int num_points = correspondence_points.size() / 3;

--- a/Studio/src/Visualization/Viewer.cpp
+++ b/Studio/src/Visualization/Viewer.cpp
@@ -223,7 +223,7 @@ void Viewer::display_vector_field() {
     glyphs_->ScalingOn();
     glyphs_->ClampingOff();
     glyphs_->SetScaleModeToDataScalingOff();
-    glyph_mapper_->SetLookupTable(lut_);
+    glyph_mapper_->SetLookupTable(glyph_lut_);
 
     glyph_points_->SetDataTypeToDouble();
     glyph_point_set_->SetPoints(glyph_points_);
@@ -1156,10 +1156,10 @@ PickResult Viewer::handle_ctrl_click(int *click_pos) {
 }
 
 //-----------------------------------------------------------------------------
-void Viewer::set_lut(vtkSmartPointer<vtkLookupTable> lut) {
-  lut_ = lut;
+void Viewer::set_glyph_lut(vtkSmartPointer<vtkLookupTable> lut) {
+  glyph_lut_ = lut;
   if (!arrows_visible_ && !showing_feature_map()) {
-    glyph_mapper_->SetLookupTable(lut_);
+    glyph_mapper_->SetLookupTable(glyph_lut_);
   }
 }
 

--- a/Studio/src/Visualization/Viewer.h
+++ b/Studio/src/Visualization/Viewer.h
@@ -92,7 +92,7 @@ class Viewer {
 
   void set_selected_point(int id);
 
-  void set_lut(vtkSmartPointer<vtkLookupTable> lut);
+  void set_glyph_lut(vtkSmartPointer<vtkLookupTable> lut);
 
   void set_loading_screen(vtkSmartPointer<vtkImageData> loading_screen);
 
@@ -207,7 +207,7 @@ class Viewer {
   std::vector<vtkSmartPointer<vtkPolyDataMapper>> compare_mappers_;
   std::vector<vtkSmartPointer<vtkActor>> compare_actors_;
 
-  vtkSmartPointer<vtkLookupTable> lut_;
+  vtkSmartPointer<vtkLookupTable> glyph_lut_;
   vtkSmartPointer<vtkLookupTable> surface_lut_;
 
   vtkSmartPointer<vtkArrowSource> arrow_source_;

--- a/Studio/src/Visualization/Visualizer.cpp
+++ b/Studio/src/Visualization/Visualizer.cpp
@@ -3,6 +3,7 @@
 #include <Shape.h>
 #include <Utils/StudioUtils.h>
 #include <Visualization/ColorMap.h>
+#include <Visualization/ParticleColors.h>
 #include <Visualization/Visualizer.h>
 #include <vtkAppendPolyData.h>
 #include <vtkLookupTable.h>
@@ -300,44 +301,41 @@ void Visualizer::update_lut() {
       }
     }
   } else {
-    auto lut = vtkSmartPointer<vtkLookupTable>::New();
-    lut->SetNumberOfTableValues(21);
+    if (preferences_.get_particle_colors() == ParticleColors::ParticleColorsType::Distinct) {
+      auto lut = vtkSmartPointer<vtkLookupTable>::New();
+      lut->SetNumberOfTableValues(21);
 
-    int v = 0;
-    // lut->SetTableValue(v++, 0, 1, 0);  // green
-    // lut->SetTableValue(v++, 1, 0, 0);  // red
-    // lut->SetTableValue(v++, 0, 0, 1);  // blue
-    // lut->SetTableValue(v++, 255 / 255.0, 72 / 255.0, 228 / 255.0);  // purple
-    // lut->SetTableValue(v++, 71 / 255.0, 207 / 255.0, 255 / 255.0);  // teal
+      int v = 0;
+      auto add_color = [&](int r, int g, int b) { lut->SetTableValue(v++, r / 255.0, g / 255.0, b / 255.0); };
 
-    auto add_color = [&](int r, int g, int b) { lut->SetTableValue(v++, r / 255.0, g / 255.0, b / 255.0); };
+      add_color(230, 25, 75);
+      add_color(60, 180, 75);
+      add_color(255, 225, 25);
+      add_color(0, 130, 200);
+      add_color(245, 130, 48);
+      add_color(145, 30, 180);
+      add_color(70, 240, 240);
+      add_color(240, 50, 230);
+      add_color(210, 245, 60);
+      add_color(250, 190, 212);
+      add_color(0, 128, 128);
+      add_color(220, 190, 255);
+      add_color(170, 110, 40);
+      add_color(255, 250, 200);
+      add_color(128, 0, 0);
+      add_color(170, 255, 195);
+      add_color(128, 128, 0);
+      add_color(255, 215, 180);
+      add_color(0, 0, 128);
+      add_color(128, 128, 128);
+      add_color(255, 255, 255);
 
-    add_color(230, 25, 75);
-    add_color(60, 180, 75);
-    add_color(255, 225, 25);
-    add_color(0, 130, 200);
-    add_color(245, 130, 48);
-    add_color(145, 30, 180);
-    add_color(70, 240, 240);
-    add_color(240, 50, 230);
-    add_color(210, 245, 60);
-    add_color(250, 190, 212);
-    add_color(0, 128, 128);
-    add_color(220, 190, 255);
-    add_color(170, 110, 40);
-    add_color(255, 250, 200);
-    add_color(128, 0, 0);
-    add_color(170, 255, 195);
-    add_color(128, 128, 0);
-    add_color(255, 215, 180);
-    add_color(0, 0, 128);
-    add_color(128, 128, 128);
-    add_color(255, 255, 255);
-
-    // normal particle coloring mode
-    glyph_lut_->ForceBuild();
-    for (int i = 0; i < num_points; i++) {
-      glyph_lut_->SetTableValue(i, lut->GetTableValue(i % lut->GetNumberOfTableValues()));
+      // normal particle coloring mode
+      for (int i = 0; i < num_points; i++) {
+        glyph_lut_->SetTableValue(i, lut->GetTableValue(i % lut->GetNumberOfTableValues()));
+      }
+    } else {
+      glyph_lut_->ForceBuild();
     }
   }
 

--- a/Studio/src/Visualization/Visualizer.cpp
+++ b/Studio/src/Visualization/Visualizer.cpp
@@ -301,23 +301,38 @@ void Visualizer::update_lut() {
     }
   } else {
     auto lut = vtkSmartPointer<vtkLookupTable>::New();
-    lut->SetNumberOfTableValues(12);
+    lut->SetNumberOfTableValues(21);
 
     int v = 0;
-    lut->SetTableValue(v++, 0, 1, 0);  // green
-    lut->SetTableValue(v++, 1, 0, 0);  // red
-    lut->SetTableValue(v++, 0, 0, 1);  // blue
+    // lut->SetTableValue(v++, 0, 1, 0);  // green
+    // lut->SetTableValue(v++, 1, 0, 0);  // red
+    // lut->SetTableValue(v++, 0, 0, 1);  // blue
+    // lut->SetTableValue(v++, 255 / 255.0, 72 / 255.0, 228 / 255.0);  // purple
+    // lut->SetTableValue(v++, 71 / 255.0, 207 / 255.0, 255 / 255.0);  // teal
 
-    lut->SetTableValue(v++, 255 / 255.0, 72 / 255.0, 228 / 255.0);  // purple
-    lut->SetTableValue(v++, 71 / 255.0, 207 / 255.0, 255 / 255.0);  // teal
+    auto add_color = [&](int r, int g, int b) { lut->SetTableValue(v++, r / 255.0, g / 255.0, b / 255.0); };
 
-    lut->SetTableValue(v++, 58 / 255.0, 130 / 255.0, 161 / 255.0);
-    lut->SetTableValue(v++, 239 / 255.0, 201 / 255.0, 112 / 255.0);
-    lut->SetTableValue(v++, 106 / 255.0, 80 / 255.0, 121 / 255.0);
-    lut->SetTableValue(v++, 170 / 255.0, 213 / 255.0, 116 / 255.0);
-    lut->SetTableValue(v++, 187 / 255.0, 80 / 255.0, 57 / 255.0);
-    lut->SetTableValue(v++, 242 / 255.0, 163 / 255.0, 100 / 255.0);
-    lut->SetTableValue(v++, 159 / 255.0, 219 / 255.0, 208 / 255.0);
+    add_color(230, 25, 75);
+    add_color(60, 180, 75);
+    add_color(255, 225, 25);
+    add_color(0, 130, 200);
+    add_color(245, 130, 48);
+    add_color(145, 30, 180);
+    add_color(70, 240, 240);
+    add_color(240, 50, 230);
+    add_color(210, 245, 60);
+    add_color(250, 190, 212);
+    add_color(0, 128, 128);
+    add_color(220, 190, 255);
+    add_color(170, 110, 40);
+    add_color(255, 250, 200);
+    add_color(128, 0, 0);
+    add_color(170, 255, 195);
+    add_color(128, 128, 0);
+    add_color(255, 215, 180);
+    add_color(0, 0, 128);
+    add_color(128, 128, 128);
+    add_color(255, 255, 255);
 
     // normal particle coloring mode
     glyph_lut_->ForceBuild();

--- a/Studio/src/Visualization/Visualizer.cpp
+++ b/Studio/src/Visualization/Visualizer.cpp
@@ -489,8 +489,22 @@ void Visualizer::set_opacities(std::vector<float> opacities) {
   opacities_ = opacities;
   if (lightbox_) {
     Q_FOREACH (ViewerHandle viewer, lightbox_->get_viewers()) { viewer->update_opacities(); }
-    lightbox_->redraw();
   }
+  lightbox_->redraw();
+}
+
+//-----------------------------------------------------------------------------
+void Visualizer::set_domain_particle_visibilities(std::vector<bool> visibilities) {
+  domain_particle_visibilities_ = visibilities;
+  if (lightbox_) {
+    Q_FOREACH (ViewerHandle viewer, lightbox_->get_viewers()) { viewer->update_points(); }
+  }
+  lightbox_->redraw();
+}
+
+//-----------------------------------------------------------------------------
+std::vector<bool> Visualizer::get_domain_particle_visibilities() {
+  return domain_particle_visibilities_;
 }
 
 //-----------------------------------------------------------------------------
@@ -586,6 +600,8 @@ QSize Visualizer::get_render_size() {
   int* size = render_window->GetSize();
   return QSize(size[0], size[1]);
 }
+
+
 //-----------------------------------------------------------------------------
 
 }  // namespace shapeworks

--- a/Studio/src/Visualization/Visualizer.cpp
+++ b/Studio/src/Visualization/Visualizer.cpp
@@ -321,10 +321,8 @@ void Visualizer::update_lut() {
 
     // normal particle coloring mode
     glyph_lut_->ForceBuild();
-    SW_TRACE(num_points);
     for (int i = 0; i < num_points; i++) {
       glyph_lut_->SetTableValue(i, lut->GetTableValue(i % lut->GetNumberOfTableValues()));
-      // glyph_lut_->SetTableValue(i, i % 2 == 0 ? 1.0 : 0, 1.0, 0);
     }
   }
 

--- a/Studio/src/Visualization/Visualizer.h
+++ b/Studio/src/Visualization/Visualizer.h
@@ -126,6 +126,12 @@ class Visualizer : public QObject {
   //! Get domain opacities
   std::vector<float> get_opacities();
 
+  //! Set the per-domain particle visibilities
+  void set_domain_particle_visibilities(std::vector<bool> visibilities);
+
+  //! Get the per-domain particle visibilities
+  std::vector<bool> get_domain_particle_visibilities();
+
   //! Get the current glyph size
   double get_current_glyph_size();
 
@@ -182,6 +188,7 @@ class Visualizer : public QObject {
   bool feature_range_valid_ = false;
   bool feature_range_uniform_ = true;
 
+  std::vector<bool> domain_particle_visibilities_;
   std::vector<float> opacities_;
 
   double current_glyph_size_{0};


### PR DESCRIPTION
Resolves:

* #1773 
* #1930 

Particle display can now be controlled per-domain, similar to the surface opacity.

<img width="517" alt="image" src="https://user-images.githubusercontent.com/1693349/201760124-42d288d6-9854-4e77-91b1-cc56c6fbb6e5.png">

Additionally, a new coloring method solves #1930.  The old mode is also provided as a preference:

<img width="473" alt="image" src="https://user-images.githubusercontent.com/1693349/201760794-253d5885-ab0f-462a-a576-ad4bda51eda5.png">

Original:

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/1693349/201760882-a749d9c1-4881-4d15-8ac4-3dff5ac4e4e8.png">

Distinct:

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/1693349/201760855-93998377-83fc-4020-ae9f-7b069056e3af.png">
