### PR TITLE
Upgrade linux docker image for ShapeWorks 6.5 to Ubuntu 18

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -1,11 +1,11 @@
 # Based on old ubuntu to create more compatible binaries
 
-# To build (e.g. for ShapeWorks 6.4):
-#    docker build --progress=plain -t akenmorris/ubuntu-build-box-sw64 .
+# To build (e.g. for ShapeWorks 6.5):
+#    docker build --progress=plain -t akenmorris/ubuntu-build-box-sw65 .
 # To publish:
-#    docker push akenmorris/ubuntu-build-box-sw64
+#    docker push akenmorris/ubuntu-build-box-sw65
 
-FROM ubuntu:xenial-20210429 AS env
+FROM ubuntu:bionic-20230308 AS env
 MAINTAINER akenmorris@gmail.com
 
 # Set environment variables
@@ -14,10 +14,6 @@ ENV LDFLAGS=-L/opt/conda/lib
 
 # Update
 RUN apt-get update -y && apt-get upgrade -y && apt-get dist-upgrade -y && apt-get install build-essential software-properties-common -y && add-apt-repository ppa:ubuntu-toolchain-r/test -y && apt-get update -y
-
-# Install GCC 9
-RUN apt-get install gcc-9 g++-9 -y
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9 && update-alternatives --config gcc
 
 # Install git and git-lfs
 RUN add-apt-repository ppa:git-core/ppa

--- a/.github/workflows/build-linux-debug.yml
+++ b/.github/workflows/build-linux-debug.yml
@@ -24,7 +24,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container: akenmorris/ubuntu-build-box-sw64
+    container: akenmorris/ubuntu-build-box-sw65
     
     steps:
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,7 +25,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container: akenmorris/ubuntu-build-box-sw64
+    container: akenmorris/ubuntu-build-box-sw65
     
     steps:
 


### PR DESCRIPTION
Upgrade docker image for ShapeWorks 6.5 to Ubuntu 18 in order to support higher glibc that is required for new dependencies (e.g. open3d pypi package)