### PR TITLE
Hopefully fix #1947

### DIFF
--- a/Libs/Optimize/ContourDomain.cpp
+++ b/Libs/Optimize/ContourDomain.cpp
@@ -236,6 +236,9 @@ void ContourDomain::ComputeGeodesics(vtkSmartPointer<vtkPolyData> poly_data) {
 
     auto out = vtkSmartPointer<vtkDoubleArray>::New();
     dijkstra->GetCumulativeWeights(out);
+    out->SetArrayFreeFunction([](void *ptr) {
+      delete[] reinterpret_cast<uint8_t *>(ptr);
+    });
 
     for (int j = 0; j < N; j++) {
       geodesics_(i, j) = out->GetValue(j);


### PR DESCRIPTION
* #1947 

Not certain this fixes #1947, but plausibly does so.

Works around a bug in VTK where the array allocated in vtkDijkstraGraphGeodesicPath::GetCumulativeWeights using `new` is incorrectly cleaned up using `free` (undefined behavior).

Valgrind reports this as:

Mismatched free() / delete / delete []