### PR TITLE
Global reference domain for offline analysis

### DIFF
--- a/Libs/Analyze/Analyze.cpp
+++ b/Libs/Analyze/Analyze.cpp
@@ -193,14 +193,17 @@ void Analyze::run_offline_analysis(std::string outfile, float range, float steps
   for (int d = 0; d < num_domains; d++) {
     std::string domain_id = std::to_string(d);
     auto mesh = meshes.meshes()[d];
-    std::string filename = "mean_shape_" + domain_id + ".vtk";
-    Mesh(mesh->get_poly_data()).write(filename);
-    mean_meshes.push_back(filename);
+    std::string vtk_filename = "mean_shape_" + domain_id + ".vtk";
+    auto filename = base / boost::filesystem::path(vtk_filename);
 
-    filename = "mean_shape_" + domain_id + ".pts";
+    Mesh(mesh->get_poly_data()).write(filename.string());
+    mean_meshes.push_back(vtk_filename);
+
+    std::string particle_filename = "mean_shape_" + domain_id + ".pts";
+    filename = base / boost::filesystem::path(particle_filename);
     auto local_particles = mean_shape->get_particles().get_local_particles(d);
-    Particles::save_particles_file(filename, local_particles);
-    mean_particles.push_back(filename);
+    Particles::save_particles_file(filename.string(), local_particles);
+    mean_particles.push_back(particle_filename);
   }
   json mean_meshes_item;
   mean_meshes_item["meshes"] = mean_meshes;

--- a/Libs/Analyze/Analyze.cpp
+++ b/Libs/Analyze/Analyze.cpp
@@ -387,6 +387,8 @@ bool Analyze::update_shapes() {
 
   SW_LOG("number of subjects: {}", num_subjects);
 
+  auto domain_names = project_->get_domain_names();
+
   for (int i = 0; i < num_subjects; i++) {
     auto shape = std::make_shared<Shape>();
     shape->set_mesh_manager(mesh_manager_);
@@ -421,6 +423,12 @@ bool Analyze::update_shapes() {
         landmark_definitions = project_->get_landmarks(domain_id);
       }
     }
+
+    // set reference domain
+    auto transform = shape->get_groomed_transform(domain_names.size());
+    shape->set_particle_transform(transform);
+    shape->set_alignment_type(AlignmentType::Global);
+
     shapes_.push_back(shape);
   }
 

--- a/Libs/Analyze/Analyze.h
+++ b/Libs/Analyze/Analyze.h
@@ -15,6 +15,13 @@ namespace shapeworks {
 
 class Analyze {
  public:
+
+  enum AlignmentType {
+    Global = -2,
+    Local = -1,
+  };
+
+
   Analyze(ProjectHandle project);
 
   /// Run offline analysis, saving results to outfile

--- a/Studio/Analysis/AnalysisTool.h
+++ b/Studio/Analysis/AnalysisTool.h
@@ -9,6 +9,7 @@
 
 // ShapeWorks
 #include <ParticleShapeStatistics.h>
+#include <Analyze/Analyze.h>
 
 // Studio
 #include <Analysis/ShapeEvaluationJob.h>
@@ -33,10 +34,8 @@ class AnalysisTool : public QWidget {
   Q_OBJECT;
 
  public:
-  enum AlignmentType {
-    Global = -2,
-    Local = -1,
-  };
+
+  using AlignmentType = Analyze::AlignmentType;
 
   enum GroupAnalysisType { None = 0, Pvalues = 1, NetworkAnalysis = 2, LDA = 3 };
 


### PR DESCRIPTION
This PR fixes the alignment reference domain in the offline analysis.  Previously, the computed shapes would overlap:

<img width="310" alt="Screen Shot 2023-10-21 at 12 30 14 AM" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/c09abd68-ff3a-4d61-b926-8443439a00b0">

Now we use the global alignment:

<img width="337" alt="Screen Shot 2023-10-21 at 12 37 36 AM" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/693e5526-4396-4389-8f44-c33b5264ae61">

This PR also fixes the output location of the mean shape and particles (source vs target)