### PR TITLE
Fix #2219 - Screenshot with transparent background shows transparent particles

### DIFF
--- a/Studio/Visualization/Visualizer.cpp
+++ b/Studio/Visualization/Visualizer.cpp
@@ -305,15 +305,16 @@ void Visualizer::update_lut() {
       }
     }
   } else {
+    glyph_lut_->ForceBuild();
     if (preferences_.get_particle_colors() == ParticleColors::ParticleColorsType::Distinct) {
       auto lut = ParticleColors::construct_distinct();
+
+      glyph_lut_->ForceBuild();
 
       // normal particle coloring mode
       for (int i = 0; i < num_points; i++) {
         glyph_lut_->SetTableValue(i, lut->GetTableValue(i % lut->GetNumberOfTableValues()));
       }
-    } else {
-      glyph_lut_->ForceBuild();
     }
   }
 


### PR DESCRIPTION
<img width="1240" alt="image" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/a42349ed-7fde-4676-8582-2d832ffc30ca">
