### PR TITLE
Enable useRobustLaplacian to heat solver

### DIFF
--- a/Examples/Python/Data/Verification.zip
+++ b/Examples/Python/Data/Verification.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cd83978ab857e5ea1f1d486e42ebad2966552c9ec2102a6c44977a2dcc9f9956
-size 1853607
+oid sha256:564df3550a96f30cf2741560b9d2a1ee2dfdc1a261fa129ecc713865e5c9f190
+size 1853611

--- a/Examples/Python/Data/Verification.zip
+++ b/Examples/Python/Data/Verification.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:564df3550a96f30cf2741560b9d2a1ee2dfdc1a261fa129ecc713865e5c9f190
-size 1853611
+oid sha256:0e291d6cd42f159397d86022643feb0c690806af0768d06dd6663c94c86e62ee
+size 1853743

--- a/Examples/Python/Data/Verification.zip
+++ b/Examples/Python/Data/Verification.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15b67bfcf9e77728e235f90726386db01362ff052e579a97175cef09c2ffe9a0
-size 1853608
+oid sha256:cd83978ab857e5ea1f1d486e42ebad2966552c9ec2102a6c44977a2dcc9f9956
+size 1853607

--- a/Examples/Python/thin_cavity_bean.py
+++ b/Examples/Python/thin_cavity_bean.py
@@ -108,8 +108,8 @@ def Run_Pipeline(args):
     # If running a tiny test, reduce some parameters
     if args.tiny_test:
         parameter_dictionary["number_of_particles"] = 32
-        parameter_dictionary["optimization_iterations"] = 25
-        parameter_dictionary["iterations_per_split"] = 25
+        parameter_dictionary["optimization_iterations"] = 50
+        parameter_dictionary["iterations_per_split"] = 50
     # Run multiscale optimization unless single scale is specified
     if not args.use_single_scale:
         parameter_dictionary["multiscale"] = 1

--- a/Libs/Optimize/Domain/VtkMeshWrapper.cpp
+++ b/Libs/Optimize/Domain/VtkMeshWrapper.cpp
@@ -897,7 +897,7 @@ void VtkMeshWrapper::PrecomputeGeodesics(const Eigen::MatrixXd& V, const Eigen::
   {
     using namespace geometrycentral::surface;
     std::tie(gc_mesh_, gc_geometry_) = makeSurfaceMeshAndGeometry(V, F);
-    gc_heatsolver_ = std::make_unique<HeatMethodDistanceSolver>(*gc_geometry_);
+    gc_heatsolver_ = std::make_unique<HeatMethodDistanceSolver>(*gc_geometry_, 1.0, true);
   }
 
   // compute k-ring

--- a/Testing/MeshTests/MeshTests.cpp
+++ b/Testing/MeshTests/MeshTests.cpp
@@ -78,8 +78,8 @@ TEST(MeshTests, geodesicTest1) {
   auto pt2 = ellipsoid.getPoint(p2);
   auto euclidean_dist = pt2.EuclideanDistanceTo(pt1);
 
-  ASSERT_TRUE(std::abs(euclidean_dist - 6.70625) < 1e-4);
-  ASSERT_TRUE(std::abs(geodesic_dist - 6.577) < 1e-4);
+  ASSERT_TRUE(std::abs(euclidean_dist - 6.7062) < 1e-4);
+  ASSERT_TRUE(std::abs(geodesic_dist - 6.55644) < 1e-4);
 }
 
 TEST(MeshTests, geodesicTest2) {

--- a/Testing/PythonTests/geodesic.py
+++ b/Testing/PythonTests/geodesic.py
@@ -14,8 +14,7 @@ def geodesicTest1():
   pt1 = mesh.getPoint(p1)
   pt2 = mesh.getPoint(p2)
   euclidean_dist = np.linalg.norm(pt2 - pt1)
-
-  return abs(geodesic_dist - 6.577) < 1e-4 and abs(euclidean_dist - 6.70625) < 1e-4
+  return abs(geodesic_dist - 6.5564) < 1e-4 and abs(euclidean_dist - 6.70625) < 1e-4
 
 success &= utils.test(geodesicTest1)
 
@@ -25,7 +24,7 @@ def geodesicTest2():
   mesh.setField("GeodesicDistanceToLandmark", distField, Mesh.Point)
 
   ground_truth = Mesh(os.environ["DATA"] + "/geodesic1.vtk")
-
+  
   return mesh.compareField(ground_truth, "GeodesicDistanceToLandmark")
 
 success &= utils.test(geodesicTest2)

--- a/Testing/data/geodesic.txt
+++ b/Testing/data/geodesic.txt
@@ -1,1 +1,1 @@
-Geodesic Distance between two points: 6.577
+Geodesic Distance between two points: 6.55644

--- a/Testing/data/geodesic1.vtk
+++ b/Testing/data/geodesic1.vtk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e132d4fe513630b04c2bb3e2e1fcecb2bec09c9dbcf7fb020a0c67d7b2802a20
-size 780223
+oid sha256:abfebe8e95d1d65b1fb5b05a0592fed35933001413c379df291a4804c23aee84
+size 1148410

--- a/Testing/data/geodesic3.vtk
+++ b/Testing/data/geodesic3.vtk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb1d30de203abab733a76e4fac65c800fdba4a616b31c3cf94b2050fb4f551c8
-size 780223
+oid sha256:18f02a3f768c271d9cbf95f32df9d16e2c0b1db08ac5c0ce47fcb5a32823afd4
+size 1148465

--- a/Testing/data/geodesic_curve.vtk
+++ b/Testing/data/geodesic_curve.vtk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:437a10e0b195deb61ad6d54b0a2016e3793d211aa995a18b96413f2ff7be713c
-size 34050
+oid sha256:d8d4f52664d138b73fc6eaa0bd54999dce5750599013714f89e0aca643d88e3a
+size 51123

--- a/Testing/data/geodesic_curve_py.vtk
+++ b/Testing/data/geodesic_curve_py.vtk
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6db843955516d0473028f42ee3381fd318dec70c88ff088add72324e8453b3e
-size 34050
+oid sha256:da3f3b0c494da652dc46dabf4680f9723dc8c685289d8323cd7bde5a1eac1d75
+size 51145


### PR DESCRIPTION
https://geometry-central.net/surface/algorithms/geodesic_distance/

useRobustLaplacian is true, the solver will internally use a robust intrinsic Laplacian, including mollification & tufting for nonmanifold inputs. See “A Laplacian for Nonmanifold Triangle Meshes” [Sharp & Crane 2020 @ SGP] for algorithmic details and citation.