### PR TITLE
Studio fixes

### DIFF
--- a/Libs/Common/Logging.h
+++ b/Libs/Common/Logging.h
@@ -187,4 +187,13 @@ class Logging {
 //! Close session macro
 #define SW_CLOSE_LOG() shapeworks::Logging::Instance().close_log();
 
+//! Log once macro, will only log the message once
+#define SW_LOG_ONCE(message, ...) \
+{ \
+    static bool logged = false; \
+    if (!logged) { \
+      SW_LOG(message, ##__VA_ARGS__); \
+      logged = true; \
+    } \
+}
 }  // namespace shapeworks

--- a/Libs/Optimize/Constraints.cpp
+++ b/Libs/Optimize/Constraints.cpp
@@ -777,7 +777,6 @@ bool Constraints::hasConstraints() {
     return true;
   }
 
-  SW_LOG("no constraints");
   return false;
 }
 

--- a/Libs/Project/ProjectUtils.cpp
+++ b/Libs/Project/ProjectUtils.cpp
@@ -140,7 +140,7 @@ StringList ProjectUtils::get_values(StringList prefixes, StringList domain_names
     for (auto& [key, value] : key_map) {
       for (const auto& prefix : prefixes) {
         if (key == prefix + domain) {
-          values.push_back(value);
+          values.push_back(StringUtils::replace_string(value, "\\", "/"));
         }
       }
     }

--- a/Studio/Analysis/AnalysisTool.cpp
+++ b/Studio/Analysis/AnalysisTool.cpp
@@ -920,17 +920,19 @@ void AnalysisTool::enable_actions(bool newly_enabled) {
     update_domain_alignment_box();
   }
 
-  auto domain_types = session_->get_groomed_domain_types();
-  bool image_domain = domain_types.size() > 0 && domain_types[0] == DomainType::Image;
-  ui_->distance_transfom_radio_button->setEnabled(session_->particles_present() && session_->get_groomed_present() &&
-                                                  image_domain);
+  if (session_->particles_present()) {
+    auto domain_types = session_->get_groomed_domain_types();
+    bool image_domain = domain_types.size() > 0 && domain_types[0] == DomainType::Image;
+    ui_->distance_transfom_radio_button->setEnabled(session_->particles_present() && session_->get_groomed_present() &&
+                                                    image_domain);
 
-  ui_->mesh_warping_radio_button->setEnabled(session_->particles_present() && session_->get_groomed_present());
+    ui_->mesh_warping_radio_button->setEnabled(session_->particles_present() && session_->get_groomed_present());
 
-  if (!ui_->mesh_warping_radio_button->isEnabled()) {
-    ui_->legacy_radio_button->setChecked(true);
+    if (!ui_->mesh_warping_radio_button->isEnabled()) {
+      ui_->legacy_radio_button->setChecked(true);
+    }
+    reconstruction_method_changed();
   }
-  reconstruction_method_changed();
 
   update_group_boxes();
   ui_->sampleSpinBox->setMaximum(session_->get_num_shapes() - 1);

--- a/Studio/Analysis/AnalysisTool.ui
+++ b/Studio/Analysis/AnalysisTool.ui
@@ -535,7 +535,7 @@ QWidget#particles_panel {
             <item row="3" column="0" colspan="2">
              <widget class="QTabWidget" name="tabWidget">
               <property name="currentIndex">
-               <number>2</number>
+               <number>0</number>
               </property>
               <widget class="QWidget" name="mean_tab">
                <attribute name="title">
@@ -603,7 +603,7 @@ QWidget#particles_panel {
                     </widget>
                    </item>
                    <item row="2" column="1">
-                    <widget class="QSlider" name="group_slider">
+                    <widget class="CustomSlider" name="group_slider">
                      <property name="toolTip">
                       <string>Group slider</string>
                      </property>
@@ -1059,15 +1059,9 @@ QWidget#particles_panel {
                       </widget>
                      </item>
                      <item row="0" column="1">
-                      <widget class="QSlider" name="pcaSlider">
+                      <widget class="CustomSlider" name="pcaSlider">
                        <property name="enabled">
                         <bool>false</bool>
-                       </property>
-                       <property name="minimumSize">
-                        <size>
-                         <width>100</width>
-                         <height>0</height>
-                        </size>
                        </property>
                        <property name="toolTip">
                         <string>Standard deviation slider</string>
@@ -2189,6 +2183,11 @@ Reference Domain</string>
    <extends>QWidget</extends>
    <header>jkqtplotter/jkqtplotter.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>CustomSlider</class>
+   <extends>QSlider</extends>
+   <header>Interface/CustomSlider.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/Studio/CMakeLists.txt
+++ b/Studio/CMakeLists.txt
@@ -169,6 +169,7 @@ SET(STUDIO_UTILS_MOC_HDRS
 
 SET(STUDIO_INTERFACE_SRCS
   Interface/CompareWidget.cpp
+  Interface/CustomSlider.cpp
   Interface/ExportImageDialog.cpp
   Interface/KeyboardShortcuts.cpp
   Interface/LogWindow.cpp
@@ -182,6 +183,7 @@ SET(STUDIO_INTERFACE_SRCS
   )
 SET(STUDIO_INTERFACE_MOC_HDRS
   Interface/CompareWidget.h
+  Interface/CustomSlider.h
   Interface/ExportImageDialog.h
   Interface/KeyboardShortcuts.h
   Interface/LogWindow.h

--- a/Studio/Data/DataTool.cpp
+++ b/Studio/Data/DataTool.cpp
@@ -109,7 +109,7 @@ void DataTool::set_session(QSharedPointer<Session> session) {
   connect(session.data(), &Session::ffc_changed, this, &DataTool::update_ffc_table);
   landmark_table_model_->set_session(session);
 
-  connect(ui_->ffc_brush_size_, &QSlider::valueChanged, session.data(), &Session::set_ffc_paint_size);
+  connect(ui_->ffc_brush_size_, &CustomSlider::valueChanged, session.data(), &Session::set_ffc_paint_size);
   connect(ui_->ffc_included_mode_, &QRadioButton::toggled, session.data(), &Session::set_ffc_paint_mode_inclusive);
   connect(ui_->ffc_active_, &QCheckBox::toggled, session.data(), &Session::set_ffc_paint_active);
 

--- a/Studio/Data/DataTool.ui
+++ b/Studio/Data/DataTool.ui
@@ -381,8 +381,8 @@ QWidget#specificity_panel {
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>470</width>
-              <height>340</height>
+              <width>464</width>
+              <height>330</height>
              </rect>
             </property>
             <layout class="QGridLayout" name="gridLayout_2">
@@ -848,7 +848,7 @@ QWidget#specificity_panel {
                 </widget>
                </item>
                <item row="1" column="1" colspan="2">
-                <widget class="QSlider" name="ffc_brush_size_">
+                <widget class="CustomSlider" name="ffc_brush_size_">
                  <property name="minimum">
                   <number>5</number>
                  </property>
@@ -1053,7 +1053,14 @@ QWidget#specificity_panel {
             </size>
            </property>
            <property name="html">
-            <string></string>
+            <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.AppleSystemUIFont'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
          </item>
@@ -1078,6 +1085,13 @@ QWidget#specificity_panel {
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CustomSlider</class>
+   <extends>QSlider</extends>
+   <header>Interface/CustomSlider.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../Resources/ShapeWorksStudio.qrc"/>
  </resources>

--- a/Studio/Data/PreferencesWindow.cpp
+++ b/Studio/Data/PreferencesWindow.cpp
@@ -46,7 +46,7 @@ PreferencesWindow::PreferencesWindow(QWidget* parent, Preferences& prefs) : pref
           &PreferencesWindow::save_to_preferences);
   connect(ui_->orientation_marker_corner, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &PreferencesWindow::save_to_preferences);
-  connect(ui_->geodesic_cache_multiplier, &QSlider::valueChanged, this, &PreferencesWindow::save_to_preferences);
+  connect(ui_->geodesic_cache_multiplier, &CustomSlider::valueChanged, this, &PreferencesWindow::save_to_preferences);
   connect(ui_->color_map, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &PreferencesWindow::save_to_preferences);
   connect(ui_->particle_colors, qOverload<int>(&QComboBox::currentIndexChanged), this,

--- a/Studio/Data/PreferencesWindow.ui
+++ b/Studio/Data/PreferencesWindow.ui
@@ -107,7 +107,7 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QSlider" name="geodesic_cache_multiplier">
+          <widget class="CustomSlider" name="geodesic_cache_multiplier">
            <property name="minimum">
             <number>0</number>
            </property>
@@ -200,7 +200,7 @@
          </widget>
         </item>
         <item row="1" column="2">
-         <widget class="QSlider" name="mesh_cache_memory">
+         <widget class="CustomSlider" name="mesh_cache_memory">
           <property name="maximum">
            <number>100</number>
           </property>
@@ -240,7 +240,7 @@
          </widget>
         </item>
         <item row="4" column="2">
-         <widget class="QSlider" name="num_threads">
+         <widget class="CustomSlider" name="num_threads">
           <property name="minimum">
            <number>1</number>
           </property>
@@ -587,6 +587,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CustomSlider</class>
+   <extends>QSlider</extends>
+   <header>Interface/CustomSlider.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>pca_range</tabstop>
   <tabstop>pca_steps</tabstop>

--- a/Studio/Data/Telemetry.cpp
+++ b/Studio/Data/Telemetry.cpp
@@ -43,12 +43,12 @@ void Telemetry::record_event(const QString& name, const QVariantMap& params) {
   QString api_secret{GA_API_SECRET};
 
   if (measurement_id.isEmpty() || api_secret.isEmpty()) {
-    SW_LOG("Telemetry disabled, no measurement id or api secret");
+    SW_LOG_ONCE("Telemetry disabled, no measurement id or api secret");
     return;
   }
 
   if (!prefs_.get_telemetry_enabled()) {
-    SW_LOG("Telemetry disabled by preferences");
+    SW_LOG_ONCE("Telemetry disabled by preferences");
     return;
   }
 

--- a/Studio/Groom/GroomTool.cpp
+++ b/Studio/Groom/GroomTool.cpp
@@ -73,13 +73,13 @@ GroomTool::GroomTool(Preferences& prefs, Telemetry& telemetry) : preferences_(pr
       "Set the adaptivity of remeshing, higher will allocate more triangles around areas of high curvature.");
 
   // connect percent controls
-  connect(ui_->remesh_percent_slider, &QSlider::valueChanged, this,
+  connect(ui_->remesh_percent_slider, &CustomSlider::valueChanged, this,
           [this](int value) { ui_->remesh_percent_spinbox->setValue(value); });
   connect(ui_->remesh_percent_spinbox, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           [=](double value) { ui_->remesh_percent_slider->setValue(static_cast<int>(value)); });
 
   // connect gradation controls
-  connect(ui_->remesh_gradation_slider, &QSlider::valueChanged, this,
+  connect(ui_->remesh_gradation_slider, &CustomSlider::valueChanged, this,
           [=](int value) { ui_->remesh_gradation_spinbox->setValue(value / 50.0); });
   connect(ui_->remesh_gradation_spinbox, qOverload<double>(&QDoubleSpinBox::valueChanged), this,
           [=](double value) { ui_->remesh_gradation_slider->setValue(static_cast<int>(value * 50.0)); });

--- a/Studio/Groom/GroomTool.ui
+++ b/Studio/Groom/GroomTool.ui
@@ -1607,7 +1607,7 @@ QWidget#domain_panel {
                    </widget>
                   </item>
                   <item row="3" column="1">
-                   <widget class="QSlider" name="remesh_gradation_slider">
+                   <widget class="CustomSlider" name="remesh_gradation_slider">
                     <property name="maximum">
                      <number>100</number>
                     </property>
@@ -1620,7 +1620,7 @@ QWidget#domain_panel {
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QSlider" name="remesh_percent_slider">
+                   <widget class="CustomSlider" name="remesh_percent_slider">
                     <property name="maximum">
                      <number>100</number>
                     </property>
@@ -2013,6 +2013,13 @@ QWidget#domain_panel {
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CustomSlider</class>
+   <extends>QSlider</extends>
+   <header>Interface/CustomSlider.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>mesh_fill_holes</tabstop>
   <tabstop>mesh_smooth</tabstop>

--- a/Studio/Interface/CompareWidget.cpp
+++ b/Studio/Interface/CompareWidget.cpp
@@ -12,7 +12,7 @@ CompareWidget::CompareWidget(QWidget *parent) : QWidget(parent), ui_(new Ui::Com
   connect(ui_->original, &QCheckBox::toggled, this, &CompareWidget::settings_changed);
   connect(ui_->groomed, &QCheckBox::toggled, this, &CompareWidget::settings_changed);
   connect(ui_->reconstructed, &QCheckBox::toggled, this, &CompareWidget::settings_changed);
-  connect(ui_->opacity, &QSlider::valueChanged, this, &CompareWidget::settings_changed);
+  connect(ui_->opacity, &CustomSlider::valueChanged, this, &CompareWidget::settings_changed);
   connect(ui_->mean_shape, &QCheckBox::toggled, this, &CompareWidget::settings_changed);
 }
 

--- a/Studio/Interface/CompareWidget.ui
+++ b/Studio/Interface/CompareWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>470</width>
-    <height>159</height>
+    <height>172</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="8" column="1">
-    <widget class="QSlider" name="opacity">
+    <widget class="CustomSlider" name="opacity">
      <property name="maximum">
       <number>100</number>
      </property>
@@ -74,6 +74,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>CustomSlider</class>
+   <extends>QSlider</extends>
+   <header>Interface/CustomSlider.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/Studio/Interface/CustomSlider.cpp
+++ b/Studio/Interface/CustomSlider.cpp
@@ -14,17 +14,17 @@ CustomSlider::CustomSlider(QWidget* parent) : QSlider(parent) {
   this->setStyleSheet(
       "\
       QSlider::groove:horizontal {\
-        height: 8px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */ \
+        border: 1px solid #262626;\
+        height: 3px;\
         background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #B1B1B1, stop:1 #c4c4c4);\
-        margin: 2px 0;\
+        margin: 0 5px;\
       }\
       \
       QSlider::handle:horizontal {\
         background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);\
         border: 1px solid #5c5c5c;\
         width: 12px;\
-        height: 12px; \
-        margin: -2px 0; /* handle is placed by default on the contents rect of the groove. Expand outside the groove */ \
+        margin: -8px -6px;\
         border-radius: 3px;\
       }\
     ");

--- a/Studio/Interface/CustomSlider.cpp
+++ b/Studio/Interface/CustomSlider.cpp
@@ -1,0 +1,68 @@
+
+
+#include "CustomSlider.h"
+
+#include <QColor>
+#include <QSlider>
+#include <QStyleOptionComplex>
+#include <QStyleOptionSlider>
+#include <QStylePainter>
+
+#include "math.h"
+
+CustomSlider::CustomSlider(QWidget* parent) : QSlider(parent) {
+  this->setStyleSheet(
+      "\
+      QSlider::groove:horizontal {\
+        height: 8px; /* the groove expands to the size of the slider by default. by giving it a height, it has a fixed size */ \
+        background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #B1B1B1, stop:1 #c4c4c4);\
+        margin: 2px 0;\
+      }\
+      \
+      QSlider::handle:horizontal {\
+        background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);\
+        border: 1px solid #5c5c5c;\
+        width: 12px;\
+        height: 12px; \
+        margin: -2px 0; /* handle is placed by default on the contents rect of the groove. Expand outside the groove */ \
+        border-radius: 3px;\
+      }\
+    ");
+};
+
+void CustomSlider::paintEvent(QPaintEvent* ev) {
+  QStylePainter p(this);
+  QStyleOptionSlider opt;
+  initStyleOption(&opt);
+
+  QRect handle = style()->subControlRect(QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
+
+  // draw tick marks
+  // do this manually because they are very badly behaved with style sheets
+  int interval = tickInterval();
+  if (interval == 0) {
+    interval = pageStep();
+  }
+
+  if (tickPosition() != NoTicks) {
+    for (int i = minimum(); i <= maximum(); i += interval) {
+      int x =
+          std::round((double)((double)((double)(i - this->minimum()) / (double)(this->maximum() - this->minimum())) *
+                                  (double)(this->width() - handle.width()) +
+                              (double)(handle.width() / 2.0))) -
+          1;
+      int h = 4;
+      p.setPen(QColor("#a5a294"));
+      if (tickPosition() == TicksBothSides || tickPosition() == TicksAbove) {
+        int y = this->rect().top();
+        p.drawLine(x, y, x, y + h);
+      }
+      if (tickPosition() == TicksBothSides || tickPosition() == TicksBelow) {
+        int y = this->rect().bottom();
+        p.drawLine(x, y, x, y - h);
+      }
+    }
+  }
+
+  QSlider::paintEvent(ev);
+}

--- a/Studio/Interface/CustomSlider.cpp
+++ b/Studio/Interface/CustomSlider.cpp
@@ -13,6 +13,9 @@
 CustomSlider::CustomSlider(QWidget* parent) : QSlider(parent) {
   this->setStyleSheet(
       "\
+      QSlider {\
+        min-height: 24px\
+      }\
       QSlider::groove:horizontal {\
         border: 1px solid #262626;\
         height: 3px;\

--- a/Studio/Interface/CustomSlider.h
+++ b/Studio/Interface/CustomSlider.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <QSlider>
+
+// adapted from:
+// https://stackoverflow.com/questions/69890284/qslider-in-qt-misbehaves-in-new-macos-monterey-v12-0-1-any-workaround/69890285#69890285
+class CustomSlider : public QSlider {
+ public:
+  explicit CustomSlider(Qt::Orientation orientation, QWidget* parent = nullptr) : QSlider(orientation, parent){};
+  explicit CustomSlider(QWidget* parent = nullptr);
+
+ protected:
+  virtual void paintEvent(QPaintEvent* ev);
+};

--- a/Studio/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/Interface/ShapeWorksStudioApp.cpp
@@ -729,7 +729,7 @@ void ShapeWorksStudioApp::create_glyph_submenu() {
   layout->addWidget(glyph_size_label_, 0, 1, 1, 1);
   layout->addWidget(glyph_quality_label_, 1, 1, 1, 1);
 
-  glyph_size_slider_ = new QSlider(widget);
+  glyph_size_slider_ = new CustomSlider(widget);
   glyph_size_slider_->setOrientation(Qt::Horizontal);
   glyph_size_slider_->setMinimum(1);
   glyph_size_slider_->setMaximum(100);
@@ -742,7 +742,7 @@ void ShapeWorksStudioApp::create_glyph_submenu() {
 
   glyph_arrow_scale_ = new QCheckBox("Scale arrows");
 
-  glyph_quality_slider_ = new QSlider(widget);
+  glyph_quality_slider_ = new CustomSlider(widget);
   glyph_quality_slider_->setMinimum(1);
   glyph_quality_slider_->setMaximum(20);
   glyph_quality_slider_->setPageStep(3);
@@ -766,8 +766,8 @@ void ShapeWorksStudioApp::create_glyph_submenu() {
   glyph_quality_label_->setText(QString::number(preferences_.get_glyph_quality()));
   glyph_size_label_->setText(QString::number(preferences_.get_glyph_size()));
 
-  connect(glyph_size_slider_, &QSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed);
-  connect(glyph_quality_slider_, &QSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed);
+  connect(glyph_size_slider_, &CustomSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed);
+  connect(glyph_quality_slider_, &CustomSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed);
   connect(glyph_auto_size_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
   connect(glyph_arrow_scale_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
 
@@ -829,7 +829,7 @@ void ShapeWorksStudioApp::create_iso_submenu() {
     QLabel* size_label = new QLabel(text);
     layout->addWidget(size_label, row, 0, 1, 1);
 
-    QSlider* slider = new QSlider(widget);
+    CustomSlider* slider = new CustomSlider(widget);
     slider->setOrientation(Qt::Horizontal);
     slider->setMinimum(1);
     slider->setMaximum(100);
@@ -838,7 +838,7 @@ void ShapeWorksStudioApp::create_iso_submenu() {
     slider->setTickInterval(10);
     slider->setValue(100);
     slider->setMinimumWidth(200);
-    connect(slider, &QSlider::valueChanged, this, &ShapeWorksStudioApp::handle_opacity_changed);
+    connect(slider, &CustomSlider::valueChanged, this, &ShapeWorksStudioApp::handle_opacity_changed);
 
     layout->addWidget(slider, row, 1, 1, 1);
     widget->setLayout(layout);

--- a/Studio/Interface/ShapeWorksStudioApp.h
+++ b/Studio/Interface/ShapeWorksStudioApp.h
@@ -20,9 +20,9 @@
 #include <QMainWindow>
 #include <QPointer>
 #include <QProgressBar>
-#include <QSlider>
 #include <QSpinBox>
 #include <QTimer>
+#include <Interface/CustomSlider.h>
 
 // Forward Qt class declarations
 class Ui_ShapeWorksStudioApp;
@@ -239,8 +239,8 @@ class ShapeWorksStudioApp : public QMainWindow {
   QSharedPointer<WheelEventForwarder> wheel_event_forwarder_;
 
   // programmatic UI elements
-  QSlider* glyph_size_slider_;
-  QSlider* glyph_quality_slider_;
+  CustomSlider* glyph_size_slider_;
+  CustomSlider* glyph_quality_slider_;
   QLabel* glyph_size_label_;
   QLabel* glyph_quality_label_;
   QCheckBox* glyph_auto_size_;
@@ -250,7 +250,7 @@ class ShapeWorksStudioApp : public QMainWindow {
   QPointer<StatusBarWidget> status_bar_;
   QSharedPointer<shapeworks::SplashScreen> splash_screen_;
   QErrorMessage error_message_dialog_;
-  std::vector<QSlider*> iso_opacity_sliders_;
+  std::vector<CustomSlider*> iso_opacity_sliders_;
   std::vector<QCheckBox*> domain_particle_checkboxes_;
 
   QString current_message_;

--- a/Studio/Interface/ShapeWorksStudioApp.ui
+++ b/Studio/Interface/ShapeWorksStudioApp.ui
@@ -368,7 +368,7 @@ QToolBar QToolButton::checked {
            </widget>
           </item>
           <item>
-           <widget class="QSlider" name="zoom_slider">
+           <widget class="CustomSlider" name="zoom_slider">
             <property name="maximumSize">
              <size>
               <width>100</width>
@@ -1215,6 +1215,11 @@ QToolBar QToolButton::checked {
   </action>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>CustomSlider</class>
+   <extends>QSlider</extends>
+   <header>Interface/CustomSlider.h</header>
+  </customwidget>
   <customwidget>
    <class>QVTKOpenGLNativeWidget</class>
    <extends>QWidget</extends>

--- a/Studio/Interface/UpdateChecker.cpp
+++ b/Studio/Interface/UpdateChecker.cpp
@@ -57,8 +57,6 @@ void UpdateChecker::run_update_check() {
 void UpdateChecker::handleNetworkReply(QNetworkReply* reply) {
   std::string response = QString(reply->readAll()).toStdString();
 
-  response = "<junk/>";
-
   // get the json response
   try {
     auto j = json::parse(response);

--- a/Studio/Interface/UpdateChecker.cpp
+++ b/Studio/Interface/UpdateChecker.cpp
@@ -57,49 +57,56 @@ void UpdateChecker::run_update_check() {
 void UpdateChecker::handleNetworkReply(QNetworkReply* reply) {
   std::string response = QString(reply->readAll()).toStdString();
 
+  response = "<junk/>";
+
   // get the json response
-  auto j = json::parse(response);
+  try {
+    auto j = json::parse(response);
+    std::string platform = StudioUtils::get_platform_string().toStdString();
 
-  std::string platform = StudioUtils::get_platform_string().toStdString();
+    int major = j[platform]["major"].get<int>();
+    int minor = j[platform]["minor"].get<int>();
+    int patch = j[platform]["patch"].get<int>();
+    QString message = QString::fromStdString(j[platform]["message"].get<std::string>());
 
-  int major = j[platform]["major"].get<int>();
-  int minor = j[platform]["minor"].get<int>();
-  int patch = j[platform]["patch"].get<int>();
-  QString message = QString::fromStdString(j[platform]["message"].get<std::string>());
-
-  bool update_available = false;
-  if (major > SHAPEWORKS_MAJOR_VERSION) {
-    update_available = true;
-  } else if (major == SHAPEWORKS_MAJOR_VERSION && minor > SHAPEWORKS_MINOR_VERSION) {
-    update_available = true;
-  } else if (major == SHAPEWORKS_MAJOR_VERSION && minor == SHAPEWORKS_MINOR_VERSION &&
-             patch > SHAPEWORKS_PATCH_VERSION) {
-    update_available = true;
-  }
-
-  if (update_available) {
-    auto url = QString("https://github.com/SCIInstitute/ShapeWorks/releases/latest");
-
-    auto title = QString("New version available");
-    setWindowTitle(title);
-    ui_->label->setTextFormat(Qt::RichText);
-    ui_->label->setOpenExternalLinks(true);
-    ui_->label->setTextInteractionFlags(Qt::TextBrowserInteraction);
-    ui_->label->setText(QString("A new version of ShapeWorks is available.<br><br>"
-                                "To download the latest version, please visit:<br><br><a href=\"%1\">%1</a><br><br>" +
-                                message)
-                            .arg(url));
-
-    show();
-    raise();
-
-  } else {
-    if (manual_trigger_) {
-      // show a messagebox saying there is no update
-      auto title = QString("No update available");
-      auto info = QString("You are running the latest version of ShapeWorks.");
-      QMessageBox::information(nullptr, title, info, QMessageBox::Ok);
+    bool update_available = false;
+    if (major > SHAPEWORKS_MAJOR_VERSION) {
+      update_available = true;
+    } else if (major == SHAPEWORKS_MAJOR_VERSION && minor > SHAPEWORKS_MINOR_VERSION) {
+      update_available = true;
+    } else if (major == SHAPEWORKS_MAJOR_VERSION && minor == SHAPEWORKS_MINOR_VERSION &&
+               patch > SHAPEWORKS_PATCH_VERSION) {
+      update_available = true;
     }
+
+    if (update_available) {
+      auto url = QString("https://github.com/SCIInstitute/ShapeWorks/releases/latest");
+
+      auto title = QString("New version available");
+      setWindowTitle(title);
+      ui_->label->setTextFormat(Qt::RichText);
+      ui_->label->setOpenExternalLinks(true);
+      ui_->label->setTextInteractionFlags(Qt::TextBrowserInteraction);
+      ui_->label->setText(QString("A new version of ShapeWorks is available.<br><br>"
+                                  "To download the latest version, please visit:<br><br><a href=\"%1\">%1</a><br><br>" +
+                                  message)
+                              .arg(url));
+
+      show();
+      raise();
+
+    } else {
+      if (manual_trigger_) {
+        // show a messagebox saying there is no update
+        auto title = QString("No update available");
+        auto info = QString("You are running the latest version of ShapeWorks.");
+        QMessageBox::information(nullptr, title, info, QMessageBox::Ok);
+      }
+    }
+
+  } catch (json::exception& e) {
+    SW_LOG("Unable to check for updates: " + std::string(e.what()));
+    return;
   }
 }
 }  // namespace shapeworks

--- a/Studio/Interface/UpdateChecker.h
+++ b/Studio/Interface/UpdateChecker.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <Data/Preferences.h>
+
 #include <QDialog>
 #include <QNetworkAccessManager>
-
-#include <Data/Preferences.h>
 
 namespace Ui {
 class UpdateChecker;
@@ -25,7 +25,6 @@ class UpdateChecker : public QDialog {
   void run_auto_update_check();
   void run_manual_update_check();
 
-
  public Q_SLOTS:
   void handleNetworkReply(QNetworkReply* reply);
 
@@ -38,7 +37,6 @@ class UpdateChecker : public QDialog {
   Ui::UpdateChecker* ui_;
 
   Preferences& prefs_;
-
 };
 
 }  // namespace shapeworks


### PR DESCRIPTION
* #2002 

Due to bugs in Qt, as described in #2002, which aren't fixed until Qt 6.4.3, we have to implement a custom slider widget to fix the display and behavior.

* #2003 

This was caused by the reconstruction mode being set before optimization was complete.  Mesh warping wasn't available yet, so it was briefly set to Legacy.

* #2005 
* #2006 