### PR TITLE
Retrieve Project Parameters using Python binding.

### DIFF
--- a/Libs/Project/Parameters.cpp
+++ b/Libs/Project/Parameters.cpp
@@ -14,7 +14,7 @@ Parameters::Parameters(StringMap map) { set_map(map); }
 void Parameters::set_map(StringMap map) { map_ = map; }
 
 //---------------------------------------------------------------------------
-StringMap Parameters::get_map() { return map_; }
+StringMap Parameters::get_map() const { return map_; }
 
 //---------------------------------------------------------------------------
 Variant Parameters::get(std::string key, Variant default_value) {

--- a/Libs/Project/Parameters.h
+++ b/Libs/Project/Parameters.h
@@ -44,7 +44,7 @@ class Parameters {
   void set_map(StringMap map);
 
   //! get underlying map
-  StringMap get_map();
+  StringMap get_map() const;
 
   //! reset parameters to blank
   void reset_parameters();
@@ -52,9 +52,6 @@ class Parameters {
  private:
   StringMap map_;
 
-  //  std::vector< std::pair<const std::string, std::string> >  container_;
-  // std::pair<const std::string, std::string>  container_;
-  //const std::string joke_;
-  tsl::ordered_map<std::string,std::string> mappy_;
 };
+
 }  // namespace shapeworks

--- a/Libs/Project/Variant.cpp
+++ b/Libs/Project/Variant.cpp
@@ -7,10 +7,10 @@
 using namespace shapeworks;
 
 //---------------------------------------------------------------------------
-Variant::operator std::string() { return str_; }
+Variant::operator std::string() const { return str_; }
 
 //---------------------------------------------------------------------------
-Variant::operator bool() {
+Variant::operator bool() const {
   // first try to read as the word 'true' or 'false', otherwise 0 or 1
   std::string str_lower(str_);
   std::transform(str_.begin(), str_.end(), str_lower.begin(), [](unsigned char c) { return std::tolower(c); });
@@ -22,57 +22,57 @@ Variant::operator bool() {
 }
 
 //---------------------------------------------------------------------------
-Variant::operator int() {
+Variant::operator int() const {
   int t;
   return (valid_ && (std::istringstream(str_) >> t)) ? t : 0;
 }
 
 //---------------------------------------------------------------------------
-Variant::operator unsigned int() {
+Variant::operator unsigned int() const {
   unsigned int t;
   return (valid_ && (std::istringstream(str_) >> t)) ? t : 0;
 }
 
 //---------------------------------------------------------------------------
-Variant::operator long() {
+Variant::operator long() const {
   long t;
   return (valid_ && (std::istringstream(str_) >> t)) ? t : 0;
 }
 
 //---------------------------------------------------------------------------
-Variant::operator unsigned long() {
+Variant::operator unsigned long() const {
   unsigned long t;
   return (valid_ && (std::istringstream(str_) >> t)) ? t : 0;
 }
 
 //---------------------------------------------------------------------------
-Variant::operator float() {
+Variant::operator float() const {
   float t;
   return (valid_ && (std::istringstream(str_) >> t)) ? t : 0;
 }
 
 //---------------------------------------------------------------------------
-Variant::operator double() {
+Variant::operator double() const {
   double t;
   return (valid_ && (std::istringstream(str_) >> t)) ? t : 0;
 }
 
 //---------------------------------------------------------------------------
-Variant::operator std::vector<double>() {
+Variant::operator std::vector<double>() const {
   std::istringstream iss(str_);
   std::vector<double> v((std::istream_iterator<double>(iss)), std::istream_iterator<double>());
   return v;
 }
 
 //---------------------------------------------------------------------------
-Variant::operator std::vector<int>() {
+Variant::operator std::vector<int>() const {
   std::istringstream iss(str_);
   std::vector<int> v((std::istream_iterator<int>(iss)), std::istream_iterator<int>());
   return v;
 }
 
 //---------------------------------------------------------------------------
-Variant::operator std::vector<bool>() {
+Variant::operator std::vector<bool>() const {
   std::istringstream iss(str_);
   std::vector<bool> v((std::istream_iterator<bool>(iss)), std::istream_iterator<bool>());
   return v;

--- a/Libs/Project/Variant.h
+++ b/Libs/Project/Variant.h
@@ -37,17 +37,17 @@ class Variant {
   Variant(std::vector<int> v) : str_(variant_to_string(v.begin(), v.end())), valid_(true) {}
   Variant(std::vector<bool> v) : str_(variant_to_string(v.begin(), v.end())), valid_(true) {}
 
-  operator std::string();
-  operator bool();
-  operator int();
-  operator unsigned int();
-  operator long();
-  operator unsigned long();
-  operator float();
-  operator double();
-  operator std::vector<double>();
-  operator std::vector<int>();
-  operator std::vector<bool>();
+  operator std::string() const;
+  operator bool() const;
+  operator int() const;
+  operator unsigned int() const;
+  operator long() const;
+  operator unsigned long() const;
+  operator float() const;
+  operator double() const;
+  operator std::vector<double>() const;
+  operator std::vector<int>() const;
+  operator std::vector<bool>() const;
 
  private:
   std::string str_;

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1968,13 +1968,17 @@ PYBIND11_MODULE(shapeworks_py, m)
       "remove an entry",
       "key"_a)
 
-  .def("set_map",
-      &Parameters::set_map,
-      "set underlying map",
-      "map"_a)
+  .def("as_map",
+      [](const Parameters& params) -> decltype(auto) {
+          project::types::StringMap m = params.get_map();
+          std::map<std::string,std::string> map;
 
-  .def("get_map",
-      &Parameters::get_map,
+         for (auto& [k, v] : m) {
+           map[k] = v;
+         }
+
+         return map;
+       },
       "get underlying map")
 
   .def("reset_parameters",
@@ -2001,6 +2005,12 @@ PYBIND11_MODULE(shapeworks_py, m)
   .def(py::init< const char*> ())
 
   .def(py::init< bool> ())
+
+  .def("as_str",
+        [](const Variant& v) -> decltype(auto) {
+          return static_cast<std::string>(v);
+       },
+      "Return the variant string content")
 
   ; //Variant
 } // PYBIND11_MODULE(shapeworks_py)

--- a/Testing/data/python/project/project.py
+++ b/Testing/data/python/project/project.py
@@ -1,8 +1,20 @@
 import shapeworks as sw
 p = sw.Project()
 p.load("sample.xlsx")
-p.get_headers()
-p.get_subjects()
+print(p.get_headers())
+
+optim_params = p.get_parameters("optimize").as_map()
+for param in optim_params:
+    print(f'{param} : {optim_params[param]}')
+
+print(sw.Variant("10").as_str())
+
+print(p.get_parameters("project").as_map()["version"])
+project_params = p.get_parameters("project")
+project_params.set("version", sw.Variant("3"))
+print(project_params.get("version", sw.Variant("10")).as_str())
+print(project_params.as_map()["version"])
+
 subjects = p.get_subjects()
 for s in subjects:
     sub_group_dict = {}


### PR DESCRIPTION
Allows to retrieve optimization parameters from xlsx project:

import shapeworks as sw
p = sw.Project()
p.load("sample.xlsx")
optim_params = p.get_parameters("optimize").as_map()

Notes: the old Parameters:get_map() and set_map() were not usable (because tsl::ordered_map not supported by pybind11), replaced by as_map()

Added Variant.as_str() for access in Python.