### PR TITLE
1775 procrustes

### DIFF
--- a/Libs/Analyze/Particles.cpp
+++ b/Libs/Analyze/Particles.cpp
@@ -1,4 +1,5 @@
 #include <Analyze/Particles.h>
+#include <Logging.h>
 #include <vtkTransform.h>
 
 #include <cassert>
@@ -105,9 +106,7 @@ void Particles::set_world_particles(int domain, Eigen::VectorXd particles) {
 Eigen::VectorXd Particles::get_combined_local_particles() const { return combine(local_particles_); }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd Particles::get_combined_global_particles() const {
-  return combine(transformed_global_particles_);
-}
+Eigen::VectorXd Particles::get_combined_global_particles() const { return combine(transformed_global_particles_); }
 
 //---------------------------------------------------------------------------
 void Particles::set_combined_global_particles(const Eigen::VectorXd& particles) {
@@ -198,14 +197,14 @@ void Particles::transform_global_particles() {
         eigen[i + 1] = new_point[1];
         eigen[i + 2] = new_point[2];
 
-        if (d < procrustes_transforms_.size() && procrustes_transforms_[d]) {
+        if (alignment_type_ < procrustes_transforms_.size() && procrustes_transforms_[alignment_type_]) {
           pt[0] = eigen[i];
           pt[1] = eigen[i + 1];
           pt[2] = eigen[i + 2];
-          double* new_point = procrustes_transforms_[d]->TransformPoint(pt);
-          eigen[i] = new_point[0];
-          eigen[i + 1] = new_point[1];
-          eigen[i + 2] = new_point[2];
+          double* new_point2 = procrustes_transforms_[alignment_type_]->TransformPoint(pt);
+          eigen[i] = new_point2[0];
+          eigen[i + 1] = new_point2[1];
+          eigen[i + 2] = new_point2[2];
         }
       }
 
@@ -223,5 +222,7 @@ void Particles::save_particles_file(std::string filename, const Eigen::VectorXd&
   }
   out.close();
 }
+
+void Particles::set_alignment_type(int alignment) { alignment_type_ = alignment; }
 
 }  // namespace shapeworks

--- a/Libs/Analyze/Particles.h
+++ b/Libs/Analyze/Particles.h
@@ -48,6 +48,7 @@ class Particles {
 
   void set_transform(vtkSmartPointer<vtkTransform> transform);
   void set_procrustes_transforms(std::vector<vtkSmartPointer<vtkTransform>> transforms);
+  void set_alignment_type(int alignment);
 
   Eigen::VectorXd get_difference_vectors(const Particles& other);
 
@@ -68,5 +69,7 @@ class Particles {
 
   vtkSmartPointer<vtkTransform> transform_;
   std::vector<vtkSmartPointer<vtkTransform>> procrustes_transforms_;
+  int alignment_type_;
+
 };
 }  // namespace shapeworks

--- a/Libs/Analyze/Shape.cpp
+++ b/Libs/Analyze/Shape.cpp
@@ -698,6 +698,11 @@ void Shape::set_particle_transform(vtkSmartPointer<vtkTransform> transform) {
 }
 
 //---------------------------------------------------------------------------
+void Shape::set_alignment_type(int alignment) {
+  particles_.set_alignment_type(alignment);
+}
+
+//---------------------------------------------------------------------------
 vtkSmartPointer<vtkTransform> Shape::get_reconstruction_transform(int domain) {
   if (domain < reconstruction_transforms_.size()) {
     return reconstruction_transforms_[domain];

--- a/Libs/Analyze/Shape.h
+++ b/Libs/Analyze/Shape.h
@@ -90,7 +90,11 @@ class Shape {
   void set_particles(Particles particles);
   Particles get_particles();
 
+  //! Set the particle transform (alignment)
   void set_particle_transform(vtkSmartPointer<vtkTransform> transform);
+
+  //! Set the alignment type
+  void set_alignment_type(int alignment);
 
   /// Get the global correspondence points
   Eigen::VectorXd get_global_correspondence_points();
@@ -205,5 +209,6 @@ class Shape {
   std::string image_volume_filename_;
 
   std::vector<Constraints> constraints_;  // one set for each domain
+  int alignment_type_;
 };
 }  // namespace shapeworks

--- a/Libs/Common/Logging.h
+++ b/Libs/Common/Logging.h
@@ -49,7 +49,7 @@ namespace shapeworks {
  * \code
  * int mode = 10;
  * double eigen_value = 42.3;
- * SW_LOG("eigen value [{}]: {}", mode, eigen_value);
+ * SW_LOG("eigen value [{}]: {:.2f}", mode, eigen_value);
  * \endcode
  *
  * Output:

--- a/Libs/Project/ExcelProjectReader.cpp
+++ b/Libs/Project/ExcelProjectReader.cpp
@@ -73,7 +73,7 @@ class ExcelProjectReader::Container {
         domain = header.substr(prefix.length());
       }
       if (header == "value") {
-        domain = "1"; // default
+        domain = ""; // default
       }
       for (int i = ws.lowest_row(); i < ws.highest_row(); i++) {
         std::string key = rows[i][0].to_string();

--- a/Libs/Project/ExcelProjectWriter.cpp
+++ b/Libs/Project/ExcelProjectWriter.cpp
@@ -94,7 +94,7 @@ static void assign_transforms(xlnt::worksheet& ws, int subject_id, std::string p
   if (transforms.empty()) {
     return;
   }
-  if (transforms.size() != domains.size() && transforms.size() != domains.size() + 1) {
+  if (transforms.size() != domains.size()) {
     throw std::runtime_error(prefix + " filenames and number of domains mismatch");
   }
   for (int i = 0; i < domains.size(); i++) {
@@ -108,6 +108,10 @@ static void assign_transforms(xlnt::worksheet& ws, int subject_id, std::string p
 static void store_subjects(Project& project, xlnt::workbook& wb) {
   auto subjects = project.get_subjects();
   auto domains = project.get_domain_names();
+  auto domains_plus_global = project.get_domain_names();
+  if (domains.size() > 1) {
+    domains_plus_global.push_back("global");
+  }
 
   xlnt::worksheet ws = wb.sheet_by_index(0);
   ws.title("data");
@@ -129,7 +133,7 @@ static void store_subjects(Project& project, xlnt::workbook& wb) {
     assign_keys(ws, i, groomed_prefixes, subject->get_groomed_filenames(), domains);
     assign_keys(ws, i, {"local_particles"}, subject->get_local_particle_filenames(), domains);
     assign_keys(ws, i, {"world_particles"}, subject->get_world_particle_filenames(), domains);
-    assign_transforms(ws, i, {"alignment"}, subject->get_groomed_transforms(), domains);
+    assign_transforms(ws, i, {"alignment"}, subject->get_groomed_transforms(), domains_plus_global);
     assign_transforms(ws, i, {"procrustes"}, subject->get_procrustes_transforms(), domains);
 
     // write out extra values

--- a/Libs/Project/ExcelProjectWriter.h
+++ b/Libs/Project/ExcelProjectWriter.h
@@ -10,9 +10,8 @@ namespace shapeworks {
  */
 class ExcelProjectWriter {
  public:
-  static bool write_project(Project& project, std::string filename);
+  static bool write_project(Project& project, const std::string& filename);
 
-private:
-
+ private:
 };
 }  // namespace shapeworks

--- a/Libs/Project/JsonProjectWriter.cpp
+++ b/Libs/Project/JsonProjectWriter.cpp
@@ -11,7 +11,6 @@ namespace shapeworks {
 //---------------------------------------------------------------------------
 static json create_data_object(Project& project) {
   auto subjects = project.get_subjects();
-  auto domains = project.get_domain_names();
 
   std::vector<json> list;
   for (int i = 0; i < subjects.size(); i++) {

--- a/Libs/Project/Project.cpp
+++ b/Libs/Project/Project.cpp
@@ -336,6 +336,7 @@ Parameters Project::get_parameters(const std::string& name, std::string domain_n
 std::map<std::string, Parameters> Project::get_parameter_map(const std::string& name) {
   std::map<std::string, Parameters> map;
   auto domains = get_domain_names();
+  domains.insert(domains.begin(), 1, ""); // add global parameters
   for (int i = 0; i < domains.size(); i++) {
     map[domains[i]] = get_parameters(name, domains[i]);
   }

--- a/Libs/Project/ProjectReader.cpp
+++ b/Libs/Project/ProjectReader.cpp
@@ -60,7 +60,7 @@ void ProjectReader::load_subjects(StringMapList list) {
 
     std::string name;
     if (contains(item, "name")) {
-      name = item["item"];
+      name = item["name"];
     }
     if (name == "") {
       if (subject->get_original_filenames().size() != 0) {

--- a/Libs/Project/ProjectUtils.cpp
+++ b/Libs/Project/ProjectUtils.cpp
@@ -11,7 +11,7 @@ using StringMap = ProjectUtils::StringMap;
 
 using namespace project::prefixes;
 
-static StringList input_prefixes{SEGMENTATION_PREFIX, SHAPE_PREFIX, MESH_PREFIX, CONTOUR_PREFIX};
+static const StringList input_prefixes{SEGMENTATION_PREFIX, SHAPE_PREFIX, MESH_PREFIX, CONTOUR_PREFIX};
 
 //---------------------------------------------------------------------------
 vtkSmartPointer<vtkTransform> shapeworks::ProjectUtils::convert_transform(std::vector<double> list) {
@@ -275,11 +275,11 @@ static void assign_keys(StringMap& j, std::vector<std::string> prefixes, std::ve
   }
   assert(!domains.empty());
   if (domains.empty()) {
-    throw std::runtime_error("Empty domains");
+    throw std::invalid_argument("Empty domains");
   }
   auto prefix = prefixes[0];
   if (filenames.size() != domains.size()) {
-    throw std::runtime_error(prefix + " filenames and number of domains mismatch (" +
+    throw std::invalid_argument(prefix + " filenames and number of domains mismatch (" +
                              std::to_string(filenames.size()) + " vs " + std::to_string(domains.size()) + ")");
   }
   for (int i = 0; i < domains.size(); i++) {
@@ -299,7 +299,7 @@ static void assign_transforms(StringMap& j, std::string prefix, std::vector<std:
     return;
   }
   if (transforms.size() != domains.size() && transforms.size() != domains.size() + 1) {
-    throw std::runtime_error(prefix + " filenames and number of domains mismatch (" +
+    throw std::invalid_argument(prefix + " filenames and number of domains mismatch (" +
                              std::to_string(transforms.size()) + " vs " + std::to_string(domains.size()) + ")");
   }
   for (int i = 0; i < transforms.size(); i++) {

--- a/Studio/src/Analysis/AnalysisTool.cpp
+++ b/Studio/src/Analysis/AnalysisTool.cpp
@@ -1219,7 +1219,7 @@ void AnalysisTool::handle_group_pvalues_complete() {
 
 //---------------------------------------------------------------------------
 void AnalysisTool::handle_alignment_changed(int new_alignment) {
-  new_alignment -= 2;
+  new_alignment -= 2;  // minus two for local and global that come first (local == -1, global == -2)
   if (new_alignment == current_alignment_) {
     return;
   }
@@ -1237,6 +1237,7 @@ void AnalysisTool::handle_alignment_changed(int new_alignment) {
     }
 
     shape->set_particle_transform(transform);
+    shape->set_alignment_type(new_alignment);
   }
 
   evals_ready_ = false;
@@ -1349,12 +1350,14 @@ void AnalysisTool::compute_reconstructed_domain_transforms() {
     reconstruction_transforms_.resize(session_->get_domains_per_shape());
     for (int domain = 0; domain < session_->get_domains_per_shape(); domain++) {
       int num_shapes = shapes.size();
+      // create a new transform
       auto transform = vtkSmartPointer<vtkTransform>::New();
+      // get a pointer to the transform's data
       double* values = transform->GetMatrix()->GetData();
 
       for (int i = 0; i < shapes.size(); i++) {
-        vtkSmartPointer<vtkTransform> base = shapes[i]->get_alignment(0);
-        vtkSmartPointer<vtkTransform> offset = shapes[i]->get_alignment(domain);
+        auto base = shapes[i]->get_alignment(0);
+        auto offset = shapes[i]->get_alignment(domain);
 
         for (int j = 0; j < 16; j++) {
           values[j] += (base->GetMatrix()->GetData()[j] - offset->GetMatrix()->GetData()[j]) / num_shapes;


### PR DESCRIPTION
Resolves:

* #1775 

The problem was that the procrustes transforms were being applied for each domain independently and always, regardless of which alignment domain was set.  Only the procrustes transform of the alignment domain should be used, or none for global/local.  If the user has performed no alignment in grooming, then local and global will be the same.  That is, until we provide a global procrustes.