### PR TITLE
Studio fixed domains

### DIFF
--- a/Examples/Python/deep_ssm.py
+++ b/Examples/Python/deep_ssm.py
@@ -107,7 +107,7 @@ def Run_Pipeline(args):
     The required grooming steps are:
     1. Load mesh
     2. Apply clipping with planes for finding alignment transform
-    3. Find reflection tansfrom
+    3. Find reflection transfrom
     4. Select reference mesh
     5. Find rigid alignment transform
     For more information on grooming see docs/workflow/groom.md

--- a/Examples/Python/deep_ssm.py
+++ b/Examples/Python/deep_ssm.py
@@ -479,7 +479,8 @@ def Run_Pipeline(args):
         transform = [ train_transforms[i].flatten() ]
         subject.set_groomed_transforms(transform)
         subject.set_constraints_filenames(rel_plane_files)
-        subject.set_landmarks_filenames([train_local_particles[i]])
+        subject.set_local_particle_filenames([train_local_particles[i]])
+        subject.set_world_particle_filenames([train_local_particles[i]])
         subject.set_extra_values({"fixed": "yes"})
         subjects.append(subject)
     # Add new validation shapes
@@ -500,7 +501,8 @@ def Run_Pipeline(args):
         transform = [ val_transforms[i].flatten() ]
         subject.set_groomed_transforms(transform)
         subject.set_constraints_filenames(rel_plane_files)
-        subject.set_landmarks_filenames(rel_particle_files)
+        subject.set_local_particle_filenames(rel_particle_files)
+        subject.set_world_particle_filenames(rel_particle_files)
         subject.set_extra_values({"fixed": "no"})
         subjects.append(subject)
     project = sw.Project()
@@ -512,11 +514,7 @@ def Run_Pipeline(args):
     parameter_dictionary["procrustes"] = 0
     parameter_dictionary["procrustes_interval"] = 0
     parameter_dictionary["procrustes_scaling"] = 0
-    parameter_dictionary["use_landmarks"] = 1
-    parameter_dictionary["use_fixed_subjects"] = 1
     parameter_dictionary["narrow_band"] = 1e10
-    parameter_dictionary["fixed_subjects_column"] = "fixed"
-    parameter_dictionary["fixed_subjects_choice"] = "yes"
     for key in parameter_dictionary:
         parameters.set(key, sw.Variant(parameter_dictionary[key]))
     project.set_parameters("optimize", parameters)

--- a/Examples/Python/ellipsoid_fd.py
+++ b/Examples/Python/ellipsoid_fd.py
@@ -123,7 +123,8 @@ def Run_Pipeline(args):
         rel_particle_files = sw.utils.get_relative_paths([os.getcwd() + "/" + fixed_local_particles[i]],  project_location)
         subject.set_original_filenames(original_groom_files)
         subject.set_groomed_filenames(rel_groom_files)
-        subject.set_landmarks_filenames(rel_particle_files)
+        subject.set_local_particle_filenames(rel_particle_files)
+        subject.set_world_particle_filenames(rel_particle_files)
         subject.set_extra_values({"fixed": "yes"})
         subjects.append(subject)
 
@@ -135,7 +136,8 @@ def Run_Pipeline(args):
         rel_particle_files = sw.utils.get_relative_paths([os.getcwd() + "/" + mean_shape_path], project_location)
         subject.set_original_filenames(original_groom_files)
         subject.set_groomed_filenames(rel_groom_files)
-        subject.set_landmarks_filenames(rel_particle_files)
+        subject.set_local_particle_filenames(rel_particle_files)
+        subject.set_world_particle_filenames(rel_particle_files)
         subject.set_extra_values({"fixed": "no"})
         subjects.append(subject)
 
@@ -186,6 +188,7 @@ def Run_Pipeline(args):
 
     # Run optimization
     optimize_cmd = ('shapeworks optimize --progress --name ' + spreadsheet_file).split()
+    print(optimize_cmd)
     subprocess.check_call(optimize_cmd)
 
     # If tiny test or verify, check results and exit

--- a/Examples/Python/ellipsoid_fd.py
+++ b/Examples/Python/ellipsoid_fd.py
@@ -162,11 +162,7 @@ def Run_Pipeline(args):
         "procrustes_scaling": 0,
         "save_init_splits": 0,
         "verbosity": 0,
-        "use_landmarks": 1,
-        "use_fixed_subjects": 1,
         "narrow_band": 1e10,
-        "fixed_subjects_column": "fixed",
-        "fixed_subjects_choice": "yes"
     }
 
     for key in parameter_dictionary:

--- a/Libs/Analyze/Shape.cpp
+++ b/Libs/Analyze/Shape.cpp
@@ -146,8 +146,10 @@ void Shape::clear_reconstructed_mesh() { reconstructed_meshes_ = MeshGroup(subje
 bool Shape::import_global_point_files(std::vector<std::string> filenames) {
   for (int i = 0; i < filenames.size(); i++) {
     Eigen::VectorXd points;
-    if (!Shape::import_point_file(filenames[i], points)) {
-      throw std::invalid_argument("Unable to import point file: " + filenames[i]);
+    if (filenames[i] != "") {
+      if (!Shape::import_point_file(filenames[i], points)) {
+        throw std::invalid_argument("Unable to import point file: " + filenames[i]);
+      }
     }
     global_point_filenames_.push_back(filenames[i]);
     particles_.set_world_particles(i, points);
@@ -160,8 +162,10 @@ bool Shape::import_global_point_files(std::vector<std::string> filenames) {
 bool Shape::import_local_point_files(std::vector<std::string> filenames) {
   for (int i = 0; i < filenames.size(); i++) {
     Eigen::VectorXd points;
-    if (!Shape::import_point_file(filenames[i], points)) {
-      throw std::invalid_argument("Unable to import point file: " + filenames[i]);
+    if (filenames[i] != "") {
+      if (!Shape::import_point_file(filenames[i], points)) {
+        throw std::invalid_argument("Unable to import point file: " + filenames[i]);
+      }
     }
     local_point_filenames_.push_back(filenames[i]);
     particles_.set_local_particles(i, points);
@@ -307,9 +311,7 @@ bool Shape::store_constraints() {
 Eigen::VectorXd Shape::get_global_correspondence_points() { return particles_.get_combined_global_particles(); }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd Shape::get_local_correspondence_points() {
-  return particles_.get_combined_local_particles();
-}
+Eigen::VectorXd Shape::get_local_correspondence_points() { return particles_.get_combined_local_particles(); }
 
 //---------------------------------------------------------------------------
 int Shape::get_id() { return id_; }
@@ -699,9 +701,7 @@ void Shape::set_particle_transform(vtkSmartPointer<vtkTransform> transform) {
 }
 
 //---------------------------------------------------------------------------
-void Shape::set_alignment_type(int alignment) {
-  particles_.set_alignment_type(alignment);
-}
+void Shape::set_alignment_type(int alignment) { particles_.set_alignment_type(alignment); }
 
 //---------------------------------------------------------------------------
 vtkSmartPointer<vtkTransform> Shape::get_reconstruction_transform(int domain) {

--- a/Libs/Groom/Groom.cpp
+++ b/Libs/Groom/Groom.cpp
@@ -24,16 +24,16 @@ typedef float PixelType;
 typedef itk::Image<PixelType, 3> ImageType;
 
 //---------------------------------------------------------------------------
-Groom::Groom(ProjectHandle project) { this->project_ = project; }
+Groom::Groom(ProjectHandle project) { project_ = project; }
 
 //---------------------------------------------------------------------------
 bool Groom::run() {
   used_names_.clear();
-  this->progress_ = 0;
-  this->progress_counter_ = 0;
-  this->total_ops_ = this->get_total_ops();
+  progress_ = 0;
+  progress_counter_ = 0;
+  total_ops_ = get_total_ops();
 
-  auto subjects = this->project_->get_subjects();
+  auto subjects = project_->get_subjects();
 
   if (subjects.empty()) {
     throw std::invalid_argument("No subjects to groom");
@@ -43,7 +43,7 @@ bool Groom::run() {
   tbb::parallel_for(tbb::blocked_range<size_t>{0, subjects.size()}, [&](const tbb::blocked_range<size_t>& r) {
     for (size_t i = r.begin(); i < r.end(); ++i) {
       for (int domain = 0; domain < project_->get_number_of_domains_per_subject(); domain++) {
-        if (this->abort_) {
+        if (abort_) {
           success = false;
           continue;
         }
@@ -53,19 +53,19 @@ bool Groom::run() {
         bool is_contour = project_->get_original_domain_types()[domain] == DomainType::Contour;
 
         if (is_image) {
-          if (!this->image_pipeline(subjects[i], domain)) {
+          if (!image_pipeline(subjects[i], domain)) {
             success = false;
           }
         }
 
         if (is_mesh) {
-          if (!this->mesh_pipeline(subjects[i], domain)) {
+          if (!mesh_pipeline(subjects[i], domain)) {
             success = false;
           }
         }
 
         if (is_contour) {
-          if (!this->contour_pipeline(subjects[i], domain)) {
+          if (!contour_pipeline(subjects[i], domain)) {
             success = false;
           }
         }
@@ -73,7 +73,7 @@ bool Groom::run() {
     }
   });
 
-  if (!this->run_alignment()) {
+  if (!run_alignment()) {
     success = false;
   }
   increment_progress(10);  // alignment complete
@@ -85,7 +85,7 @@ bool Groom::run() {
 //---------------------------------------------------------------------------
 bool Groom::image_pipeline(std::shared_ptr<Subject> subject, size_t domain) {
   // grab parameters
-  auto params = GroomParameters(this->project_, this->project_->get_domain_names()[domain]);
+  auto params = GroomParameters(project_, project_->get_domain_names()[domain]);
 
   auto original = subject->get_original_filenames()[domain];
 
@@ -119,34 +119,34 @@ bool Groom::image_pipeline(std::shared_ptr<Subject> subject, size_t domain) {
     return true;
   }
 
-  this->run_image_pipeline(image, params);
+  run_image_pipeline(image, params);
 
   // reflection
   if (params.get_reflect()) {
     auto table = subject->get_table_values();
     if (table.find(params.get_reflect_column()) != table.end()) {
       if (table[params.get_reflect_column()] == params.get_reflect_choice()) {
-        this->add_reflect_transform(transform, params.get_reflect_axis());
+        add_reflect_transform(transform, params.get_reflect_axis());
       }
     }
   }
 
   // centering
   if (params.get_use_center()) {
-    this->add_center_transform(transform, image);
+    add_center_transform(transform, image);
   }
 
-  if (this->abort_) {
+  if (abort_) {
     return false;
   }
 
   // groomed filename
-  std::string groomed_name = this->get_output_filename(original, DomainType::Image);
+  std::string groomed_name = get_output_filename(original, DomainType::Image);
 
   if (params.get_convert_to_mesh()) {
     Mesh mesh = image.toMesh(0.0);
-    this->run_mesh_pipeline(mesh, params);
-    groomed_name = this->get_output_filename(original, DomainType::Mesh);
+    run_mesh_pipeline(mesh, params);
+    groomed_name = get_output_filename(original, DomainType::Mesh);
     // save the groomed mesh
     MeshUtils::threadSafeWriteMesh(groomed_name, mesh);
   } else {
@@ -179,18 +179,18 @@ bool Groom::run_image_pipeline(Image& image, GroomParameters params) {
   // isolate
   if (params.get_isolate_tool()) {
     image.isolate();
-    this->increment_progress();
+    increment_progress();
   }
-  if (this->abort_) {
+  if (abort_) {
     return false;
   }
 
   // fill holes
   if (params.get_fill_holes_tool()) {
     image.closeHoles();
-    this->increment_progress();
+    increment_progress();
   }
-  if (this->abort_) {
+  if (abort_) {
     return false;
   }
 
@@ -198,28 +198,28 @@ bool Groom::run_image_pipeline(Image& image, GroomParameters params) {
   if (params.get_crop()) {
     PhysicalRegion region = image.physicalBoundingBox(0.5);
     image.crop(region);
-    this->increment_progress();
+    increment_progress();
   }
-  if (this->abort_) {
+  if (abort_) {
     return false;
   }
 
   // autopad
   if (params.get_auto_pad_tool()) {
     image.pad(params.get_padding_amount());
-    this->fix_origin(image);
-    this->increment_progress();
+    fix_origin(image);
+    increment_progress();
   }
-  if (this->abort_) {
+  if (abort_) {
     return false;
   }
 
   // antialias
   if (params.get_antialias_tool()) {
     image.antialias(params.get_antialias_iterations());
-    this->increment_progress();
+    increment_progress();
   }
-  if (this->abort_) {
+  if (abort_) {
     return false;
   }
 
@@ -239,26 +239,26 @@ bool Groom::run_image_pipeline(Image& image, GroomParameters params) {
     } else {
       image.resample(v, Image::InterpolationType::Linear);
     }
-    this->increment_progress();
+    increment_progress();
   }
-  if (this->abort_) {
+  if (abort_) {
     return false;
   }
 
   // create distance transform
   if (params.get_fast_marching()) {
     image.computeDT();
-    this->increment_progress(10);
+    increment_progress(10);
   }
 
-  if (this->abort_) {
+  if (abort_) {
     return false;
   }
 
   // blur
   if (params.get_blur_tool()) {
     image.gaussianBlur(params.get_blur_amount());
-    this->increment_progress();
+    increment_progress();
   }
 
   return true;
@@ -267,12 +267,12 @@ bool Groom::run_image_pipeline(Image& image, GroomParameters params) {
 //---------------------------------------------------------------------------
 bool Groom::mesh_pipeline(std::shared_ptr<Subject> subject, size_t domain) {
   // grab parameters
-  auto params = GroomParameters(this->project_, this->project_->get_domain_names()[domain]);
+  auto params = GroomParameters(project_, project_->get_domain_names()[domain]);
 
   auto original = subject->get_original_filenames()[domain];
 
   // groomed mesh name
-  std::string groom_name = this->get_output_filename(original, DomainType::Mesh);
+  std::string groom_name = get_output_filename(original, DomainType::Mesh);
 
   Mesh mesh = MeshUtils::threadSafeReadMesh(original);
 
@@ -280,21 +280,21 @@ bool Groom::mesh_pipeline(std::shared_ptr<Subject> subject, size_t domain) {
   auto transform = vtkSmartPointer<vtkTransform>::New();
 
   if (!params.get_skip_grooming()) {
-    this->run_mesh_pipeline(mesh, params);
+    run_mesh_pipeline(mesh, params);
 
     // reflection
     if (params.get_reflect()) {
       auto table = subject->get_table_values();
       if (table.find(params.get_reflect_column()) != table.end()) {
         if (table[params.get_reflect_column()] == params.get_reflect_choice()) {
-          this->add_reflect_transform(transform, params.get_reflect_axis());
+          add_reflect_transform(transform, params.get_reflect_axis());
         }
       }
     }
 
     // centering
     if (params.get_use_center()) {
-      this->add_center_transform(transform, mesh);
+      add_center_transform(transform, mesh);
     }
     // save the groomed mesh
     MeshUtils::threadSafeWriteMesh(groom_name, mesh);
@@ -328,7 +328,7 @@ bool Groom::mesh_pipeline(std::shared_ptr<Subject> subject, size_t domain) {
 bool Groom::run_mesh_pipeline(Mesh& mesh, GroomParameters params) {
   if (params.get_fill_mesh_holes_tool()) {
     mesh.fillHoles();
-    this->increment_progress();
+    increment_progress();
   }
 
   if (params.get_remesh()) {
@@ -344,7 +344,7 @@ bool Groom::run_mesh_pipeline(Mesh& mesh, GroomParameters params) {
     num_vertices = std::max<int>(num_vertices, 25);
     double gradation = clamp<double>(params.get_remesh_gradation(), 0.0, 2.0);
     mesh.remesh(num_vertices, gradation);
-    this->increment_progress();
+    increment_progress();
   }
 
   if (params.get_mesh_smooth()) {
@@ -353,7 +353,7 @@ bool Groom::run_mesh_pipeline(Mesh& mesh, GroomParameters params) {
     } else if (params.get_mesh_smoothing_method() == GroomParameters::GROOM_SMOOTH_VTK_WINDOWED_SINC_C) {
       mesh.smoothSinc(params.get_mesh_vtk_windowed_sinc_iterations(), params.get_mesh_vtk_windowed_sinc_passband());
     }
-    this->increment_progress();
+    increment_progress();
   }
   return true;
 }
@@ -361,12 +361,12 @@ bool Groom::run_mesh_pipeline(Mesh& mesh, GroomParameters params) {
 //---------------------------------------------------------------------------
 bool Groom::contour_pipeline(std::shared_ptr<Subject> subject, size_t domain) {
   // grab parameters
-  auto params = GroomParameters(this->project_, this->project_->get_domain_names()[domain]);
+  auto params = GroomParameters(project_, project_->get_domain_names()[domain]);
 
   auto original = subject->get_original_filenames()[domain];
 
   // groomed mesh name
-  std::string groom_name = this->get_output_filename(original, DomainType::Mesh);
+  std::string groom_name = get_output_filename(original, DomainType::Mesh);
 
   Mesh mesh = MeshUtils::threadSafeReadMesh(original);
 
@@ -379,14 +379,14 @@ bool Groom::contour_pipeline(std::shared_ptr<Subject> subject, size_t domain) {
       auto table = subject->get_table_values();
       if (table.find(params.get_reflect_column()) != table.end()) {
         if (table[params.get_reflect_column()] == params.get_reflect_choice()) {
-          this->add_reflect_transform(transform, params.get_reflect_axis());
+          add_reflect_transform(transform, params.get_reflect_axis());
         }
       }
     }
 
     // centering
     if (params.get_use_center()) {
-      this->add_center_transform(transform, mesh);
+      add_center_transform(transform, mesh);
     }
 
     // save the groomed contour
@@ -430,16 +430,16 @@ void Groom::fix_origin(Image& image) {
 
 //---------------------------------------------------------------------------
 int Groom::get_total_ops() {
-  int num_subjects = this->project_->get_subjects().size();
+  int num_subjects = project_->get_subjects().size();
 
   int num_tools = 0;
 
   project_->update_subjects();
-  auto domains = this->project_->get_domain_names();
-  auto subjects = this->project_->get_subjects();
+  auto domains = project_->get_domain_names();
+  auto subjects = project_->get_subjects();
 
   for (int i = 0; i < domains.size(); i++) {
-    auto params = GroomParameters(this->project_, domains[i]);
+    auto params = GroomParameters(project_, domains[i]);
 
     if (project_->get_original_domain_types()[i] == DomainType::Image) {
       num_tools += params.get_isolate_tool() ? 1 : 0;
@@ -469,39 +469,39 @@ int Groom::get_total_ops() {
 //---------------------------------------------------------------------------
 void Groom::increment_progress(int amount) {
   std::scoped_lock lock(mutex);
-  this->progress_counter_ += amount;
-  this->progress_ = static_cast<float>(this->progress_counter_) / static_cast<float>(this->total_ops_) * 100.0;
+  progress_counter_ += amount;
+  progress_ = static_cast<float>(progress_counter_) / static_cast<float>(total_ops_) * 100.0;
   SW_PROGRESS(progress_, fmt::format("Grooming ({}/{} ops)", progress_counter_, total_ops_));
 }
 
 //---------------------------------------------------------------------------
-void Groom::abort() { this->abort_ = true; }
+void Groom::abort() { abort_ = true; }
 
 //---------------------------------------------------------------------------
-bool Groom::get_aborted() { return this->abort_; }
+bool Groom::get_aborted() { return abort_; }
 
 //---------------------------------------------------------------------------
 bool Groom::run_alignment() {
-  size_t num_domains = this->project_->get_number_of_domains_per_subject();
-  auto subjects = this->project_->get_subjects();
+  size_t num_domains = project_->get_number_of_domains_per_subject();
+  auto subjects = project_->get_subjects();
 
-  auto base_params = GroomParameters(this->project_);
+  auto base_params = GroomParameters(project_);
 
   bool global_icp = false;
   bool global_landmarks = false;
   // per-domain alignment
   for (size_t domain = 0; domain < num_domains; domain++) {
-    if (this->abort_) {
+    if (abort_) {
       return false;
     }
 
-    auto params = GroomParameters(this->project_, this->project_->get_domain_names()[domain]);
+    auto params = GroomParameters(project_, project_->get_domain_names()[domain]);
 
     if (params.get_use_icp()) {
       global_icp = true;
       std::vector<Mesh> meshes;
       for (size_t i = 0; i < subjects.size(); i++) {
-        auto mesh = this->get_mesh(i, domain);
+        auto mesh = get_mesh(i, domain);
 
         auto list = subjects[i]->get_groomed_transforms()[domain];
         vtkSmartPointer<vtkTransform> transform = ProjectUtils::convert_transform(list);
@@ -532,9 +532,9 @@ bool Groom::run_alignment() {
     std::vector<Mesh> meshes;
 
     for (size_t i = 0; i < subjects.size(); i++) {
-      Mesh mesh = this->get_mesh(i, 0);
+      Mesh mesh = get_mesh(i, 0);
       for (size_t domain = 1; domain < num_domains; domain++) {
-        mesh += this->get_mesh(i, domain);  // combine
+        mesh += get_mesh(i, domain);  // combine
       }
 
       // grab the first domain's initial transform (e.g. potentially reflect) and use before ICP
@@ -577,7 +577,7 @@ bool Groom::run_alignment() {
 
 //---------------------------------------------------------------------------
 void Groom::assign_transforms(std::vector<std::vector<double>> transforms, int domain, bool global) {
-  auto subjects = this->project_->get_subjects();
+  auto subjects = project_->get_subjects();
 
   for (size_t i = 0; i < subjects.size(); i++) {
     auto subject = subjects[i];
@@ -615,10 +615,10 @@ std::string Groom::get_output_filename(std::string input, DomainType domain_type
   std::scoped_lock lock(mutex_);
 
   // grab parameters
-  auto params = GroomParameters(this->project_);
+  auto params = GroomParameters(project_);
 
   // if the project is not saved, use the path of the input filename
-  auto filename = this->project_->get_filename();
+  auto filename = project_->get_filename();
   if (filename == "") {
     filename = input;
   }
@@ -663,7 +663,7 @@ std::string Groom::get_output_filename(std::string input, DomainType domain_type
 
 //---------------------------------------------------------------------------
 Mesh Groom::get_mesh(int subject, int domain) {
-  auto subjects = this->project_->get_subjects();
+  auto subjects = project_->get_subjects();
   auto path = subjects[subject]->get_original_filenames()[domain];
 
   if (project_->get_original_domain_types()[domain] == DomainType::Image) {
@@ -682,7 +682,7 @@ Mesh Groom::get_mesh(int subject, int domain) {
 //---------------------------------------------------------------------------
 vtkSmartPointer<vtkPoints> Groom::get_landmarks(int subject, int domain) {
   vtkSmartPointer<vtkPoints> vtk_points = vtkSmartPointer<vtkPoints>::New();
-  auto subjects = this->project_->get_subjects();
+  auto subjects = project_->get_subjects();
   auto path = subjects[subject]->get_landmarks_filenames()[domain];
 
   std::ifstream in(path.c_str());
@@ -852,7 +852,7 @@ void Groom::add_center_transform(vtkSmartPointer<vtkTransform> transform, vtkSma
 //---------------------------------------------------------------------------
 std::vector<vtkSmartPointer<vtkPoints>> Groom::get_combined_points() {
   auto subjects = project_->get_subjects();
-  size_t num_domains = this->project_->get_number_of_domains_per_subject();
+  size_t num_domains = project_->get_number_of_domains_per_subject();
 
   std::vector<vtkSmartPointer<vtkPoints>> landmarks;
   for (size_t i = 0; i < subjects.size(); i++) {

--- a/Libs/Optimize/Constraints/FreeFormConstraint.cpp
+++ b/Libs/Optimize/Constraints/FreeFormConstraint.cpp
@@ -30,6 +30,7 @@ namespace shapeworks {
 //-----------------------------------------------------------------------------
 bool FreeFormConstraint::readyForOptimize() const { return mesh_ != nullptr; }
 
+//-----------------------------------------------------------------------------
 bool FreeFormConstraint::isViolated(const Eigen::Vector3d& pt) const {
   if (constraintEval(pt) >= 0) {
     return false;
@@ -298,7 +299,6 @@ std::vector<Eigen::Matrix3d> FreeFormConstraint::setGradientFieldForFFCs(std::sh
 
   // Flatten the gradient operator so we can quickly compute the gradient at a given point
   face_grad.resize(F.rows());
-  size_t n_insertions = 0;
   for (int k = 0; k < G.outerSize(); k++) {
     for (Eigen::SparseMatrix<double>::InnerIterator it(G, k); it; ++it) {
       const double val = it.value();
@@ -310,7 +310,6 @@ std::vector<Eigen::Matrix3d> FreeFormConstraint::setGradientFieldForFFCs(std::sh
       for (int i = 0; i < 3; i++) {
         if (F(f, i) == c) {
           face_grad[f](axis, i) = val;
-          n_insertions++;
           break;
         }
       }
@@ -353,6 +352,7 @@ std::vector<Eigen::Matrix3d> FreeFormConstraint::setGradientFieldForFFCs(std::sh
   return face_grad;
 }
 
+//-----------------------------------------------------------------------------
 void FreeFormConstraint::convertLegacyFFC(vtkSmartPointer<vtkPolyData> polyData) {
   if (polyData->GetPointData()->GetArray("ffc_paint")) {
     // clear out any old versions of the inout array or else they will get merged in
@@ -439,6 +439,7 @@ void FreeFormConstraint::convertLegacyFFC(vtkSmartPointer<vtkPolyData> polyData)
   createInoutPolyData();
 }
 
+//-----------------------------------------------------------------------------
 vtkSmartPointer<vtkFloatArray> FreeFormConstraint::computeInOutForFFCs(vtkSmartPointer<vtkPolyData> polyData,
                                                                        Eigen::Vector3d query,
                                                                        vtkSmartPointer<vtkPolyData> halfmesh) {

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1963,15 +1963,15 @@ void Optimize::SetNarrowBand(double v) {
 
 //---------------------------------------------------------------------------
 double Optimize::GetNarrowBand() {
+  if (this->m_fixed_domains_present) {
+    return 1e10;
+  }
+
   if (this->m_narrow_band_set) {
     return this->m_narrow_band;
   }
 
-  if (this->m_fixed_domains_present) {
-    return 1e10;
-  } else {
-    return 4.0;
-  }
+  return 4.0;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -24,8 +24,6 @@
 // shapeworks
 #include <Project/Project.h>
 
-//#include "Libs/Optimize/Domain/ImageDomain.h"
-//#include "Libs/Optimize/Domain/ImplicitSurfaceDomain.h"
 #include <Libs/Particles/ParticleFile.h>
 
 #include "Libs/Optimize/Domain/VtkMeshWrapper.h"
@@ -1919,9 +1917,6 @@ void Optimize::SetShowVisualizer(bool show) {
 bool Optimize::GetShowVisualizer() { return this->show_visualizer_; }
 
 //---------------------------------------------------------------------------
-void Optimize::SetMeshFiles(const std::vector<std::string>& mesh_files) { m_sampler->SetMeshFiles(mesh_files); }
-
-//---------------------------------------------------------------------------
 void Optimize::SetAttributeScales(const std::vector<double>& scales) { m_sampler->SetAttributeScales(scales); }
 
 //---------------------------------------------------------------------------
@@ -1933,7 +1928,7 @@ void Optimize::SetFieldAttributes(const std::vector<std::string>& field_attribut
 void Optimize::SetParticleFlags(std::vector<int> flags) { this->m_particle_flags = flags; }
 
 //---------------------------------------------------------------------------
-void Optimize::SetDomainFlags(std::vector<int> flags) {
+void Optimize::SetFixedDomains(std::vector<int> flags) {
   if (flags.size() > 0) {
     // Fixed domains are in use.
     this->m_fixed_domains_present = true;

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -22,9 +22,8 @@
 #include <itkMultiThreaderBase.h>
 
 // shapeworks
-#include <Project/Project.h>
-
 #include <Libs/Particles/ParticleFile.h>
+#include <Project/Project.h>
 
 #include "Libs/Optimize/Domain/VtkMeshWrapper.h"
 #include "Libs/Optimize/Utils/ObjectReader.h"
@@ -1903,10 +1902,18 @@ void Optimize::SetPointFiles(const std::vector<std::string>& point_files) {
 }
 
 //---------------------------------------------------------------------------
+void Optimize::SetInitialPoints(std::vector<std::vector<itk::Point<double> > > initial_points)
+{
+
+}
+
+//---------------------------------------------------------------------------
 int Optimize::GetNumShapes() { return this->m_num_shapes; }
 
+//---------------------------------------------------------------------------
 shapeworks::OptimizationVisualizer& Optimize::GetVisualizer() { return visualizer_; }
 
+//---------------------------------------------------------------------------
 void Optimize::SetShowVisualizer(bool show) {
   if (show && this->m_verbosity_level > 0) {
     std::cout << "WARNING Using the visualizer will increase run time!\n";
@@ -1914,6 +1921,7 @@ void Optimize::SetShowVisualizer(bool show) {
   this->show_visualizer_ = show;
 }
 
+//---------------------------------------------------------------------------
 bool Optimize::GetShowVisualizer() { return this->show_visualizer_; }
 
 //---------------------------------------------------------------------------
@@ -2014,8 +2022,8 @@ bool Optimize::LoadParameterFile(std::string filename) {
 }
 
 //---------------------------------------------------------------------------
-bool Optimize::SetUpOptimize(ProjectHandle projectFile) {
-  OptimizeParameters param(projectFile);
+bool Optimize::SetUpOptimize(ProjectHandle project) {
+  OptimizeParameters param(project);
   param.set_up_optimize(this);
   return true;
 }

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1887,8 +1887,8 @@ void Optimize::AddMesh(vtkSmartPointer<vtkPolyData> poly_data) {
 //---------------------------------------------------------------------------
 void Optimize::AddContour(vtkSmartPointer<vtkPolyData> poly_data) {
   m_sampler->AddContour(poly_data);
-  this->m_num_shapes++;
-  this->m_spacing = 0.5;
+  m_num_shapes++;
+  m_spacing = 0.5;
 }
 
 //---------------------------------------------------------------------------
@@ -1902,9 +1902,8 @@ void Optimize::SetPointFiles(const std::vector<std::string>& point_files) {
 }
 
 //---------------------------------------------------------------------------
-void Optimize::SetInitialPoints(std::vector<std::vector<itk::Point<double> > > initial_points)
-{
-
+void Optimize::SetInitialPoints(std::vector<std::vector<itk::Point<double>>> initial_points) {
+  m_sampler->SetInitialPoints(initial_points);
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -66,11 +66,13 @@ class Optimize {
   //! Load a parameter file
   bool LoadParameterFile(std::string filename);
 
-  bool SetUpOptimize(ProjectHandle projectFile);
+  //! Set up this Optimize object using a ShapeWorks project
+  bool SetUpOptimize(ProjectHandle project);
 
-  //! Set the Projects
+  //! Set the Project object
   void SetProject(std::shared_ptr<Project> project);
 
+  //! Set an iteration callback function to be called after each iteration
   void SetIterationCallbackFunction(const std::function<void(void)>& f) { this->iteration_callback_ = f; }
 
   //! Abort optimization
@@ -225,6 +227,9 @@ class Optimize {
   void SetFilenames(const std::vector<std::string>& filenames);
   //! Set starting point files (TODO: details)
   void SetPointFiles(const std::vector<std::string>& point_files);
+
+  //! Set initial particle positions (e.g. for fixed subjects)
+  void SetInitialPoints(std::vector<std::vector<itk::Point<double>>> initial_points);
 
   //! Get number of shapes
   int GetNumShapes();

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -19,10 +19,8 @@
 #include <Project/Project.h>
 
 #include "Libs/Optimize/Domain/DomainType.h"
-#include "Libs/Optimize/Domain/MeshWrapper.h"
 #include "Libs/Optimize/Function/VectorFunction.h"
 #include "Libs/Optimize/Utils/OptimizationVisualizer.h"
-#include "ParticleSystem.h"
 #include "ProcrustesRegistration.h"
 #include "Sampler.h"
 

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -228,8 +228,6 @@ class Optimize {
 
   //! Get number of shapes
   int GetNumShapes();
-  //! Set the mesh files (TODO: details)
-  void SetMeshFiles(const std::vector<std::string>& mesh_files);
   //! Set attribute scales (TODO: details)
   void SetAttributeScales(const std::vector<double>& scales);
 
@@ -239,7 +237,7 @@ class Optimize {
   //! Set Particle Flags (TODO: details)
   void SetParticleFlags(std::vector<int> flags);
   //! Set Domain Flags (TODO: details)
-  void SetDomainFlags(std::vector<int> flags);
+  void SetFixedDomains(std::vector<int> flags);
 
   //! Shared boundary settings
   void SetSharedBoundaryEnabled(bool enabled);

--- a/Libs/Optimize/OptimizeParameterFile.cpp
+++ b/Libs/Optimize/OptimizeParameterFile.cpp
@@ -698,26 +698,6 @@ bool OptimizeParameterFile::read_mesh_attributes(TiXmlHandle* docHandle, Optimiz
   std::string filename;
   int numShapes = optimize->GetNumShapes();
 
-  // load mesh files
-  elem = docHandle->FirstChild("mesh_files").Element();
-  if (elem) {
-    std::vector<std::string> meshFiles;
-    inputsBuffer.str(elem->GetText());
-    while (inputsBuffer >> filename) {
-      meshFiles.push_back(filename);
-    }
-    inputsBuffer.clear();
-    inputsBuffer.str("");
-
-    // read mesh files only if they are all present
-    if (meshFiles.size() != numShapes) {
-      std::cerr << "Error: incorrect number of mesh files!" << std::endl;
-      return false;
-    } else {
-      optimize->SetMeshFiles(meshFiles);
-    }
-  }
-
   std::vector<int> attributes_per_domain = optimize->GetAttributesPerDomain();
 
   // attributes
@@ -1048,7 +1028,7 @@ bool OptimizeParameterFile::read_flag_particles(TiXmlHandle* doc_handle, Optimiz
 
 //---------------------------------------------------------------------------
 bool OptimizeParameterFile::read_flag_domains(TiXmlHandle* doc_handle, Optimize* optimize) {
-  optimize->SetDomainFlags(this->read_int_list(doc_handle, "fixed_domains"));
+  optimize->SetFixedDomains(this->read_int_list(doc_handle, "fixed_domains"));
   return true;
 }
 

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -3,6 +3,7 @@
 #include <Image/Image.h>
 #include <Logging.h>
 #include <Mesh/MeshUtils.h>
+#include <Particles/ParticleFile.h>
 #include <Utils/StringUtils.h>
 
 #include <boost/algorithm/string.hpp>
@@ -13,6 +14,7 @@
 #include "Optimize.h"
 
 using namespace shapeworks;
+using namespace shapeworks::particles;
 
 namespace Keys {
 const std::string number_of_particles = "number_of_particles";
@@ -276,6 +278,68 @@ std::string OptimizeParameters::get_output_prefix() {
 }
 
 //---------------------------------------------------------------------------
+std::vector<std::vector<itk::Point<double>>> OptimizeParameters::get_initial_points() {
+  int domains_per_shape = project_->get_number_of_domains_per_subject();
+
+  auto subjects = project_->get_subjects();
+  std::vector<std::vector<itk::Point<double>>> domain_means;
+
+  for (int d = 0; d < domains_per_shape; d++) {
+    std::vector<itk::Point<double>> domain_sum;
+    int count = 0;
+    for (auto s : subjects) {
+      if (s->is_fixed()) {
+        count++;
+        // read the local points
+        auto filename = s->get_world_particle_filenames()[d];
+        auto particles = read_particles_as_vector(filename);
+        if (domain_sum.size() == 0) {
+          domain_sum = particles;
+        } else {
+          for (int p = 0; p < particles.size(); p++) {
+            domain_sum[p] += particles[p];
+          }
+        }
+      }
+    }
+    // now divide to find mean
+    for (int p = 0; p < domain_sum.size(); p++) {
+      domain_sum[p] /= count;
+    }
+
+    domain_means.push_back(domain_sum);
+  }
+
+  std::vector<std::vector<itk::Point<double>>> initial_points;
+  for (auto s : subjects) {
+    for (int d = 0; d < domains_per_shape; d++) {
+      if (s->is_fixed()) {
+        auto filename = s->get_local_particle_filenames()[d];
+        auto particles = read_particles_as_vector(filename);
+        initial_points.push_back(particles);
+      } else {
+        // get alignment transform and invert it
+        auto transforms = s->get_groomed_transforms();
+        vtkSmartPointer<vtkTransform> transform = ProjectUtils::convert_transform(transforms[d]);
+        transform->Inverse();
+
+        // transform each of the domain mean positions back to the local space of this new shape
+        std::vector<itk::Point<double>> points;
+        for (int i = 0; i < domain_means[d].size(); i++) {
+          itk::Point<double> point;
+          transform->TransformPoint(domain_means[d][i].GetDataPointer(), point.GetDataPointer());
+          points.push_back(point);
+        }
+
+        initial_points.push_back(points);
+      }
+    }
+  }
+
+  return initial_points;
+}
+
+//---------------------------------------------------------------------------
 int OptimizeParameters::get_geodesic_cache_multiplier() { return params_.get(Keys::geodesic_cache_multiplier, 0); }
 
 //---------------------------------------------------------------------------
@@ -442,6 +506,8 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
   if (project_->get_fixed_subjects_present()) {
     int idx = 0;
     std::vector<int> fixed_domains;
+
+    //    std::vector<std::vector<itk::Point<double>>> fixed_points;
     for (auto s : subjects) {
       if (s->is_fixed()) {
         for (int i = 0; i < domains_per_shape; i++) {
@@ -453,6 +519,7 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
     }
 
     optimize->SetFixedDomains(fixed_domains);
+    optimize->SetInitialPoints(get_initial_points());
   }
 
   for (auto s : subjects) {
@@ -559,8 +626,6 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
           Constraints constraint = constraints[domain_count];
           constraint.clipMesh(mesh);
         }
-
-        /// HERE!
 
         if (get_use_geodesics_to_landmarks()) {
           auto filenames = s->get_landmarks_filenames();

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -320,8 +320,13 @@ std::vector<std::vector<itk::Point<double>>> OptimizeParameters::get_initial_poi
       } else {
         // get alignment transform and invert it
         auto transforms = s->get_groomed_transforms();
-        vtkSmartPointer<vtkTransform> transform = ProjectUtils::convert_transform(transforms[d]);
-        transform->Inverse();
+
+        // create identify transform in case there are no groomed transforms
+        auto transform = vtkSmartPointer<vtkTransform>::New();
+        if (d < transforms.size()) {
+          transform = ProjectUtils::convert_transform(transforms[d]);
+          transform->Inverse();
+        }
 
         // transform each of the domain mean positions back to the local space of this new shape
         std::vector<itk::Point<double>> points;

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -439,6 +439,22 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
     throw std::invalid_argument("No subjects to optimize");
   }
 
+  if (project_->get_fixed_subjects_present()) {
+    int idx = 0;
+    std::vector<int> fixed_domains;
+    for (auto s : subjects) {
+      if (s->is_fixed()) {
+        for (int i = 0; i < domains_per_shape; i++) {
+          fixed_domains.push_back(idx++);
+        }
+      } else {
+        idx += domains_per_shape;
+      }
+    }
+
+    optimize->SetFixedDomains(fixed_domains);
+  }
+
   for (auto s : subjects) {
     if (abort_load_) {
       return false;
@@ -472,7 +488,7 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
         count++;
       }
     }
-    optimize->SetDomainFlags(domain_flags);
+    optimize->SetFixedDomains(domain_flags);
   }
 
   // add constraints

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -512,7 +512,6 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
     int idx = 0;
     std::vector<int> fixed_domains;
 
-    //    std::vector<std::vector<itk::Point<double>>> fixed_points;
     for (auto s : subjects) {
       if (s->is_fixed()) {
         for (int i = 0; i < domains_per_shape; i++) {
@@ -673,7 +672,7 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
         }
       } else {
         Image image(filename);
-        if (is_subject_fixed(s)) {
+        if (s->is_fixed()) {
           optimize->AddImage(nullptr);
         } else {
           optimize->AddImage(image);

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -291,7 +291,7 @@ std::vector<std::vector<itk::Point<double>>> OptimizeParameters::get_initial_poi
       if (s->is_fixed()) {
         count++;
         // read the local points
-        auto filename = s->get_world_particle_filenames()[d];
+        auto filename = s->get_local_particle_filenames()[d];
         auto particles = read_particles_as_vector(filename);
         if (domain_sum.size() == 0) {
           domain_sum = particles;
@@ -553,7 +553,7 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
     int count = 0;
     for (const auto& subject : subjects) {
       for (int i = 0; i < domains_per_shape; i++) {  // need one flag for each domain
-        if (is_subject_fixed(subject)) {
+        if (subject->is_fixed()) {
           domain_flags.push_back(count);
         }
         count++;

--- a/Libs/Optimize/OptimizeParameters.h
+++ b/Libs/Optimize/OptimizeParameters.h
@@ -2,6 +2,8 @@
 
 #include <Project/Project.h>
 
+#include <itkPoint.h>
+
 #include <functional>
 
 namespace shapeworks {
@@ -130,6 +132,8 @@ class OptimizeParameters {
 
  private:
   std::string get_output_prefix();
+
+  std::vector<std::vector<itk::Point<double>>> get_initial_points();
 
   Parameters params_;
   ProjectHandle project_;

--- a/Libs/Optimize/ParticleSystem.cpp
+++ b/Libs/Optimize/ParticleSystem.cpp
@@ -41,7 +41,7 @@ void ParticleSystem::SetNumberOfDomains(unsigned int num) {
   m_Domains.resize(num);
   m_Transforms.resize(num);
   m_InverseTransforms.resize(num);
-  while (num >= m_PrefixTransforms.size()) {
+  while (num > m_PrefixTransforms.size()) {
     TransformType transform;
     transform.set_identity();
     m_PrefixTransforms.push_back(transform);
@@ -50,7 +50,7 @@ void ParticleSystem::SetNumberOfDomains(unsigned int num) {
   m_Positions.resize(num);
   m_IndexCounters.resize(num);
   m_Neighborhoods.resize(num);
-  while (num >= this->m_DomainFlags.size()) {
+  while (num > this->m_DomainFlags.size()) {
     m_DomainFlags.push_back(false);
   }
   this->Modified();
@@ -136,7 +136,7 @@ const ParticleSystem::PointType& ParticleSystem::AddPosition(const PointType& p,
   m_Positions[d]->operator[](m_IndexCounters[d]) = p;
 
   // Potentially modifies position!
-  if (m_DomainFlags[d] == false) {
+  if (m_DomainFlags[d] == false) {  // Not a fixed domain.  Fixed domains won't load the image
     const auto idx = m_IndexCounters[d];
     m_Domains[d]->ApplyConstraints(m_Positions[d]->operator[](idx), idx);
     m_Neighborhoods[d]->AddPosition(m_Positions[d]->operator[](idx), idx);
@@ -157,8 +157,7 @@ const ParticleSystem::PointType& ParticleSystem::AddPosition(const PointType& p,
   return m_Positions[d]->operator[](m_IndexCounters[d] - 1);
 }
 
-const ParticleSystem::PointType& ParticleSystem::SetPosition(const PointType& p, unsigned long int k,
-                                                                      unsigned int d) {
+const ParticleSystem::PointType& ParticleSystem::SetPosition(const PointType& p, unsigned long int k, unsigned int d) {
   if (m_FixedParticleFlags[d % m_DomainsPerShape][k] == false) {
     // Potentially modifies position!
     if (m_DomainFlags[d] == false) {

--- a/Libs/Optimize/ParticleSystem.cpp
+++ b/Libs/Optimize/ParticleSystem.cpp
@@ -132,17 +132,13 @@ void ParticleSystem::SetNeighborhood(unsigned int i, NeighborhoodType* N) {
   this->InvokeEvent(e);
 }
 
-const typename ParticleSystem::PointType& ParticleSystem::AddPosition(const PointType& p, unsigned int d) {
+const ParticleSystem::PointType& ParticleSystem::AddPosition(const PointType& p, unsigned int d) {
   m_Positions[d]->operator[](m_IndexCounters[d]) = p;
 
   // Potentially modifies position!
   if (m_DomainFlags[d] == false) {
-    // debugg
-    // std::cout << "d" << d << " before apply " << m_Positions[d]->operator[](m_IndexCounters[d]);
     const auto idx = m_IndexCounters[d];
     m_Domains[d]->ApplyConstraints(m_Positions[d]->operator[](idx), idx);
-    // debugg
-    // std::cout << " after apply " << m_Positions[d]->operator[](m_IndexCounters[d]) << std::endl;
     m_Neighborhoods[d]->AddPosition(m_Positions[d]->operator[](idx), idx);
   }
 
@@ -161,19 +157,13 @@ const typename ParticleSystem::PointType& ParticleSystem::AddPosition(const Poin
   return m_Positions[d]->operator[](m_IndexCounters[d] - 1);
 }
 
-const typename ParticleSystem::PointType& ParticleSystem::SetPosition(const PointType& p, unsigned long int k,
+const ParticleSystem::PointType& ParticleSystem::SetPosition(const PointType& p, unsigned long int k,
                                                                       unsigned int d) {
   if (m_FixedParticleFlags[d % m_DomainsPerShape][k] == false) {
     // Potentially modifies position!
     if (m_DomainFlags[d] == false) {
       m_Positions[d]->operator[](k) = p;
-
-      // Debuggg
-      // std::cout << "SynchronizePositions Apply constraints " << m_Positions[d]->operator[](k);
       m_Domains[d]->ApplyConstraints(m_Positions[d]->operator[](k), k);
-      // Debuggg
-      // std::cout << " updated " << m_Positions[d]->operator[](k) << std::endl;
-
       m_Neighborhoods[d]->SetPosition(m_Positions[d]->operator[](k), k);
     }
   }
@@ -190,7 +180,7 @@ const typename ParticleSystem::PointType& ParticleSystem::SetPosition(const Poin
 
 void ParticleSystem::AddPositionList(const std::vector<PointType>& p, unsigned int d) {
   // Traverse the list and add each point to the domain.
-  for (typename std::vector<PointType>::const_iterator it = p.begin(); it != p.end(); it++) {
+  for (auto it = p.begin(); it != p.end(); it++) {
     this->AddPosition(*it, d);
   }
 }
@@ -241,11 +231,10 @@ void ParticleSystem::AdvancedAllParticleSplitting(double epsilon, unsigned int d
 
   // Only runs if domains were successfully retrieved
   if (lists.size() > 0) {
-
     // Initialize augmentend lagrangian variables (mus and possibly lambdas)
     for (size_t domain = dom_to_process; domain < num_doms; domain += domains_per_shape) {
       size_t num_particles = lists[0].size();
-      std::vector<double> zeros(num_particles*2, 0.0);
+      std::vector<double> zeros(num_particles * 2, 0.0);
       this->GetDomain(domain)->GetConstraints()->InitializeLagrangianParameters(zeros);
     }
 

--- a/Libs/Optimize/Sampler.cpp
+++ b/Libs/Optimize/Sampler.cpp
@@ -19,7 +19,6 @@ Sampler::Sampler() {
   m_Optimizer = OptimizerType::New();
 
   m_PointsFiles.push_back("");
-  m_MeshFiles.push_back("");
 
   m_LinkingFunction = DualVectorFunction::New();
   m_EnsembleEntropyFunction = LegacyCorrespondenceFunction::New();

--- a/Libs/Optimize/Sampler.cpp
+++ b/Libs/Optimize/Sampler.cpp
@@ -49,6 +49,7 @@ Sampler::Sampler() {
   m_CorrespondenceMode = shapeworks::CorrespondenceMode::EnsembleEntropy;
 }
 
+//---------------------------------------------------------------------------
 void Sampler::AllocateDataCaches() {
   // Set up the various data caches that the optimization functions will use.
   m_Sigma1Cache = GenericContainerArray<double>::New();
@@ -65,6 +66,7 @@ void Sampler::AllocateDataCaches() {
   m_ParticleSystem->RegisterObserver(m_MeanCurvatureCache);
 }
 
+//---------------------------------------------------------------------------
 void Sampler::AllocateDomainsAndNeighborhoods() {
   // Allocate all the necessary domains and neighborhoods. This must be done
   // *after* registering the attributes to the particle system since some of
@@ -179,8 +181,7 @@ void Sampler::InitializeOptimizationFunctions() {
   m_GeneralShapeGradMatrix->Initialize();
 }
 
-void Sampler::GenerateData() {}
-
+//---------------------------------------------------------------------------
 void Sampler::Execute() {
   if (this->GetInitialized() == false) {
     this->AllocateDataCaches();
@@ -196,6 +197,7 @@ void Sampler::Execute() {
     this->GetOptimizer()->SetParticleSystem(m_ParticleSystem);
     this->ReadTransforms();
     this->ReadPointsFiles();
+    initialize_initial_positions();
     this->InitializeOptimizationFunctions();
 
     this->SetInitialized(true);
@@ -207,6 +209,7 @@ void Sampler::Execute() {
   this->GetOptimizer()->StartOptimization();
 }
 
+//---------------------------------------------------------------------------
 Sampler::CuttingPlaneList Sampler::ComputeCuttingPlanes() {
   CuttingPlaneList planes;
   for (size_t i = 0; i < m_CuttingPlanes.size(); i++) {
@@ -224,7 +227,9 @@ Sampler::CuttingPlaneList Sampler::ComputeCuttingPlanes() {
   return planes;
 }
 
-Eigen::Vector3d Sampler::ComputePlaneNormal(const vnl_vector<double> &a, const vnl_vector<double> &b, const vnl_vector<double> &c) {
+//---------------------------------------------------------------------------
+Eigen::Vector3d Sampler::ComputePlaneNormal(const vnl_vector<double>& a, const vnl_vector<double>& b,
+                                            const vnl_vector<double>& c) {
   // See http://mathworld.wolfram.com/Plane.html, for example
   vnl_vector<double> q;
   q = vnl_cross_3d((b - a), (c - a));
@@ -402,7 +407,7 @@ void Sampler::AddImage(ImageType::Pointer image, double narrow_band, std::string
     double narrow_band_world = image->GetSpacing().GetVnlVector().max_value() * narrow_band;
     domain->SetImage(image, narrow_band_world);
 
-            // Adding meshes for FFCs
+    // Adding meshes for FFCs
     vtkSmartPointer<vtkPolyData> mesh = Image(image).toMesh(0.0).getVTKMesh();
     this->m_meshes.push_back(mesh);
   }
@@ -418,7 +423,7 @@ bool Sampler::initialize_ffcs(size_t dom) {
     std::cout << "dom " << dom << " point count " << mesh->numPoints() << " faces " << mesh->numFaces() << std::endl;
 
   if (m_FFCs[dom].isSet()) {
-    this->m_DomainList[dom]->GetConstraints()->addFreeFormConstraint(mesh);
+    m_DomainList[dom]->GetConstraints()->addFreeFormConstraint(mesh);
     m_FFCs[dom].computeGradientFields(mesh);
   }
 

--- a/Libs/Optimize/Sampler.h
+++ b/Libs/Optimize/Sampler.h
@@ -98,18 +98,6 @@ class Sampler {
 
   void SetPointsFile(const std::string& s) { this->SetPointsFile(0, s); }
 
-  /**Optionally provide a filename for a mesh with geodesic distances.*/
-  void SetMeshFile(unsigned int i, const std::string& s) {
-    if (m_MeshFiles.size() < i + 1) {
-      m_MeshFiles.resize(i + 1);
-    }
-    m_MeshFiles[i] = s;
-  }
-
-  void SetMeshFile(const std::string& s) { this->SetMeshFile(0, s); }
-
-  void SetMeshFiles(const std::vector<std::string>& s) { m_MeshFiles = s; }
-
   void AddImage(ImageType::Pointer image, double narrow_band, std::string name = "");
 
   void ApplyConstraintsToZeroCrossing() {
@@ -432,10 +420,6 @@ class Sampler {
   void operator=(const Sampler&);  // purposely not implemented
 
   std::vector<std::string> m_PointsFiles;
-  std::vector<std::string> m_MeshFiles;
-  std::vector<std::string> m_FeaMeshFiles;
-  std::vector<std::string> m_FeaGradFiles;
-  std::vector<std::string> m_FidsFiles;
   std::vector<int> m_AttributesPerDomain;
   int m_DomainsPerShape;
   double m_Spacing{0};

--- a/Libs/Optimize/Sampler.h
+++ b/Libs/Optimize/Sampler.h
@@ -289,8 +289,7 @@ class Sampler {
 
   void SetMeshFFCMode(bool mesh_ffc_mode) { m_meshFFCMode = mesh_ffc_mode; }
 
- protected:
-  void GenerateData();
+ private:
 
   bool GetInitialized() { return this->m_Initialized; }
 

--- a/Libs/Particles/ParticleFile.cpp
+++ b/Libs/Particles/ParticleFile.cpp
@@ -6,6 +6,8 @@
 #include <vtkPolyDataWriter.h>
 #include <vtkSmartPointer.h>
 
+#include <StringUtils.h>
+
 #include <fstream>
 
 namespace shapeworks::particles {
@@ -54,7 +56,7 @@ static Eigen::VectorXd read_vtk_particles(std::string filename) {
 
 //---------------------------------------------------------------------------
 Eigen::VectorXd read_particles(std::string filename) {
-  if (filename.substr(filename.size() - 4) == ".vtk") {
+  if (StringUtils::hasSuffix(filename, ".vtk")) {
     return read_vtk_particles(filename);
   }
 
@@ -92,7 +94,7 @@ Eigen::VectorXd read_particles(std::string filename) {
 
 //---------------------------------------------------------------------------
 void write_particles(std::string filename, const Eigen::VectorXd& points) {
-  if (filename.substr(filename.size() - 4) == ".vtk") {
+  if (StringUtils::hasSuffix(filename, ".vtk")) {
     write_vtk_particles(filename, points);
     return;
   }

--- a/Libs/Particles/ParticleShapeStatistics.cpp
+++ b/Libs/Particles/ParticleShapeStatistics.cpp
@@ -391,9 +391,6 @@ int ParticleShapeStatistics::ReadPointFiles(const std::string& s) {
     }
   }
 
-  std::cerr << "group id size = " << m_groupIDs.size() << "\n";
-  std::cerr << "numSamples = " << m_numSamples << "\n";
-
   // If there are no group IDs, make up some bogus ones
   if (m_groupIDs.size() != m_numSamples) {
     if (m_groupIDs.size() > 0) {

--- a/Libs/Project/Project.cpp
+++ b/Libs/Project/Project.cpp
@@ -315,6 +315,17 @@ bool Project::get_particles_present() const { return particles_present_; }
 bool Project::get_images_present() { return images_present_; }
 
 //---------------------------------------------------------------------------
+bool Project::get_fixed_subjects_present() {
+  // return if any subjects are fixed
+  for (auto& subject : subjects_) {
+    if (subject->is_fixed()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+//---------------------------------------------------------------------------
 Parameters Project::get_parameters(const std::string& name, std::string domain_name) {
   Parameters params;
   if (parameters_.find(name) == parameters_.end()) {

--- a/Libs/Project/Project.h
+++ b/Libs/Project/Project.h
@@ -91,6 +91,9 @@ class Project {
   //! Return if images are present (e.g. CT/MRI)
   bool get_images_present();
 
+  //! Return if there are fixed subjects present
+  bool get_fixed_subjects_present();
+
   //! Get feature names
   std::vector<std::string> get_feature_names();
 

--- a/Libs/Project/ProjectReader.cpp
+++ b/Libs/Project/ProjectReader.cpp
@@ -62,6 +62,9 @@ void ProjectReader::load_subjects(StringMapList list) {
     if (contains(item, "name")) {
       name = item["name"];
     }
+    if (contains(item, "fixed")) {
+      subject->set_fixed(Variant(item["fixed"]));
+    }
     if (name == "") {
       if (subject->get_original_filenames().size() != 0) {
         name = StringUtils::getBaseFilenameWithoutExtension(subject->get_original_filenames()[0]);

--- a/Libs/Project/ProjectUtils.cpp
+++ b/Libs/Project/ProjectUtils.cpp
@@ -183,6 +183,7 @@ StringMap ProjectUtils::get_value_map(std::vector<std::string> prefixes, StringM
 //---------------------------------------------------------------------------
 StringMap ProjectUtils::get_extra_columns(StringMap key_map) {
   StringList prefixes = {"name",
+                         "fixed",
                          SEGMENTATION_PREFIX,
                          SHAPE_PREFIX,
                          MESH_PREFIX,
@@ -280,7 +281,7 @@ static void assign_keys(StringMap& j, std::vector<std::string> prefixes, std::ve
   auto prefix = prefixes[0];
   if (filenames.size() != domains.size()) {
     throw std::invalid_argument(prefix + " filenames and number of domains mismatch (" +
-                             std::to_string(filenames.size()) + " vs " + std::to_string(domains.size()) + ")");
+                                std::to_string(filenames.size()) + " vs " + std::to_string(domains.size()) + ")");
   }
   for (int i = 0; i < domains.size(); i++) {
     if (prefixes.size() == domains.size()) {
@@ -300,7 +301,7 @@ static void assign_transforms(StringMap& j, std::string prefix, std::vector<std:
   }
   if (transforms.size() != domains.size() && transforms.size() != domains.size() + 1) {
     throw std::invalid_argument(prefix + " filenames and number of domains mismatch (" +
-                             std::to_string(transforms.size()) + " vs " + std::to_string(domains.size()) + ")");
+                                std::to_string(transforms.size()) + " vs " + std::to_string(domains.size()) + ")");
   }
   for (int i = 0; i < transforms.size(); i++) {
     std::string key = prefix + "_";
@@ -319,6 +320,9 @@ ProjectUtils::StringMap ProjectUtils::convert_subject_to_map(Project* project, S
 
   StringMap j;
   j["name"] = subject->get_display_name();
+  if (project->get_fixed_subjects_present()) {
+    j["fixed"] = subject->is_fixed() ? "true" : "false";
+  }
 
   auto original_prefixes = ProjectUtils::convert_domain_types(project->get_original_domain_types());
   auto groomed_prefixes = ProjectUtils::convert_groomed_domain_types(project->get_groomed_domain_types());

--- a/Libs/Project/Subject.cpp
+++ b/Libs/Project/Subject.cpp
@@ -88,6 +88,12 @@ std::string Subject::get_display_name() { return display_name_; }
 void Subject::set_display_name(std::string display_name) { display_name_ = display_name; }
 
 //---------------------------------------------------------------------------
+bool Subject::is_fixed() { return fixed_; }
+
+//---------------------------------------------------------------------------
+void Subject::set_fixed(bool fixed) { fixed_ = fixed; }
+
+//---------------------------------------------------------------------------
 void Subject::set_local_particle_filenames(StringList filenames) { local_particle_filenames_ = filenames; }
 
 //---------------------------------------------------------------------------

--- a/Libs/Project/Subject.h
+++ b/Libs/Project/Subject.h
@@ -97,10 +97,16 @@ class Subject {
   //! Set the display name
   void set_display_name(std::string display_name);
 
+  //! Get if this subject is fixed or not
+  bool is_fixed();
+  //! Set if this subject is fixed or not
+  void set_fixed(bool fixed);
+
  private:
   int number_of_domains_ = 0;
 
   std::string display_name_;
+  bool fixed_ = false;
   StringList original_filenames_;
   StringList groomed_filenames_;
   StringList local_particle_filenames_;

--- a/Libs/Project/Variant.cpp
+++ b/Libs/Project/Variant.cpp
@@ -11,7 +11,7 @@ Variant::operator std::string() const { return str_; }
 
 //---------------------------------------------------------------------------
 Variant::operator bool() const {
-  // first try to read as the word 'true' or 'false', otherwise 0 or 1
+  // first try to read as the word 'yes', 'no', 'true' or 'false', otherwise 0 or 1
   std::string str_lower(str_);
   if (str_ == "yes") {
     return true;

--- a/Libs/Project/Variant.cpp
+++ b/Libs/Project/Variant.cpp
@@ -13,6 +13,11 @@ Variant::operator std::string() const { return str_; }
 Variant::operator bool() const {
   // first try to read as the word 'true' or 'false', otherwise 0 or 1
   std::string str_lower(str_);
+  if (str_ == "yes") {
+    return true;
+  } else if (str_ == "no") {
+    return false;
+  }
   std::transform(str_.begin(), str_.end(), str_lower.begin(), [](unsigned char c) { return std::tolower(c); });
   bool t = (valid_ && (std::istringstream(str_lower) >> std::boolalpha >> t)) ? t : false;
   if (!t) {

--- a/Studio/Analysis/AnalysisTool.cpp
+++ b/Studio/Analysis/AnalysisTool.cpp
@@ -444,6 +444,9 @@ bool AnalysisTool::compute_stats() {
   number_of_particles_ar.resize(dps);
   bool flag_get_num_part = false;
   for (auto& shape : session_->get_shapes()) {
+    if (shape->get_global_correspondence_points().size() == 0) {
+      continue; // skip any that don't have particles
+    }
     if (groups_enabled) {
       auto value = shape->get_subject()->get_group_value(group_set);
       if (value == left_group) {

--- a/Studio/Data/DataTool.cpp
+++ b/Studio/Data/DataTool.cpp
@@ -7,11 +7,15 @@
 #include <Shape.h>
 #include <StudioMesh.h>
 #include <ui_DataTool.h>
+#include <vtkPointData.h>
+#include <vtkTransformPolyDataFilter.h>
 
 #include <QDebug>
 #include <QMessageBox>
 #include <QThread>
 #include <iostream>
+
+#include "qt/QtWidgets/qmenu.h"
 
 #ifdef __APPLE__
 static QString click_message = "⌘+click";
@@ -58,11 +62,11 @@ DataTool::DataTool(Preferences& prefs) : preferences_(prefs) {
 
   // start with these off
   ui_->landmarks_open_button->toggle();
-  ui_->constraints_open_button->toggle();
+  // ui_->constraints_open_button->toggle();
   ui_->notes_open_button->toggle();
 
   // table on
-  // ui_->table_open_button->toggle();
+  ui_->table_open_button->toggle();
 
   landmark_table_model_ = std::make_shared<LandmarkTableModel>(this);
   connect(ui_->new_landmark_button, &QPushButton::clicked, landmark_table_model_.get(),
@@ -76,6 +80,9 @@ DataTool::DataTool(Preferences& prefs) : preferences_(prefs) {
           &LandmarkTableModel::handle_double_click);
   connect(ui_->landmark_table->horizontalHeader(), &QHeaderView::sectionClicked, landmark_table_model_.get(),
           &LandmarkTableModel::handle_header_click);
+
+  // handle right click on constraints QTableWidget
+  connect(ui_->ffc_table_, &QTableView::customContextMenuRequested, this, &DataTool::constraints_table_right_click);
 
   auto delegate = new LandmarkItemDelegate(ui_->landmark_table);
   delegate->set_model(landmark_table_model_);
@@ -437,6 +444,91 @@ void DataTool::handle_constraints_mode_changed() {
   if (ui_->landmarks_open_button->isChecked() && ui_->constraints_open_button->isChecked()) {
     ui_->landmarks_open_button->setChecked(false);
   }
+}
+
+//---------------------------------------------------------------------------
+void DataTool::constraints_table_right_click(const QPoint& point) {
+  // get the item at the position
+  auto item = ui_->ffc_table_->itemAt(point);
+  int row = ui_->ffc_table_->row(item);
+  ui_->ffc_table_->selectRow(row);
+
+  if (!item) {
+    return;
+  }
+
+  QMenu menu(this);
+  QAction* copy_action = new QAction("Copy constraint to other shapes", this);
+  connect(copy_action, &QAction::triggered, this, &DataTool::copy_ffc_clicked);
+  menu.addAction(copy_action);
+  menu.exec(QCursor::pos());
+}
+
+//---------------------------------------------------------------------------
+void DataTool::copy_ffc_clicked() {
+  // get the selected row
+  QModelIndexList list = ui_->ffc_table_->selectionModel()->selectedRows();
+  if (list.size() < 1) {
+    return;
+  }
+  int shape_id = list[0].row();
+
+  // for each domain, copy the constraints from the selected shape to all other shapes
+  auto shapes = session_->get_shapes();
+  auto domain_names = session_->get_project()->get_domain_names();
+
+  // get current display mode
+  auto display_mode = session_->get_display_mode();
+
+  for (int d = 0; d < domain_names.size(); d++) {
+    auto constraints = shapes[shape_id]->get_constraints(d);
+    auto ffc = constraints.getFreeformConstraint();
+
+    // transform from source shape to common space
+    auto base_transform = shapes[shape_id]->get_transform(d);
+
+    for (int i = 0; i < shapes.size(); i++) {
+      if (i == shape_id) {
+        continue;
+      }
+
+      // transform from common space to destination space
+      auto inverse = shapes[i]->get_inverse_transform(d);
+
+      // get the polydata, transform and set to the new ffc
+      auto ffc_poly_data = ffc.getInoutPolyData();
+
+      // apply vtk transforms to poly data
+      auto transform_filter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+      transform_filter->SetInputData(ffc_poly_data);
+      transform_filter->SetTransform(base_transform);
+      transform_filter->Update();
+      ffc_poly_data = transform_filter->GetOutput();
+      transform_filter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+      transform_filter->SetInputData(ffc_poly_data);
+      transform_filter->SetTransform(inverse);
+      transform_filter->Update();
+      ffc_poly_data = transform_filter->GetOutput();
+
+      // apply the new ffc to the destination shape
+      auto meshes = shapes[i]->get_meshes(display_mode, true);
+      MeshHandle mesh = meshes.meshes()[d];
+      auto poly_data = mesh->get_poly_data();
+
+      // create a new FreeFormConstraint with the transformed source definition
+      FreeFormConstraint new_ffc;
+      new_ffc.setInoutPolyData(ffc_poly_data);
+      new_ffc.applyToPolyData(poly_data);
+
+      // store the new ffc
+      auto& this_ffc = shapes[i]->get_constraints(d).getFreeformConstraint();
+      this_ffc.setDefinition(poly_data);
+      this_ffc.setInoutPolyData(poly_data);
+      this_ffc.setPainted(true);
+    }
+  }
+  session_->trigger_ffc_changed();
+  session_->trigger_repaint();
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Data/DataTool.cpp
+++ b/Studio/Data/DataTool.cpp
@@ -13,9 +13,9 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <QThread>
+#include <QMenu>
 #include <iostream>
 
-#include "qt/QtWidgets/qmenu.h"
 
 #ifdef __APPLE__
 static QString click_message = "⌘+click";

--- a/Studio/Data/DataTool.cpp
+++ b/Studio/Data/DataTool.cpp
@@ -62,11 +62,11 @@ DataTool::DataTool(Preferences& prefs) : preferences_(prefs) {
 
   // start with these off
   ui_->landmarks_open_button->toggle();
-  // ui_->constraints_open_button->toggle();
+  ui_->constraints_open_button->toggle();
   ui_->notes_open_button->toggle();
 
   // table on
-  ui_->table_open_button->toggle();
+  //ui_->table_open_button->toggle();
 
   landmark_table_model_ = std::make_shared<LandmarkTableModel>(this);
   connect(ui_->new_landmark_button, &QPushButton::clicked, landmark_table_model_.get(),

--- a/Studio/Data/DataTool.h
+++ b/Studio/Data/DataTool.h
@@ -64,6 +64,8 @@ class DataTool : public QWidget {
   void handle_landmark_mode_changed();
   void handle_constraints_mode_changed();
 
+  void constraints_table_right_click(const QPoint &point);
+  void copy_ffc_clicked();
 
  Q_SIGNALS:
   void import_button_clicked();

--- a/Studio/Data/DataTool.ui
+++ b/Studio/Data/DataTool.ui
@@ -906,6 +906,9 @@ QWidget#specificity_panel {
             </item>
             <item row="1" column="0" colspan="2">
              <widget class="QTableWidget" name="ffc_table_">
+              <property name="contextMenuPolicy">
+               <enum>Qt::CustomContextMenu</enum>
+              </property>
               <property name="alternatingRowColors">
                <bool>true</bool>
               </property>

--- a/Studio/Data/Session.cpp
+++ b/Studio/Data/Session.cpp
@@ -27,15 +27,15 @@
 #include <ExcelProjectWriter.h>
 #include <JsonProjectReader.h>
 #include <JsonProjectWriter.h>
-#include <Project/Project.h>
 #include <Logging.h>
 #include <MeshManager.h>
+#include <Project/Project.h>
 #include <Shape.h>
 #include <Utils/AnalysisUtils.h>
 #include <Utils/StudioUtils.h>
 #include <Visualization/Visualizer.h>
-#include "ExternalLibs/tinyxml/tinyxml.h"
 
+#include "ExternalLibs/tinyxml/tinyxml.h"
 
 namespace shapeworks {
 
@@ -437,7 +437,6 @@ bool Session::load_xl_project(QString filename) {
       break;
     }
     progress.setValue(progress.value() + 1);
-
   }
 
   groups_available_ = project_->get_group_names().size() > 0;
@@ -446,9 +445,7 @@ bool Session::load_xl_project(QString filename) {
 }
 
 //---------------------------------------------------------------------------
-void Session::set_project_path(QString relative_path) {
-  project_->set_project_path(relative_path.toStdString());
-}
+void Session::set_project_path(QString relative_path) { project_->set_project_path(relative_path.toStdString()); }
 
 //---------------------------------------------------------------------------
 std::shared_ptr<Project> Session::get_project() { return project_; }
@@ -690,10 +687,10 @@ void Session::remove_shapes(QList<int> list) {
     shapes_.erase(shapes_.begin() + i);
   }
 
-  project_->get_subjects();
   renumber_shapes();
   project_->update_subjects();
   Q_EMIT data_changed();
+  Q_EMIT update_display();
 }
 
 //---------------------------------------------------------------------------
@@ -1163,7 +1160,6 @@ void Session::trigger_repaint() { Q_EMIT repaint(); }
 
 //---------------------------------------------------------------------------
 void Session::trigger_reinsert_shapes() { Q_EMIT reinsert_shapes(); }
-
 
 //---------------------------------------------------------------------------
 void Session::set_display_mode(DisplayMode mode) {

--- a/Studio/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/Interface/ShapeWorksStudioApp.cpp
@@ -1216,9 +1216,11 @@ void ShapeWorksStudioApp::handle_reconstruction_complete() {
 
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::handle_groom_start() {
-  // clear out old points
-  session_->clear_particles();
-  ui_->action_analysis_mode->setEnabled(false);
+  // clear out old points (unless fixed subjects)
+  if (!session_->get_project()->get_fixed_subjects_present()) {
+    session_->clear_particles();
+    ui_->action_analysis_mode->setEnabled(false);
+  }
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/Interface/ShapeWorksStudioApp.cpp
@@ -2035,7 +2035,18 @@ bool ShapeWorksStudioApp::set_feature_map(std::string feature_map) {
 }
 
 //---------------------------------------------------------------------------
-std::string ShapeWorksStudioApp::get_feature_map() { return session_->parameters().get("feature_map", ""); }
+std::string ShapeWorksStudioApp::get_feature_map() {
+  std::string feature_map = session_->parameters().get("feature_map", "");
+
+  // confirm that this is a valid feature map
+  auto feature_maps = session_->get_project()->get_feature_names();
+  for (const std::string& feature : feature_maps) {
+    if (feature_map == feature) {
+      return feature_map;
+    }
+  }
+  return "";
+}
 
 //---------------------------------------------------------------------------
 bool ShapeWorksStudioApp::get_feature_uniform_scale() {

--- a/Studio/Optimize/OptimizeTool.cpp
+++ b/Studio/Optimize/OptimizeTool.cpp
@@ -144,6 +144,8 @@ void OptimizeTool::handle_optimize_complete() {
   telemetry_.record_event("optimize", {{"duration_seconds", duration},
                                        {"num_particles", QVariant::fromValue(session_->get_num_particles())}});
 
+  session_->save_project(session_->get_filename());
+
   Q_EMIT optimize_complete();
   update_run_button();
 }

--- a/Studio/Utils/StudioUtils.cpp
+++ b/Studio/Utils/StudioUtils.cpp
@@ -1,12 +1,12 @@
 #include <Utils/StudioUtils.h>
-#include <vtkImageData.h>
-#include <vtkPolyLine.h>
-#include <vtkReverseSense.h>
-#include <vtkCoordinate.h>
-#include <vtkPolyDataMapper2D.h>
 #include <vtkActor2D.h>
+#include <vtkCoordinate.h>
+#include <vtkImageData.h>
+#include <vtkPolyDataMapper2D.h>
+#include <vtkPolyLine.h>
 #include <vtkProperty2D.h>
 #include <vtkRenderer.h>
+#include <vtkReverseSense.h>
 
 #include <QMessageBox>
 
@@ -104,10 +104,8 @@ void StudioUtils::add_viewport_border(vtkRenderer* renderer, double* color) {
   points->InsertPoint(2, 0, 0, 0);
   points->InsertPoint(3, 1, 0, 0);
 
-  // Create cells, and lines.
   vtkNew<vtkCellArray> cells;
   cells->Initialize();
-
   vtkNew<vtkPolyLine> lines;
 
   lines->GetPointIds()->SetNumberOfIds(5);
@@ -117,14 +115,12 @@ void StudioUtils::add_viewport_border(vtkRenderer* renderer, double* color) {
   lines->GetPointIds()->SetId(4, 0);
   cells->InsertNextCell(lines);
 
-  // Now make the polydata and display it.
   vtkNew<vtkPolyData> poly;
   poly->Initialize();
   poly->SetPoints(points);
   poly->SetLines(cells);
 
-  // Use normalized viewport coordinates since
-  // they are independent of window size.
+  // use normalized viewport coordinates since they are independent of window size
   vtkNew<vtkCoordinate> coordinate;
   coordinate->SetCoordinateSystemToNormalizedViewport();
 
@@ -135,9 +131,7 @@ void StudioUtils::add_viewport_border(vtkRenderer* renderer, double* color) {
   vtkNew<vtkActor2D> actor;
   actor->SetMapper(mapper);
   actor->GetProperty()->SetColor(color);
-  // Line width should be at least 2 to be visible at extremes.
-
-  actor->GetProperty()->SetLineWidth(4.0);  // Line Width
+  actor->GetProperty()->SetLineWidth(6.0);
 
   renderer->AddViewProp(actor);
 }

--- a/Studio/Utils/StudioUtils.cpp
+++ b/Studio/Utils/StudioUtils.cpp
@@ -1,6 +1,12 @@
 #include <Utils/StudioUtils.h>
 #include <vtkImageData.h>
+#include <vtkPolyLine.h>
 #include <vtkReverseSense.h>
+#include <vtkCoordinate.h>
+#include <vtkPolyDataMapper2D.h>
+#include <vtkActor2D.h>
+#include <vtkProperty2D.h>
+#include <vtkRenderer.h>
 
 #include <QMessageBox>
 
@@ -86,5 +92,53 @@ QString StudioUtils::get_platform_string() {
   platform = "linux";
 #endif
   return platform;
+}
+
+//---------------------------------------------------------------------------
+void StudioUtils::add_viewport_border(vtkRenderer* renderer, double* color) {
+  // points start at upper right and proceed anti-clockwise
+  vtkNew<vtkPoints> points;
+  points->SetNumberOfPoints(4);
+  points->InsertPoint(0, 1, 1, 0);
+  points->InsertPoint(1, 0, 1, 0);
+  points->InsertPoint(2, 0, 0, 0);
+  points->InsertPoint(3, 1, 0, 0);
+
+  // Create cells, and lines.
+  vtkNew<vtkCellArray> cells;
+  cells->Initialize();
+
+  vtkNew<vtkPolyLine> lines;
+
+  lines->GetPointIds()->SetNumberOfIds(5);
+  for (unsigned int i = 0; i < 4; ++i) {
+    lines->GetPointIds()->SetId(i, i);
+  }
+  lines->GetPointIds()->SetId(4, 0);
+  cells->InsertNextCell(lines);
+
+  // Now make the polydata and display it.
+  vtkNew<vtkPolyData> poly;
+  poly->Initialize();
+  poly->SetPoints(points);
+  poly->SetLines(cells);
+
+  // Use normalized viewport coordinates since
+  // they are independent of window size.
+  vtkNew<vtkCoordinate> coordinate;
+  coordinate->SetCoordinateSystemToNormalizedViewport();
+
+  vtkNew<vtkPolyDataMapper2D> mapper;
+  mapper->SetInputData(poly);
+  mapper->SetTransformCoordinate(coordinate);
+
+  vtkNew<vtkActor2D> actor;
+  actor->SetMapper(mapper);
+  actor->GetProperty()->SetColor(color);
+  // Line width should be at least 2 to be visible at extremes.
+
+  actor->GetProperty()->SetLineWidth(4.0);  // Line Width
+
+  renderer->AddViewProp(actor);
 }
 }  // namespace shapeworks

--- a/Studio/Utils/StudioUtils.h
+++ b/Studio/Utils/StudioUtils.h
@@ -10,6 +10,7 @@ class QWidget;
 #include <QStringList>
 
 class vtkImageData;
+class vtkRenderer;
 
 namespace shapeworks {
 
@@ -27,7 +28,11 @@ class StudioUtils {
   //! reverse a poly data
   static vtkSmartPointer<vtkPolyData> reverse_poly_data(vtkSmartPointer<vtkPolyData> poly_data);
 
+  //! return platform string
   static QString get_platform_string();
+
+  //! add a color border to a viewport
+  static void add_viewport_border(vtkRenderer* renderer, double* color);
 
 };
 

--- a/Studio/Visualization/Viewer.cpp
+++ b/Studio/Visualization/Viewer.cpp
@@ -638,7 +638,14 @@ void Viewer::display_shape(std::shared_ptr<Shape> shape) {
   corner_annotation_->SetText(3, (annotations[3]).c_str());
   corner_annotation_->GetTextProperty()->SetColor(0.50, 0.5, 0.5);
 
+
   renderer_->RemoveAllViewProps();
+
+  auto subject = shape->get_subject();
+  if (subject && subject->is_fixed()) {
+    double color[4] = {0.0, 0.0, 1.0, 1.0};
+    StudioUtils::add_viewport_border(renderer_, color);
+  }
 
   number_of_domains_ = session_->get_domains_per_shape();
   if (meshes_.valid()) {
@@ -704,8 +711,8 @@ void Viewer::display_shape(std::shared_ptr<Shape> shape) {
         auto compare_poly_data = compare_meshes_.meshes()[i]->get_poly_data();
 
         if (compare_settings.get_mean_shape_checked()) {
-          auto transform =
-              visualizer_->get_transform(shape_, compare_settings.get_display_mode(), visualizer_->get_alignment_domain(), i);
+          auto transform = visualizer_->get_transform(shape_, compare_settings.get_display_mode(),
+                                                      visualizer_->get_alignment_domain(), i);
 
           transform->Inverse();
           auto transform_filter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
@@ -1081,7 +1088,6 @@ void Viewer::insert_compare_meshes() {
       actor->SetUserTransform(identity);
     } else {
       actor->SetUserTransform(transform);
-
     }
     mapper->SetInputData(poly_data);
 


### PR DESCRIPTION
Resolve #1911 

* #1911 

This PR adds first class support for fixed domains in Studio.  Domains are marked fixed with the 'fixed' subject column.  They display with a blue border and are held constant for grooming and optimization.  For grooming, the fixed domains are used to find the reference mesh and the non-fixed domains are not.

Start:
<img width="1259" alt="image" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/32547075-abc3-447f-bb0e-ef60851051f5">

Groomed:
<img width="1259" alt="image" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/ba6a3fae-3665-4374-9af2-1c378da7b975">

Optimized:
<img width="1259" alt="image" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/cf83ddb5-72b2-4674-9932-9fdf10ef1c45">

