### PR TITLE
#2218 scalar evaluation

### DIFF
--- a/Libs/Analyze/StudioMesh.cpp
+++ b/Libs/Analyze/StudioMesh.cpp
@@ -98,7 +98,7 @@ void StudioMesh::interpolate_scalars_to_mesh(std::string name, Eigen::VectorXd p
 
   if (num_points != scalar_values.size()) {
     std::cerr << "Warning, mismatch of points and scalar values (num_points = " << num_points
-              << ", scalar_values.size() = " << scalar_values.size() << std::endl;
+              << ", scalar_values.size() = " << scalar_values.size() << ")\n";
     return;
   }
 

--- a/Libs/Particles/ParticleSystemEvaluation.cpp
+++ b/Libs/Particles/ParticleSystemEvaluation.cpp
@@ -18,11 +18,6 @@ ParticleSystemEvaluation::ParticleSystemEvaluation(const std::vector<std::string
   const int VDimension = 3;
   assert(N > 0);
 
-  // TODO: We're using the existing particle file reader here. This is not ideal
-  //  since this particle reader loads into a std::vector, which subsequently
-  //  is copied to Eigen. Refactor it to load directly to Eigen. (This is not a
-  //  huge problem for now because the particle files are quite small)
-
   // Read the first file to find dimensions
   auto points0 = particles::read_particles_as_vector(paths_[0]);
   const int D = points0.size() * VDimension;

--- a/Libs/Particles/ParticleSystemEvaluation.cpp
+++ b/Libs/Particles/ParticleSystemEvaluation.cpp
@@ -7,13 +7,14 @@
 
 namespace shapeworks {
 
-ParticleSystemEvaluation::ParticleSystemEvaluation(const std::vector<std::string>& _paths) {
-  if (_paths.empty()) {
+//---------------------------------------------------------------------------
+ParticleSystemEvaluation::ParticleSystemEvaluation(const std::vector<std::string>& paths) {
+  if (paths.empty()) {
     throw std::runtime_error("No filenames passed to readParticleSystemEvaluation");
   }
 
-  this->paths = _paths;
-  const int N = paths.size();
+  paths_ = paths;
+  const int N = paths_.size();
   const int VDimension = 3;
   assert(N > 0);
 
@@ -23,34 +24,36 @@ ParticleSystemEvaluation::ParticleSystemEvaluation(const std::vector<std::string
   //  huge problem for now because the particle files are quite small)
 
   // Read the first file to find dimensions
-  auto points0 = particles::read_particles_as_vector(paths[0]);
+  auto points0 = particles::read_particles_as_vector(paths_[0]);
   const int D = points0.size() * VDimension;
 
-  P.resize(D, N);
-  P.col(0) = Eigen::Map<const Eigen::VectorXd>((double*)points0.data(), D);
+  matrix_.resize(D, N);
+  matrix_.col(0) = Eigen::Map<const Eigen::VectorXd>((double*)points0.data(), D);
 
   for (int i = 1; i < N; i++) {
-    auto points = particles::read_particles_as_vector(paths[i]);
+    auto points = particles::read_particles_as_vector(paths_[i]);
     int count = points.size() * VDimension;
     if (count != D) {
       throw std::runtime_error("ParticleSystemEvaluation files must have the same number of particles");
     }
-    P.col(i) = Eigen::Map<const Eigen::VectorXd>((double*)points.data(), D);
+    matrix_.col(i) = Eigen::Map<const Eigen::VectorXd>((double*)points.data(), D);
   }
 }
 
-ParticleSystemEvaluation::ParticleSystemEvaluation(const Eigen::MatrixXd& matrix) { this->P = matrix; }
+//---------------------------------------------------------------------------
+ParticleSystemEvaluation::ParticleSystemEvaluation(const Eigen::MatrixXd& matrix) { matrix_ = matrix; }
 
+//---------------------------------------------------------------------------
 bool ParticleSystemEvaluation::ExactCompare(const ParticleSystemEvaluation& other) const {
-  if (P.rows() != other.P.rows() || P.cols() != other.P.cols()) {
+  if (matrix_.rows() != other.matrix_.rows() || matrix_.cols() != other.matrix_.cols()) {
     std::cerr << "Rows/Columns mismatch\n";
     return false;
   }
   bool same = true;
-  for (int r = 0; r < P.rows(); r++) {
-    for (int c = 0; c < P.cols(); c++) {
-      if (!epsEqual(P(r, c), other.P(r, c), 0.001)) {
-        std::cerr << "(" << r << "," << c << "): " << P(r, c) << " vs " << other.P(r, c) << "\n";
+  for (int r = 0; r < matrix_.rows(); r++) {
+    for (int c = 0; c < matrix_.cols(); c++) {
+      if (!epsEqual(matrix_(r, c), other.matrix_(r, c), 0.001)) {
+        std::cerr << "(" << r << "," << c << "): " << matrix_(r, c) << " vs " << other.matrix_(r, c) << "\n";
         same = false;
       }
     }
@@ -58,6 +61,7 @@ bool ParticleSystemEvaluation::ExactCompare(const ParticleSystemEvaluation& othe
   return same;
 }
 
+//---------------------------------------------------------------------------
 bool ParticleSystemEvaluation::EvaluationCompare(const ParticleSystemEvaluation& other) const {
   auto compactness1 = ShapeEvaluation::ComputeFullCompactness(*this);
   auto compactness2 = ShapeEvaluation::ComputeFullCompactness(other);
@@ -113,9 +117,12 @@ bool ParticleSystemEvaluation::EvaluationCompare(const ParticleSystemEvaluation&
   return good;
 }
 
+//---------------------------------------------------------------------------
 bool ParticleSystemEvaluation::ReadParticleFile(std::string filename, Eigen::VectorXd& points) {
   points = particles::read_particles(filename);
   return true;
 }
+
+//---------------------------------------------------------------------------
 
 }  // namespace shapeworks

--- a/Libs/Particles/ParticleSystemEvaluation.h
+++ b/Libs/Particles/ParticleSystemEvaluation.h
@@ -12,15 +12,15 @@ class ParticleSystemEvaluation {
   // Initialize particle system from eigen matrix (rows=dimensions, cols=num_samples)
   ParticleSystemEvaluation(const Eigen::MatrixXd& matrix);
 
-  const Eigen::MatrixXd& Particles() const { return P; };
+  const Eigen::MatrixXd& Particles() const { return matrix_; };
 
-  const std::vector<std::string>& Paths() const { return paths; }
+  const std::vector<std::string>& Paths() const { return paths_; }
 
   //! Number of samples
-  int N() const { return P.cols(); }
+  int N() const { return matrix_.cols(); }
 
   //! Dimensions (e.g. x/y/z * number of particles)
-  int D() const { return P.rows(); }
+  int D() const { return matrix_.rows(); }
 
   bool ExactCompare(const ParticleSystemEvaluation& other) const;
 
@@ -34,7 +34,7 @@ class ParticleSystemEvaluation {
   ParticleSystemEvaluation() {
   }  // only for use by SharedCommandData since a ParticleSystem should always be valid, never "empty"
 
-  Eigen::MatrixXd P;
-  std::vector<std::string> paths;
+  Eigen::MatrixXd matrix_;
+  std::vector<std::string> paths_;
 };
 }  // namespace shapeworks

--- a/Libs/Particles/ShapeEvaluation.cpp
+++ b/Libs/Particles/ShapeEvaluation.cpp
@@ -2,8 +2,7 @@
 
 #include <Eigen/Core>
 #include <Eigen/SVD>
-#include <iostream>
-
+#include <fstream>
 #include "EvaluationUtil.h"
 
 typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> RowMajorMatrix;

--- a/Libs/Particles/ShapeEvaluation.h
+++ b/Libs/Particles/ShapeEvaluation.h
@@ -3,7 +3,6 @@
 #include <Eigen/Core>
 #include <string>
 
-#include "ParticleShapeStatistics.h"
 #include "ParticleSystemEvaluation.h"
 
 namespace shapeworks {

--- a/Studio/Analysis/AnalysisTool.h
+++ b/Studio/Analysis/AnalysisTool.h
@@ -197,6 +197,8 @@ class AnalysisTool : public QWidget {
   //! Compute the mean shape outside of the PCA in case we are using scalars only
   Eigen::VectorXd construct_mean_shape();
 
+  void handle_samples_predicted_scalar_options();
+
  Q_SIGNALS:
 
   void update_view();

--- a/Studio/Analysis/AnalysisTool.ui
+++ b/Studio/Analysis/AnalysisTool.ui
@@ -535,7 +535,7 @@ QWidget#particles_panel {
             <item row="3" column="0" colspan="2">
              <widget class="QTabWidget" name="tabWidget">
               <property name="currentIndex">
-               <number>2</number>
+               <number>1</number>
               </property>
               <widget class="QWidget" name="mean_tab">
                <attribute name="title">
@@ -1089,16 +1089,6 @@ QWidget#particles_panel {
                 <string>Samples</string>
                </attribute>
                <layout class="QGridLayout" name="gridLayout_4">
-                <item row="1" column="1">
-                 <widget class="QSpinBox" name="sampleSpinBox">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
-                  <property name="toolTip">
-                   <string>Sample selection</string>
-                  </property>
-                 </widget>
-                </item>
                 <item row="1" column="0">
                  <widget class="QRadioButton" name="singleSamplesRadio">
                   <property name="toolTip">
@@ -1106,6 +1096,19 @@ QWidget#particles_panel {
                   </property>
                   <property name="text">
                    <string>Single Sample:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="2" column="0" colspan="2">
+                 <widget class="QPushButton" name="medianButton">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
+                  <property name="toolTip">
+                   <string>Show median sample</string>
+                  </property>
+                  <property name="text">
+                   <string>Median</string>
                   </property>
                  </widget>
                 </item>
@@ -1122,18 +1125,61 @@ QWidget#particles_panel {
                   </property>
                  </widget>
                 </item>
-                <item row="2" column="0" colspan="2">
-                 <widget class="QPushButton" name="medianButton">
+                <item row="3" column="0" colspan="2">
+                 <widget class="QWidget" name="predict_diff_widget" native="true">
+                  <layout class="QGridLayout" name="gridLayout_28">
+                   <item row="0" column="0">
+                    <widget class="QCheckBox" name="show_difference_to_predicted_scalar">
+                     <property name="text">
+                      <string>Show difference to predicted scalar</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="1">
+                    <spacer name="horizontalSpacer_9">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QCheckBox" name="show_predicted_scalar">
+                     <property name="text">
+                      <string>Show predicted scalar</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item row="1" column="1">
+                 <widget class="QSpinBox" name="sampleSpinBox">
                   <property name="enabled">
                    <bool>false</bool>
                   </property>
                   <property name="toolTip">
-                   <string>Show median sample</string>
-                  </property>
-                  <property name="text">
-                   <string>Median</string>
+                   <string>Sample selection</string>
                   </property>
                  </widget>
+                </item>
+                <item row="4" column="0">
+                 <spacer name="verticalSpacer_3">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>40</height>
+                   </size>
+                  </property>
+                 </spacer>
                 </item>
                </layout>
               </widget>

--- a/Studio/Analysis/ShapeEvaluationJob.cpp
+++ b/Studio/Analysis/ShapeEvaluationJob.cpp
@@ -1,44 +1,38 @@
-
+#include "ShapeEvaluationJob.h"
 
 #include <Logging.h>
-#include "ShapeEvaluationJob.h"
+
 namespace shapeworks {
 
 //-----------------------------------------------------------------------------
 ShapeEvaluationJob::ShapeEvaluationJob(JobType job_type, ParticleShapeStatistics stats)
-  : job_type_(job_type), stats_(stats)
-{
-  qRegisterMetaType<shapeworks::ShapeEvaluationJob::JobType>(
-    "shapeworks::ShapeEvaluationWorker::JobType");
+    : job_type_(job_type), stats_(stats) {
+  qRegisterMetaType<shapeworks::ShapeEvaluationJob::JobType>("shapeworks::ShapeEvaluationWorker::JobType");
   qRegisterMetaType<Eigen::VectorXd>("Eigen::VectorXd");
 }
 
 //-----------------------------------------------------------------------------
-void ShapeEvaluationJob::run()
-{
+void ShapeEvaluationJob::run() {
   auto callback = std::bind(&ShapeEvaluationJob::receive_progress, this, std::placeholders::_1);
-  switch (this->job_type_) {
-  case JobType::CompactnessType:
-    Q_EMIT result_ready(this->job_type_, this->stats_.get_compactness(callback));
-    break;
-  case JobType::GeneralizationType:
-    Q_EMIT result_ready(this->job_type_, this->stats_.get_generalization(callback));
-    break;
-  case JobType::SpecificityType:
-    Q_EMIT result_ready(this->job_type_, this->stats_.get_specificity(callback));
-    break;
+  switch (job_type_) {
+    case JobType::CompactnessType:
+      Q_EMIT result_ready(job_type_, stats_.get_compactness(callback));
+      break;
+    case JobType::GeneralizationType:
+      Q_EMIT result_ready(job_type_, stats_.get_generalization(callback));
+      break;
+    case JobType::SpecificityType:
+      Q_EMIT result_ready(job_type_, stats_.get_specificity(callback));
+      break;
   }
 }
 
 //-----------------------------------------------------------------------------
-QString ShapeEvaluationJob::name()
-{
-  return "Shape Evaluation";
-}
+QString ShapeEvaluationJob::name() { return "Shape Evaluation"; }
 
 //-----------------------------------------------------------------------------
-void ShapeEvaluationJob::receive_progress(float progress)
-{
-  Q_EMIT report_progress(this->job_type_, progress);
-}
-}
+void ShapeEvaluationJob::receive_progress(float progress) { Q_EMIT report_progress(job_type_, progress); }
+
+//-----------------------------------------------------------------------------
+
+}  // namespace shapeworks

--- a/Studio/Analysis/ShapeEvaluationJob.h
+++ b/Studio/Analysis/ShapeEvaluationJob.h
@@ -1,20 +1,19 @@
 #pragma once
 
-#include <ParticleShapeStatistics.h>
-
 #include <Data/Worker.h>
 #include <Job/Job.h>
+#include <ParticleShapeStatistics.h>
 
 namespace shapeworks {
 
-class ShapeEvaluationJob : public Job
-{
+/**
+ * @brief The ShapeEvaluationJob class is a worker class that computes shape evaluation metrics of compactness,
+ * specificity, and generalization.  It runs asynchronously using the Job and Worker interfaces.
+ */
+class ShapeEvaluationJob : public Job {
   Q_OBJECT
-public:
-
-  enum class JobType {
-    CompactnessType, SpecificityType, GeneralizationType
-  };
+ public:
+  enum class JobType { CompactnessType, SpecificityType, GeneralizationType };
 
   ShapeEvaluationJob(JobType job_type, ParticleShapeStatistics stats);
 
@@ -22,19 +21,18 @@ public:
 
   QString name() override;
 
-Q_SIGNALS:
+ Q_SIGNALS:
 
   void report_progress(shapeworks::ShapeEvaluationJob::JobType job_type, float progress);
   void result_ready(shapeworks::ShapeEvaluationJob::JobType job_type, Eigen::VectorXd data);
 
-private:
-
+ private:
   void receive_progress(float progress);
 
   JobType job_type_;
   ParticleShapeStatistics stats_;
 };
-}
+}  // namespace shapeworks
 
 Q_DECLARE_METATYPE(Eigen::VectorXd);
 Q_DECLARE_METATYPE(shapeworks::ShapeEvaluationJob::JobType);

--- a/Studio/Data/Session.h
+++ b/Studio/Data/Session.h
@@ -285,6 +285,7 @@ class Session : public QObject, public QEnableSharedFromThis<Session> {
   void planes_changed();
   void ffc_changed();
   void update_display();
+  void feature_map_changed();
   void reset_stats();
   void new_mesh();
   void feature_range_changed();

--- a/Studio/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/Interface/ShapeWorksStudioApp.cpp
@@ -423,7 +423,7 @@ void ShapeWorksStudioApp::import_files(QStringList file_names) {
 
     if (first_load) {
       // On first load, we can check if there was an active scalar on loaded meshes
-      set_feature_map(session_->get_default_feature_map());
+      session_->set_feature_map(session_->get_default_feature_map());
     }
   } catch (std::runtime_error& e) {
     handle_error(e.what());
@@ -970,6 +970,7 @@ void ShapeWorksStudioApp::new_session() {
   connect(session_.data(), &Session::reset_stats, this, &ShapeWorksStudioApp::handle_reset_stats);
   connect(session_.data(), &Session::update_display, this, &ShapeWorksStudioApp::handle_display_setting_changed);
   connect(session_.data(), &Session::update_view_mode, this, &ShapeWorksStudioApp::update_view_mode);
+  connect(session_.data(), &Session::feature_map_changed, this, &ShapeWorksStudioApp::update_view_mode);
   connect(session_.data(), &Session::new_mesh, this, &ShapeWorksStudioApp::handle_new_mesh);
   connect(session_.data(), &Session::reinsert_shapes, this, [&]() { update_display(true); });
   connect(session_.data(), &Session::save, this, &ShapeWorksStudioApp::on_action_save_project_triggered);
@@ -1087,7 +1088,7 @@ void ShapeWorksStudioApp::update_view_mode() {
   ui_->view_mode_combobox->setCurrentText(QString::fromStdString(display_mode_to_string(view_mode)));
   update_view_combo();
 
-  auto feature_map = get_feature_map();
+  auto feature_map = session_->get_feature_map();
   ui_->features->setCurrentText(QString::fromStdString(feature_map));
 
   if (visualizer_) {
@@ -2041,7 +2042,7 @@ QString ShapeWorksStudioApp::get_mesh_file_filter() {
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::update_feature_map_selection(int index) {
   QString feature_map = ui_->features->itemText(index);
-  set_feature_map(feature_map.toStdString());
+  session_->set_feature_map(feature_map.toStdString());
 }
 
 //---------------------------------------------------------------------------
@@ -2063,30 +2064,6 @@ void ShapeWorksStudioApp::update_feature_map_scale() {
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::image_combo_changed(int index) {
   session_->set_image_name(ui_->image_combo_->itemText(index).toStdString());
-}
-
-//---------------------------------------------------------------------------
-bool ShapeWorksStudioApp::set_feature_map(std::string feature_map) {
-  if (feature_map != get_feature_map()) {
-    session_->set_feature_map(feature_map);
-    update_view_mode();
-    return true;
-  }
-  return false;
-}
-
-//---------------------------------------------------------------------------
-std::string ShapeWorksStudioApp::get_feature_map() {
-  std::string feature_map = session_->get_feature_map();
-
-  // confirm that this is a valid feature map
-  auto feature_maps = session_->get_project()->get_feature_names();
-  for (const std::string& feature : feature_maps) {
-    if (feature_map == feature) {
-      return feature_map;
-    }
-  }
-  return "";
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Interface/ShapeWorksStudioApp.h
+++ b/Studio/Interface/ShapeWorksStudioApp.h
@@ -195,9 +195,6 @@ class ShapeWorksStudioApp : public QMainWindow {
 
   void display_mode_shape();
 
-  bool set_feature_map(std::string feature_map);
-  std::string get_feature_map();
-
   bool get_feature_uniform_scale();
   void set_feature_uniform_scale(bool value);
 


### PR DESCRIPTION
This PR addresses part of #2218, adding the ability to show predicted scalars for samples and the difference to the true scalars.

<img width="1520" alt="image" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/ec9bd13c-cafd-47b3-b907-49e5dc17e14f">

<img width="1520" alt="image" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/b7decb88-50d5-4a25-8525-bc4ce4e9ea4d">

<img width="1520" alt="image" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/c31d2b7b-d96a-44d7-9ba8-ccac5433071d">

