### PR TITLE
Fix 1998 crash

### DIFF
--- a/Libs/Analyze/MeshGenerator.cpp
+++ b/Libs/Analyze/MeshGenerator.cpp
@@ -84,7 +84,7 @@ MeshHandle MeshGenerator::build_mesh_from_points(const Eigen::VectorXd& shape, i
     if (!poly_data) {
       std::string message = "Unable to warp mesh";
       SW_ERROR(message);
-      auto poly_data = vtkSmartPointer<vtkPolyData>::New();
+      poly_data = vtkSmartPointer<vtkPolyData>::New();
       mesh->set_poly_data(poly_data);
       mesh->set_error_message(message);
       return mesh;
@@ -124,9 +124,9 @@ MeshHandle MeshGenerator::build_mesh_from_image(ImageType::Pointer image, float 
     mesh->set_poly_data(Mesh(marching->GetOutput()).clean().computeNormals().getVTKMesh());
 
   } catch (itk::ExceptionObject& excep) {
-    std::cerr << "Exception caught!" << std::endl;
-    std::cerr << excep << std::endl;
-    mesh->set_error_message(std::string("Exception: ") + excep.what());
+    auto message = std::string("Exception: ") + excep.what();
+    SW_ERROR(message);
+    mesh->set_error_message(message);
   }
   return mesh;
 }

--- a/Libs/Analyze/MeshGenerator.cpp
+++ b/Libs/Analyze/MeshGenerator.cpp
@@ -84,6 +84,8 @@ MeshHandle MeshGenerator::build_mesh_from_points(const Eigen::VectorXd& shape, i
     if (!poly_data) {
       std::string message = "Unable to warp mesh";
       SW_ERROR(message);
+      auto poly_data = vtkSmartPointer<vtkPolyData>::New();
+      mesh->set_poly_data(poly_data);
       mesh->set_error_message(message);
       return mesh;
     }

--- a/Libs/Mesh/MeshWarper.cpp
+++ b/Libs/Mesh/MeshWarper.cpp
@@ -45,7 +45,7 @@ vtkSmartPointer<vtkPolyData> MeshWarper::build_mesh(const Eigen::MatrixXd& parti
     double* p = poly_data->GetPoint(i);
     if (std::isnan(p[0]) || std::isnan(p[1]) || std::isnan(p[2])) {
       this->warp_available_ = false;  // failed
-      std::cerr << "Reconstruction Failed\n";
+      SW_ERROR("Reconstruction failed. NaN detected in mesh.");
       return nullptr;
     }
   }
@@ -438,7 +438,7 @@ bool MeshWarper::generate_warp() {
   Eigen::MatrixXd vertices = referenceMesh.points();
   this->faces_ = referenceMesh.faces();
 
-  // perform warp
+  // generate the warp
   if (!MeshWarper::generate_warp_matrix(vertices, this->faces_, this->vertices_, this->warp_)) {
     this->update_progress(1.0);
     this->warp_available_ = false;
@@ -473,7 +473,7 @@ bool MeshWarper::generate_warp_matrix(Eigen::MatrixXd TV, Eigen::MatrixXi TF, co
   // faster and looks OK
   const int k = 2;
   if (!igl::biharmonic_coordinates(TV, TF, S, k, W)) {
-    std::cerr << "igl:biharmonic_coordinates failed\n";
+    SW_ERROR("Mesh Warp Error: igl:biharmonic_coordinates failed");
     return false;
   }
   // Throw away interior tet-vertices, keep weights and indices of boundary


### PR DESCRIPTION
Fixes:

* #1998 

Return an empty mesh on warp mesh error instead of nullptr.

Improve error reporting of mesh warp errors.