### PR TITLE
Fixes for #2230

### DIFF
--- a/Examples/Python/deep_ssm.py
+++ b/Examples/Python/deep_ssm.py
@@ -529,8 +529,11 @@ def Run_Pipeline(args):
                                                      planes=test_planes)
         print("Test mean mesh surface-to-surface distance: " + str(mean_dist))
 
+        DeepSSMUtils.process_test_predictions(project, config_file)
+        
         # If tiny test or verify, check results and exit
         check_results(args, mean_dist)
+
         open(status_dir + "step_12.txt", 'w').close()
 
     print("All steps complete")

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/run_utils.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/run_utils.py
@@ -500,7 +500,7 @@ def process_test_predictions(project, config_file):
     if not os.path.exists(world_predictions_dir):
         os.makedirs(world_predictions_dir)
 
-    reference_index = DeepSSMUtils.get_reference_index(project)
+    reference_index = sw.utils.get_reference_index(project)
     template_mesh = project_path + subjects[reference_index].get_groomed_filenames()[0]
     template_particles = project_path + subjects[reference_index].get_local_particle_filenames()[0]
 

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/train_viz.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/train_viz.py
@@ -38,13 +38,7 @@ def write_examples(pred_particles, true_particles, filenames, out_dir):
 
         # reshape pred to be 1D
         pred = pred.flatten()
-
-        # print type of pred
-        print(f"pred type: {type(pred)}")
-        print(f"pred shape: {pred.shape}")
-        print(f"scalars type: {type(scalars)}")
-        print(f"scalars shape: {scalars.shape}")
-
+        # interpolate scalars to mesh
         mesh.interpolate_scalars_to_mesh("deepssm_error", pred, scalars)
         out_mesh_file = out_dir + names[i] + ".vtk"
         mesh.write(out_mesh_file)


### PR DESCRIPTION
Fixes for #2232

    Fix error:

    e)
    celery-gpu-1  |   File "/opt/conda/envs/shapeworks/lib/python3.9/site-packages/DeepSSMUtils/run_utils.py", line 503, in process_test_predictions
    celery-gpu-1  |     reference_index = DeepSSMUtils.get_reference_index(project)
    celery-gpu-1  | AttributeError: module 'DeepSSMUtils' has no attribute 'get_reference_index'~

    Also add the code to run this as part of the tiny test.