### PR TITLE
Remove pip cache clear.  Getting this error:

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -63,10 +63,6 @@ jobs:
       shell: bash -l {0}
       run: .github/workflows/gha_conda.sh
 
-    - name: Clear pip cache
-      shell: bash -l {0}
-      run: conda activate shapeworks && pip cache info && pip cache purge
-      
     - name: try import vtk
       shell: bash -l {0}
       run: conda activate shapeworks && python -c "import vtk"


### PR DESCRIPTION
WARNING: The directory '/github/home/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.
ERROR: pip cache commands can not function since cache is disabled.