### PR TITLE
Fix #2014 - Windows GitHub Actions build

### DIFF
--- a/Support/package_windows.sh
+++ b/Support/package_windows.sh
@@ -50,41 +50,6 @@ PATH=$BUILD/bin/Release/bin:$PATH
 # add $PATH to $PYTHONPATH
 PYTHONPATH=$PYTHONPATH:$PATH
 
-# check that 'shapeworks -h' is working
-shapeworks -h
-if [ $? -eq 0 ]; then
-    echo "shapeworks -h is working"
-else
-    echo "shapeworks -h is not working"
-    exit 1
-fi
-python Python/RunShapeWorksAutoDoc.py --md_filename docs/tools/ShapeWorksCommands.md
-pip list
-export PYTHONPATH
-
-echo "PYTHONPATH before = $PYTHONPATH"
-
-# on windows, the PYTHONPATH should use semicolons
-if [[ $OSTYPE == "msys" ]]; then
-    PYTHONPATH=${PYTHONPATH//:/;}
-    PYTHONPATH=${PYTHONPATH//;\/d\//;D:/}
-    PYTHONPATH=${PYTHONPATH//;\/c\//;C:/}
-    PYTHONPATH=${PYTHONPATH//\/d\/a/D:/a}
-fi
-
-
-echo "PATH = $PATH"
-echo "PYTHONPATH after = $PYTHONPATH"
-echo "See if we can import shapeworks_py..."
-
-echo "import os; print(os.environ)" | python
-
-echo "import shapeworks; import shapeworks_py ; print(dir(shapeworks_py))" | python
-
-echo "running mkdocs build"
-mkdocs build
-mv site Documentation
-cp -a Documentation bin/
 
 # Remove tests, they won't work for users anyway
 rm bin/*Tests.exe

--- a/Support/shapeworks.nsi
+++ b/Support/shapeworks.nsi
@@ -75,7 +75,6 @@ Section "ShapeWorks (required)"
   File /r "bin"
   File /r "Examples"
   File /r /x Studio /x Lib "Python"
-  File /r "Documentation"
   File /r "Installation"
 
   ${registerExtension} "$INSTDIR\bin\ShapeWorksStudio.exe" ".swproj" "ShapeWorks Project"


### PR DESCRIPTION
Fixes #2014 

* #2014 

A change in the runner environment has caused a different python DLL to be loaded when going to build the docs.  This happens due to some fixup that we have to do for PYTHONPATH for a dependency of mkdocs (libgaffe?).  On windows, it cannot parse the colons to search for modules, so we change to semicolons, but this changes how python is finding it's DLL and it's breaking.

There is probably some way around this, but it's extremely time consuming to maintain the offline docs for the windows build.  There isn't really any need for it now that we have the versioned mkdocs on the website.  As discussed the last time we invested time into this, we would drop it the next time it caused a problem.