### PR TITLE
Bug fix Mesh::interpolateFieldAtPoint() and add Python binding.

### DIFF
--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -1002,7 +1002,7 @@ double Mesh::interpolateFieldAtPoint(const std::string& field, const Point3& que
   Eigen::Vector3d values(this->getFieldValue(field, v1), this->getFieldValue(field, v2),
                          this->getFieldValue(field, v3));
 
-  return (bary * values.transpose()).mean();
+  return values[0] * bary[0] + values[1] * bary[1] + values[2] * bary[2];
 }
 
 Mesh& Mesh::applySubdivisionFilter(const SubdivisionType type, int subdivision) {

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1097,6 +1097,14 @@ PYBIND11_MODULE(shapeworks_py, m)
        "returns closest point id in this mesh to the given point in space",
        "point"_a)
 
+   .def("interpolateFieldAtPoint",
+       [](Mesh &mesh, const std::string& name, std::vector<double> p) -> decltype(auto) {
+         return mesh.interpolateFieldAtPoint(name, Point({p[0], p[1], p[2]}));
+       },
+       "Interpolate the feature at the location using barycentric coordinate",
+       "field"_a,
+       "point"_a)
+
   .def("geodesicDistance",
        static_cast<double (Mesh::*)(int,int) const>(&Mesh::geodesicDistance),
        //py::overload_cast_const<int, int>(&Mesh::geodesicDistance),

--- a/Testing/MeshTests/MeshTests.cpp
+++ b/Testing/MeshTests/MeshTests.cpp
@@ -808,3 +808,36 @@ TEST(MeshTests, thicknessTest) {
   Mesh baseline(std::string(TEST_DATA_DIR) + "/thickness/thickness.vtk");
   ASSERT_TRUE(thickness == baseline);
 }
+
+TEST(MeshTests, interpolateFieldAtPoint) {
+  
+  Eigen::MatrixXd points;
+  Eigen::MatrixXi faces;
+
+  points.resize(3, 3);
+  points.block<1, 3>(0, 0) = Eigen::Vector3d(-10, 0, 50);
+  points.block<1, 3>(1, 0) = Eigen::Vector3d(0, 10, 50);
+  points.block<1, 3>(2, 0) = Eigen::Vector3d(10, 0, 50);
+
+  faces.resize(1, 3);
+  faces(0) = 0;
+  faces(1) = 1;
+  faces(2) = 2;
+
+  Mesh mesh(points, faces);
+
+  auto values = vtkDoubleArray::New();
+  values->SetNumberOfValues(3);
+  values->SetValue(0, -100);
+  values->SetValue(1, 0);
+  values->SetValue(2, 100);
+
+  const std::string fieldName = "Test";
+  mesh.setField(fieldName, values, Mesh::Point);
+
+  ASSERT_DOUBLE_EQ(mesh.interpolateFieldAtPoint(fieldName, Point3({-10, 0, 50})), -100);
+  ASSERT_DOUBLE_EQ(mesh.interpolateFieldAtPoint(fieldName, Point3({0, 10, 50})), 0);
+  ASSERT_DOUBLE_EQ(mesh.interpolateFieldAtPoint(fieldName, Point3({10, 0, 50})), 100);
+  ASSERT_DOUBLE_EQ(mesh.interpolateFieldAtPoint(fieldName, Point3({0, 0, 50})), 0);
+}
+


### PR DESCRIPTION
 return (bary * values.transpose()).mean(); is the mean of the OUTER product so the values returned by interpolateFieldAtPoint() are wrong.

We could use (values.transpose()*bary)(0) but it is more clear using: values[0] * bary[0] + values[1] * bary[1] + values[2] * bary[2]; for the interpolation