### PR TITLE
New generalization and specificity

### DIFF
--- a/Libs/Particles/ParticleShapeStatistics.cpp
+++ b/Libs/Particles/ParticleShapeStatistics.cpp
@@ -679,7 +679,8 @@ Eigen::VectorXd ParticleShapeStatistics::get_specificity(const std::function<voi
 //---------------------------------------------------------------------------
 Eigen::VectorXd ParticleShapeStatistics::get_generalization(const std::function<void(float)>& progress_callback) const {
   auto ps = ParticleSystemEvaluation(matrix_);
-  return shapeworks::ShapeEvaluation::compute_full_generalization(ps, progress_callback);
+  ps.set_meshes(meshes_);
+  return shapeworks::ShapeEvaluation::compute_full_generalization(ps, progress_callback, particle_to_surface_mode_);
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Particles/ParticleShapeStatistics.cpp
+++ b/Libs/Particles/ParticleShapeStatistics.cpp
@@ -673,7 +673,8 @@ Eigen::VectorXd ParticleShapeStatistics::get_compactness(const std::function<voi
 //---------------------------------------------------------------------------
 Eigen::VectorXd ParticleShapeStatistics::get_specificity(const std::function<void(float)>& progress_callback) const {
   auto ps = ParticleSystemEvaluation(matrix_);
-  return shapeworks::ShapeEvaluation::compute_full_specificity(ps, progress_callback);
+  ps.set_meshes(meshes_);
+  return shapeworks::ShapeEvaluation::compute_full_specificity(ps, progress_callback, particle_to_surface_mode_);
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Particles/ParticleShapeStatistics.cpp
+++ b/Libs/Particles/ParticleShapeStatistics.cpp
@@ -671,17 +671,21 @@ Eigen::VectorXd ParticleShapeStatistics::get_compactness(const std::function<voi
 }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd ParticleShapeStatistics::get_specificity(const std::function<void(float)>& progress_callback) const {
+Eigen::VectorXd ParticleShapeStatistics::get_specificity(const std::function<void(float)>& progress_callback,
+                                                         const std::function<bool(void)>& check_abort) const {
   auto ps = ParticleSystemEvaluation(matrix_);
   ps.set_meshes(meshes_);
-  return shapeworks::ShapeEvaluation::compute_full_specificity(ps, progress_callback, particle_to_surface_mode_);
+  return shapeworks::ShapeEvaluation::compute_full_specificity(ps, progress_callback, check_abort,
+                                                               particle_to_surface_mode_);
 }
 
 //---------------------------------------------------------------------------
-Eigen::VectorXd ParticleShapeStatistics::get_generalization(const std::function<void(float)>& progress_callback) const {
+Eigen::VectorXd ParticleShapeStatistics::get_generalization(const std::function<void(float)>& progress_callback,
+                                                            const std::function<bool(void)>& check_abort) const {
   auto ps = ParticleSystemEvaluation(matrix_);
   ps.set_meshes(meshes_);
-  return shapeworks::ShapeEvaluation::compute_full_generalization(ps, progress_callback, particle_to_surface_mode_);
+  return shapeworks::ShapeEvaluation::compute_full_generalization(ps, progress_callback, check_abort,
+                                                                  particle_to_surface_mode_);
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Particles/ParticleShapeStatistics.h
+++ b/Libs/Particles/ParticleShapeStatistics.h
@@ -128,6 +128,11 @@ class ParticleShapeStatistics {
   //! Set the number of values for each particle (e.g. 3 for x/y/z, 4 for x/y/z/scalar)
   void set_num_values_per_particle(int value_per_particle) { values_per_particle_ = value_per_particle; }
 
+  void set_particle_to_surface_mode(bool value) { particle_to_surface_mode_ = value; }
+  bool get_particle_to_surface_mode() const { return particle_to_surface_mode_; }
+  //! Set the meshes for each sample (used for some evaluation metrics)
+  void set_meshes(const std::vector<Mesh>& meshes) { meshes_ = meshes; }
+
  private:
   unsigned int num_samples_group1_;
   unsigned int num_samples_group2_;
@@ -150,17 +155,16 @@ class ParticleShapeStatistics {
   Eigen::VectorXd groupdiff_;
 
   // Variables for MLCA
-  std::vector<int> num_particles_array_;     // Number of Particles for each object in the multi-object shape structure
-  Eigen::MatrixXd eigenvectors_rel_pose_;   // Eigenvectors defined for relative pose subspace
-  Eigen::MatrixXd eigenvectors_shape_dev_;  // Eigenvectors defined for morphological subspace
-  std::vector<double> eigenvalues_rel_pose_;   // Eigenvalues defined in relative pose subspace
+  std::vector<int> num_particles_array_;      // Number of Particles for each object in the multi-object shape structure
+  Eigen::MatrixXd eigenvectors_rel_pose_;     // Eigenvectors defined for relative pose subspace
+  Eigen::MatrixXd eigenvectors_shape_dev_;    // Eigenvectors defined for morphological subspace
+  std::vector<double> eigenvalues_rel_pose_;  // Eigenvalues defined in relative pose subspace
   std::vector<double> eigenvalues_shape_dev_;  // Eigenvectors defined in morphological subspace
   Eigen::MatrixXd points_minus_mean_rel_pose_;
   Eigen::MatrixXd points_minus_mean_shape_dev_;
   Eigen::VectorXd mean_shape_dev_;
   Eigen::VectorXd mean_rel_pose_;
   Eigen::MatrixXd super_matrix_;  // Shape Matrix reshaped, used to compute MLCA statistics
-
 
   Eigen::MatrixXd matrix_;
 
@@ -170,6 +174,8 @@ class ParticleShapeStatistics {
   std::vector<Eigen::VectorXd> points_;
 
   int values_per_particle_ = 3;  // e.g. 3 for x/y/z, 4 for x/y/z/scalar
+  bool particle_to_surface_mode_ = false;
+  std::vector<Mesh> meshes_;
 };
 
 }  // namespace shapeworks

--- a/Libs/Particles/ParticleShapeStatistics.h
+++ b/Libs/Particles/ParticleShapeStatistics.h
@@ -117,8 +117,10 @@ class ParticleShapeStatistics {
   static int simple_linear_regression(const std::vector<double>& y, const std::vector<double>& x, double& a, double& b);
 
   Eigen::VectorXd get_compactness(const std::function<void(float)>& progress_callback = nullptr) const;
-  Eigen::VectorXd get_specificity(const std::function<void(float)>& progress_callback = nullptr) const;
-  Eigen::VectorXd get_generalization(const std::function<void(float)>& progress_callback = nullptr) const;
+  Eigen::VectorXd get_specificity(const std::function<void(float)>& progress_callback = nullptr,
+                                  const std::function<bool()>& check_abort = nullptr) const;
+  Eigen::VectorXd get_generalization(const std::function<void(float)>& progress_callback = nullptr,
+                                     const std::function<bool(void)>& check_abort = nullptr) const;
 
   Eigen::MatrixXd get_group1_matrix() const;
   Eigen::MatrixXd get_group2_matrix() const;

--- a/Libs/Particles/ParticleSystemEvaluation.cpp
+++ b/Libs/Particles/ParticleSystemEvaluation.cpp
@@ -119,5 +119,8 @@ bool ParticleSystemEvaluation::read_particle_file(std::string filename, Eigen::V
 }
 
 //---------------------------------------------------------------------------
+void ParticleSystemEvaluation::set_meshes(const std::vector<Mesh>& meshes) { meshes_ = meshes; }
+
+//---------------------------------------------------------------------------
 
 }  // namespace shapeworks

--- a/Libs/Particles/ParticleSystemEvaluation.cpp
+++ b/Libs/Particles/ParticleSystemEvaluation.cpp
@@ -14,12 +14,12 @@ ParticleSystemEvaluation::ParticleSystemEvaluation(const std::vector<std::string
   }
 
   paths_ = paths;
-  const int N = paths_.size();
+  const size_t N = paths_.size();
   assert(N > 0);
 
   // Read the first file to find dimensions
   auto points0 = particles::read_particles_as_vector(paths_[0]);
-  const int D = points0.size() * num_values_per_particle_;
+  const size_t D = points0.size() * num_values_per_particle_;
 
   matrix_.resize(D, N);
   matrix_.col(0) = Eigen::Map<const Eigen::VectorXd>((double*)points0.data(), D);

--- a/Libs/Particles/ParticleSystemEvaluation.h
+++ b/Libs/Particles/ParticleSystemEvaluation.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Libs/Mesh/Mesh.h>
+
 #include <Eigen/Core>
 #include <vector>
 
@@ -23,10 +25,10 @@ class ParticleSystemEvaluation {
   const std::vector<std::string>& get_paths() const { return paths_; }
 
   //! Number of samples
-  long num_samples() const { return matrix_.cols(); }
+  int num_samples() const { return matrix_.cols(); }
 
   //! Dimensions (e.g. x/y/z * number of particles)
-  long num_dims() const { return matrix_.rows(); }
+  int num_dims() const { return matrix_.rows(); }
 
   //! Perform an exact comparison of two particle systems
   bool exact_compare(const ParticleSystemEvaluation& other) const;
@@ -37,6 +39,12 @@ class ParticleSystemEvaluation {
   //! Read a particle file into an Eigen vector
   static bool read_particle_file(std::string filename, Eigen::VectorXd& points);
 
+  //! Set the meshes for each sample (used for some evaluation metrics)
+  void set_meshes(const std::vector<Mesh>& meshes);
+
+  //! Get the meshes for each sample
+  const std::vector<Mesh>& get_meshes() const { return meshes_; }
+
  private:
   friend struct SharedCommandData;
 
@@ -46,5 +54,6 @@ class ParticleSystemEvaluation {
   Eigen::MatrixXd matrix_;
   std::vector<std::string> paths_;
   int num_values_per_particle_ = 3;  // e.g. 3 for x/y/z, 4 for x/y/z/scalar, 1 for scalar-only
+  std::vector<Mesh> meshes_;
 };
 }  // namespace shapeworks

--- a/Libs/Particles/ShapeEvaluation.cpp
+++ b/Libs/Particles/ShapeEvaluation.cpp
@@ -371,15 +371,15 @@ Eigen::VectorXd ShapeEvaluation::compute_full_specificity(const ParticleSystemEv
 
         unsigned long num_meshes = meshes.size();
         tbb::parallel_for(tbb::blocked_range<size_t>{0, num_meshes}, [&](const tbb::blocked_range<size_t>& r) {
-          for (size_t j = r.begin(); i < r.end(); ++i) {  // for each original subject
+          for (size_t j = r.begin(); j < r.end(); ++j) {  // for each original subject
             auto mesh = meshes[j];
-            for (int i = 0; i < num_particles; i++) {
+            for (int k = 0; k < num_particles; k++) {
               vtkIdType face_id = 0;
               double this_dist = 0;
               Point3 point;
-              point[0] = pts_m(i, 0);
-              point[1] = pts_m(i, 1);
-              point[2] = pts_m(i, 2);
+              point[0] = pts_m(k*3+0);
+              point[1] = pts_m(k*3+1);
+              point[2] = pts_m(k*3+2);
               mesh.closestPoint(point, this_dist, face_id);
               pts_distance_vec(i, j) = this_dist;
             }

--- a/Libs/Particles/ShapeEvaluation.h
+++ b/Libs/Particles/ShapeEvaluation.h
@@ -22,6 +22,7 @@ class ShapeEvaluation {
 
   static Eigen::VectorXd compute_full_generalization(const ParticleSystemEvaluation& particle_system,
                                                      std::function<void(float)> progress_callback = nullptr,
+                                                     std::function<bool()> check_abort = nullptr,
                                                      bool surface_distance_mode = false);
 
   static double compute_specificity(const ParticleSystemEvaluation& particle_system, int num_mode,
@@ -29,6 +30,7 @@ class ShapeEvaluation {
 
   static Eigen::VectorXd compute_full_specificity(const ParticleSystemEvaluation& particle_system,
                                                   std::function<void(float)> progress_callback = nullptr,
+                                                  std::function<bool()> check_abort = nullptr,
                                                   bool surface_distance_mode = false);
 };
 }  // namespace shapeworks

--- a/Libs/Particles/ShapeEvaluation.h
+++ b/Libs/Particles/ShapeEvaluation.h
@@ -18,11 +18,11 @@ class ShapeEvaluation {
                                                   std::function<void(float)> progress_callback = nullptr);
 
   static double compute_generalization(const ParticleSystemEvaluation& particle_system, int num_modes,
-                                       const std::string& save_to = "", bool surface_distance_mode = true);
+                                       const std::string& save_to = "", bool surface_distance_mode = false);
 
   static Eigen::VectorXd compute_full_generalization(
       const ParticleSystemEvaluation &particle_system,
-      std::function<void(float)> progress_callback = nullptr);
+      std::function<void(float)> progress_callback = nullptr, bool surface_distance_mode = false);
 
   static double compute_specificity(const ParticleSystemEvaluation& particle_system, int num_mode,
                                     const std::string& save_to = "");

--- a/Libs/Particles/ShapeEvaluation.h
+++ b/Libs/Particles/ShapeEvaluation.h
@@ -20,14 +20,15 @@ class ShapeEvaluation {
   static double compute_generalization(const ParticleSystemEvaluation& particle_system, int num_modes,
                                        const std::string& save_to = "", bool surface_distance_mode = false);
 
-  static Eigen::VectorXd compute_full_generalization(
-      const ParticleSystemEvaluation &particle_system,
-      std::function<void(float)> progress_callback = nullptr, bool surface_distance_mode = false);
+  static Eigen::VectorXd compute_full_generalization(const ParticleSystemEvaluation& particle_system,
+                                                     std::function<void(float)> progress_callback = nullptr,
+                                                     bool surface_distance_mode = false);
 
   static double compute_specificity(const ParticleSystemEvaluation& particle_system, int num_mode,
-                                    const std::string& save_to = "");
+                                    const std::string& save_to = "", bool surface_distance_mode = false);
 
   static Eigen::VectorXd compute_full_specificity(const ParticleSystemEvaluation& particle_system,
-                                                  std::function<void(float)> progress_callback = nullptr);
+                                                  std::function<void(float)> progress_callback = nullptr,
+                                                  bool surface_distance_mode = false);
 };
 }  // namespace shapeworks

--- a/Libs/Particles/ShapeEvaluation.h
+++ b/Libs/Particles/ShapeEvaluation.h
@@ -20,8 +20,10 @@ class ShapeEvaluation {
   static double compute_generalization(const ParticleSystemEvaluation& particle_system, int num_modes,
                                        const std::string& save_to = "");
 
-  static Eigen::VectorXd compute_full_generalization(const ParticleSystemEvaluation& particle_system,
-                                                     std::function<void(float)> progress_callback = nullptr);
+  static Eigen::VectorXd extracted();
+  static Eigen::VectorXd compute_full_generalization(
+      const ParticleSystemEvaluation &particle_system,
+      std::function<void(float)> progress_callback = nullptr);
 
   static double compute_specificity(const ParticleSystemEvaluation& particle_system, int num_mode,
                                     const std::string& save_to = "");

--- a/Libs/Particles/ShapeEvaluation.h
+++ b/Libs/Particles/ShapeEvaluation.h
@@ -18,7 +18,7 @@ class ShapeEvaluation {
                                                   std::function<void(float)> progress_callback = nullptr);
 
   static double compute_generalization(const ParticleSystemEvaluation& particle_system, int num_modes,
-                                       const std::string& save_to = "");
+                                       const std::string& save_to = "", bool surface_distance_mode = true);
 
   static Eigen::VectorXd compute_full_generalization(
       const ParticleSystemEvaluation &particle_system,

--- a/Libs/Particles/ShapeEvaluation.h
+++ b/Libs/Particles/ShapeEvaluation.h
@@ -20,7 +20,6 @@ class ShapeEvaluation {
   static double compute_generalization(const ParticleSystemEvaluation& particle_system, int num_modes,
                                        const std::string& save_to = "");
 
-  static Eigen::VectorXd extracted();
   static Eigen::VectorXd compute_full_generalization(
       const ParticleSystemEvaluation &particle_system,
       std::function<void(float)> progress_callback = nullptr);

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1261,7 +1261,7 @@ PYBIND11_MODULE(shapeworks_py, m) {
 
       .def_static("ComputeSpecificity", &ShapeEvaluation::compute_specificity,
                   "Computes the specificity measure for a particle system", "particleSystem"_a, "nModes"_a,
-                  "saveTo"_a = "")
+                  "saveTo"_a = "", "surface_distance_mode"_a = false)
 
       .def_static("ComputeFullCompactness", &ShapeEvaluation::compute_full_compactness,
                   "Computes the compactness measure for a particle system, all modes", "particleSystem"_a,
@@ -1273,7 +1273,7 @@ PYBIND11_MODULE(shapeworks_py, m) {
 
       .def_static("ComputeFullSpecificity", &ShapeEvaluation::compute_full_specificity,
                   "Computes the specificity measure for a particle system, all modes", "particleSystem"_a,
-                  "progress_callback"_a = nullptr);
+                  "progress_callback"_a = nullptr, "surface_distance_mode"_a = false);
 
   py::class_<ParticleShapeStatistics>(m, "ParticleShapeStatistics")
 

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1254,8 +1254,7 @@ PYBIND11_MODULE(shapeworks_py, m) {
                   "Computes the compactness measure for a particle system", "particleSystem"_a, "nModes"_a,
                   "saveTo"_a = "")
 
-      .def_static("ComputeGeneralization",
-                  &ShapeEvaluation::compute_generalization,
+      .def_static("ComputeGeneralization", &ShapeEvaluation::compute_generalization,
                   "Computes the generalization measure for a particle system", "particleSystem"_a, "nModes"_a,
                   "saveTo"_a = "", "surface_distance_mode"_a = false)
 
@@ -1269,11 +1268,11 @@ PYBIND11_MODULE(shapeworks_py, m) {
 
       .def_static("ComputeFullGeneralization", &ShapeEvaluation::compute_full_generalization,
                   "Computes the generalization measure for a particle system, all modes", "particleSystem"_a,
-                  "progress_callback"_a = nullptr, "surface_distance_mode"_a = false)
+                  "progress_callback"_a = nullptr, "check_abort"_a = nullptr, "surface_distance_mode"_a = false)
 
       .def_static("ComputeFullSpecificity", &ShapeEvaluation::compute_full_specificity,
                   "Computes the specificity measure for a particle system, all modes", "particleSystem"_a,
-                  "progress_callback"_a = nullptr, "surface_distance_mode"_a = false);
+                  "progress_callback"_a = nullptr, "check_abort"_a = nullptr, "surface_distance_mode"_a = false);
 
   py::class_<ParticleShapeStatistics>(m, "ParticleShapeStatistics")
 

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1257,7 +1257,7 @@ PYBIND11_MODULE(shapeworks_py, m) {
       .def_static("ComputeGeneralization",
                   &ShapeEvaluation::compute_generalization,
                   "Computes the generalization measure for a particle system", "particleSystem"_a, "nModes"_a,
-                  "saveTo"_a = "")
+                  "saveTo"_a = "", "surface_distance_mode"_a = false)
 
       .def_static("ComputeSpecificity", &ShapeEvaluation::compute_specificity,
                   "Computes the specificity measure for a particle system", "particleSystem"_a, "nModes"_a,
@@ -1269,7 +1269,7 @@ PYBIND11_MODULE(shapeworks_py, m) {
 
       .def_static("ComputeFullGeneralization", &ShapeEvaluation::compute_full_generalization,
                   "Computes the generalization measure for a particle system, all modes", "particleSystem"_a,
-                  "progress_callback"_a = nullptr)
+                  "progress_callback"_a = nullptr, "surface_distance_mode"_a = false)
 
       .def_static("ComputeFullSpecificity", &ShapeEvaluation::compute_full_specificity,
                   "Computes the specificity measure for a particle system, all modes", "particleSystem"_a,

--- a/Studio/Analysis/AnalysisTool.cpp
+++ b/Studio/Analysis/AnalysisTool.cpp
@@ -880,11 +880,8 @@ void AnalysisTool::compute_shape_evaluations() {
   eval_generalization_ = Eigen::VectorXd();
 
   ui_->compactness_graph->setMinimumSize(QSize(250, 250));
-  ui_->compactness_graph->setMaximumSize(QSize(250, 250));
   ui_->generalization_graph->setMinimumSize(QSize(250, 300));
-  ui_->generalization_graph->setMaximumSize(QSize(250, 300));
   ui_->specificity_graph->setMinimumSize(QSize(250, 300));
-  ui_->specificity_graph->setMaximumSize(QSize(250, 300));
 
   ui_->compactness_progress_widget->show();
   ui_->generalization_progress_widget->show();

--- a/Studio/Analysis/AnalysisTool.h
+++ b/Studio/Analysis/AnalysisTool.h
@@ -180,6 +180,8 @@ class AnalysisTool : public QWidget {
   void handle_group_pvalues_complete();
   void handle_alignment_changed(int new_alignment);
 
+  void handle_distance_method_changed();
+
   void run_good_bad_particles();
 
   void handle_lda_progress(double progress);
@@ -242,7 +244,6 @@ class AnalysisTool : public QWidget {
   QSharedPointer<Session> session_;
   ShapeWorksStudioApp* app_;
 
-  /// itk particle shape statistics
   ParticleShapeStatistics stats_;
   bool stats_ready_ = false;
   bool evals_ready_ = false;

--- a/Studio/Analysis/AnalysisTool.h
+++ b/Studio/Analysis/AnalysisTool.h
@@ -289,5 +289,7 @@ class AnalysisTool : public QWidget {
 
   ParticleAreaPanel* particle_area_panel_{nullptr};
   ShapeScalarPanel* shape_scalar_panel_{nullptr};
+
+  std::vector<QPointer<Worker>> workers_;
 };
 }  // namespace shapeworks

--- a/Studio/Analysis/AnalysisTool.h
+++ b/Studio/Analysis/AnalysisTool.h
@@ -287,7 +287,6 @@ class AnalysisTool : public QWidget {
   bool lda_computed_ = false;
   bool block_group_change_ = false;
 
-  AlignmentType current_alignment_{AlignmentType::Local};
   ParticleAreaPanel* particle_area_panel_{nullptr};
   ShapeScalarPanel* shape_scalar_panel_{nullptr};
 };

--- a/Studio/Analysis/AnalysisTool.ui
+++ b/Studio/Analysis/AnalysisTool.ui
@@ -1896,7 +1896,7 @@ Reference Domain</string>
               <property name="minimumSize">
                <size>
                 <width>50</width>
-                <height>50</height>
+                <height>300</height>
                </size>
               </property>
              </widget>
@@ -1944,7 +1944,7 @@ Reference Domain</string>
               <property name="minimumSize">
                <size>
                 <width>50</width>
-                <height>50</height>
+                <height>300</height>
                </size>
               </property>
              </widget>
@@ -1992,7 +1992,7 @@ Reference Domain</string>
               <property name="minimumSize">
                <size>
                 <width>50</width>
-                <height>50</height>
+                <height>300</height>
                </size>
               </property>
              </widget>
@@ -2021,6 +2021,32 @@ Reference Domain</string>
                 </widget>
                </item>
               </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QGroupBox" name="distance_method_groupbox">
+           <property name="title">
+            <string>Distance Method</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_29">
+            <item row="0" column="0">
+             <widget class="QRadioButton" name="distance_method_particle">
+              <property name="text">
+               <string>Particle to Particle</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QRadioButton" name="distance_method_surface">
+              <property name="text">
+               <string>Particle to Surface</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
            </layout>

--- a/Studio/Analysis/AnalysisTool.ui
+++ b/Studio/Analysis/AnalysisTool.ui
@@ -2037,6 +2037,9 @@ Reference Domain</string>
               <property name="text">
                <string>Particle to Particle</string>
               </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
              </widget>
             </item>
             <item row="1" column="0">
@@ -2045,7 +2048,7 @@ Reference Domain</string>
                <string>Particle to Surface</string>
               </property>
               <property name="checked">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
              </widget>
             </item>

--- a/Studio/Analysis/AnalysisTool.ui
+++ b/Studio/Analysis/AnalysisTool.ui
@@ -1896,7 +1896,7 @@ Reference Domain</string>
               <property name="minimumSize">
                <size>
                 <width>50</width>
-                <height>300</height>
+                <height>50</height>
                </size>
               </property>
              </widget>
@@ -1944,7 +1944,7 @@ Reference Domain</string>
               <property name="minimumSize">
                <size>
                 <width>50</width>
-                <height>300</height>
+                <height>50</height>
                </size>
               </property>
              </widget>
@@ -1992,7 +1992,7 @@ Reference Domain</string>
               <property name="minimumSize">
                <size>
                 <width>50</width>
-                <height>300</height>
+                <height>50</height>
                </size>
               </property>
              </widget>

--- a/Studio/Analysis/ShapeEvaluationJob.cpp
+++ b/Studio/Analysis/ShapeEvaluationJob.cpp
@@ -15,16 +15,17 @@ ShapeEvaluationJob::ShapeEvaluationJob(JobType job_type, ParticleShapeStatistics
 //-----------------------------------------------------------------------------
 void ShapeEvaluationJob::run() {
   auto callback = std::bind(&ShapeEvaluationJob::receive_progress, this, std::placeholders::_1);
+  auto check_abort = std::bind(&Job::is_aborted, this);
   prep_meshes();
   switch (job_type_) {
     case JobType::CompactnessType:
       Q_EMIT result_ready(job_type_, stats_.get_compactness(callback));
       break;
     case JobType::GeneralizationType:
-      Q_EMIT result_ready(job_type_, stats_.get_generalization(callback));
+      Q_EMIT result_ready(job_type_, stats_.get_generalization(callback, check_abort));
       break;
     case JobType::SpecificityType:
-      Q_EMIT result_ready(job_type_, stats_.get_specificity(callback));
+      Q_EMIT result_ready(job_type_, stats_.get_specificity(callback, check_abort));
       break;
   }
 }

--- a/Studio/Analysis/ShapeEvaluationJob.cpp
+++ b/Studio/Analysis/ShapeEvaluationJob.cpp
@@ -1,12 +1,13 @@
 #include "ShapeEvaluationJob.h"
 
+#include <Data/Session.h>
 #include <Logging.h>
 
 namespace shapeworks {
 
 //-----------------------------------------------------------------------------
-ShapeEvaluationJob::ShapeEvaluationJob(JobType job_type, ParticleShapeStatistics stats)
-    : job_type_(job_type), stats_(stats) {
+ShapeEvaluationJob::ShapeEvaluationJob(JobType job_type, ParticleShapeStatistics stats, QSharedPointer<Session> session)
+    : job_type_(job_type), stats_(stats), session_(session) {
   qRegisterMetaType<shapeworks::ShapeEvaluationJob::JobType>("shapeworks::ShapeEvaluationWorker::JobType");
   qRegisterMetaType<Eigen::VectorXd>("Eigen::VectorXd");
 }
@@ -14,6 +15,7 @@ ShapeEvaluationJob::ShapeEvaluationJob(JobType job_type, ParticleShapeStatistics
 //-----------------------------------------------------------------------------
 void ShapeEvaluationJob::run() {
   auto callback = std::bind(&ShapeEvaluationJob::receive_progress, this, std::placeholders::_1);
+  prep_meshes();
   switch (job_type_) {
     case JobType::CompactnessType:
       Q_EMIT result_ready(job_type_, stats_.get_compactness(callback));
@@ -32,6 +34,18 @@ QString ShapeEvaluationJob::name() { return "Shape Evaluation"; }
 
 //-----------------------------------------------------------------------------
 void ShapeEvaluationJob::receive_progress(float progress) { Q_EMIT report_progress(job_type_, progress); }
+
+//-----------------------------------------------------------------------------
+void ShapeEvaluationJob::prep_meshes() {
+  if (stats_.get_particle_to_surface_mode() &&
+      (job_type_ == JobType::GeneralizationType || job_type_ == JobType::SpecificityType)) {
+    std::vector<Mesh> meshes;
+    for (auto& shape : session_->get_shapes()) {
+      meshes.push_back(shape->get_groomed_meshes(true).get_combined_poly_data());
+    }
+    stats_.set_meshes(meshes);
+  }
+}
 
 //-----------------------------------------------------------------------------
 

--- a/Studio/Analysis/ShapeEvaluationJob.cpp
+++ b/Studio/Analysis/ShapeEvaluationJob.cpp
@@ -41,7 +41,13 @@ void ShapeEvaluationJob::prep_meshes() {
       (job_type_ == JobType::GeneralizationType || job_type_ == JobType::SpecificityType)) {
     std::vector<Mesh> meshes;
     for (auto& shape : session_->get_shapes()) {
-      meshes.push_back(shape->get_groomed_meshes(true).get_combined_poly_data());
+      Mesh mesh = shape->get_groomed_meshes(true).get_combined_poly_data();
+
+      auto transform = shape->get_alignment(session_->get_current_alignment());
+      // Apply the transform to the mesh
+      mesh.applyTransform(transform);
+
+      meshes.emplace_back(mesh);
     }
     stats_.set_meshes(meshes);
   }

--- a/Studio/Analysis/ShapeEvaluationJob.h
+++ b/Studio/Analysis/ShapeEvaluationJob.h
@@ -4,7 +4,11 @@
 #include <Job/Job.h>
 #include <ParticleShapeStatistics.h>
 
+#include <QSharedPointer>
+
 namespace shapeworks {
+
+class Session;
 
 /**
  * @brief The ShapeEvaluationJob class is a worker class that computes shape evaluation metrics of compactness,
@@ -15,7 +19,7 @@ class ShapeEvaluationJob : public Job {
  public:
   enum class JobType { CompactnessType, SpecificityType, GeneralizationType };
 
-  ShapeEvaluationJob(JobType job_type, ParticleShapeStatistics stats);
+  ShapeEvaluationJob(JobType job_type, ParticleShapeStatistics stats, QSharedPointer<Session> session);
 
   void run() override;
 
@@ -28,9 +32,11 @@ class ShapeEvaluationJob : public Job {
 
  private:
   void receive_progress(float progress);
+  void prep_meshes();
 
   JobType job_type_;
   ParticleShapeStatistics stats_;
+  QSharedPointer<Session> session_;
 };
 }  // namespace shapeworks
 

--- a/Studio/Data/Session.h
+++ b/Studio/Data/Session.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Analyze/Analyze.h>
 #include <Analyze/Particles.h>
 #include <Data/Preferences.h>
 #include <MeshManager.h>
@@ -58,6 +59,8 @@ class Session : public QObject, public QEnableSharedFromThis<Session> {
   Q_OBJECT;
 
  public:
+  using AlignmentType = Analyze::AlignmentType;
+
   /// constructor
   Session(QWidget* parent, Preferences& prefs);
 
@@ -267,6 +270,9 @@ class Session : public QObject, public QEnableSharedFromThis<Session> {
   //! Return all scalars for all shapes, given target feature
   Eigen::MatrixXd get_all_scalars(std::string target_feature);
 
+  void set_current_alignment(AlignmentType alignment) { current_alignment_ = alignment; }
+  AlignmentType get_current_alignment() { return current_alignment_; }
+
  public Q_SLOTS:
   void set_feature_auto_scale(bool value);
 
@@ -355,6 +361,8 @@ class Session : public QObject, public QEnableSharedFromThis<Session> {
   vtkSmartPointer<vtkLookupTable> glyph_lut_;
 
   QSharedPointer<PythonWorker> py_worker_;
+
+  AlignmentType current_alignment_{AlignmentType::Local};
 };
 
 }  // namespace shapeworks

--- a/Studio/Data/Worker.cpp
+++ b/Studio/Data/Worker.cpp
@@ -20,15 +20,22 @@ Worker* Worker::create_worker() {
 //---------------------------------------------------------------------------
 void Worker::run_job(QSharedPointer<Job> job) {
   job_ = job;
-  QThread* thread = new QThread;
-  this->moveToThread(thread);
-  job_->moveToThread(thread);
-  connect(thread, &QThread::started, this, &Worker::process);
-  connect(this, &Worker::finished, thread, &QThread::quit);
+  thread_ = new QThread;
+  this->moveToThread(thread_);
+  job_->moveToThread(thread_);
+  connect(thread_, &QThread::started, this, &Worker::process);
+  connect(this, &Worker::finished, thread_, &QThread::quit);
   connect(this, &Worker::finished, this, &Worker::deleteLater);
-  connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+  connect(thread_, &QThread::finished, thread_, &QThread::deleteLater);
+  thread_->start();
+}
 
-  thread->start();
+//---------------------------------------------------------------------------
+void Worker::stop() {
+  if (thread_ != nullptr && job_ != nullptr) {
+    job_->abort();
+    thread_->quit();
+  }
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Data/Worker.h
+++ b/Studio/Data/Worker.h
@@ -3,6 +3,7 @@
 #include <Job/Job.h>
 
 #include <QObject>
+#include <QPointer>
 #include <QSharedPointer>
 
 namespace shapeworks {
@@ -18,6 +19,10 @@ class Worker : public QObject {
 
   void run_job(QSharedPointer<Job> job);
 
+  QPointer<QThread> get_thread() { return thread_; }
+
+  void stop();
+
  public Q_SLOTS:
   void process();
 
@@ -30,5 +35,6 @@ class Worker : public QObject {
 
  private:
   QSharedPointer<Job> job_;
+  QPointer<QThread> thread_;
 };
 }  // namespace shapeworks

--- a/Studio/Utils/AnalysisUtils.cpp
+++ b/Studio/Utils/AnalysisUtils.cpp
@@ -73,6 +73,9 @@ void AnalysisUtils::create_plot(JKQTPlotter* plot, Eigen::VectorXd data, QString
   plot->setMinimumSize(250, 250);
   plot->addGraph(graph);
   plot->zoomToFit();
+  plot->update();
+  plot->getPlotter()->redrawPlot();
+  plot->resize(plot->sizeHint());
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Utils/AnalysisUtils.cpp
+++ b/Studio/Utils/AnalysisUtils.cpp
@@ -1,6 +1,7 @@
 #include "AnalysisUtils.h"
 
 #include <Data/Session.h>
+#include <Logging.h>
 #include <jkqtplotter/graphs/jkqtpboxplot.h>
 #include <jkqtplotter/graphs/jkqtpscatter.h>
 #include <jkqtplotter/graphs/jkqtpstatisticsadaptors.h>
@@ -70,12 +71,8 @@ void AnalysisUtils::create_plot(JKQTPlotter* plot, Eigen::VectorXd data, QString
 
   plot->clearAllMouseWheelActions();
   plot->setMousePositionShown(false);
-  plot->setMinimumSize(250, 250);
   plot->addGraph(graph);
   plot->zoomToFit();
-  plot->update();
-  plot->getPlotter()->redrawPlot();
-  plot->resize(plot->sizeHint());
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
* #2212 

This PR adds the ability to use particle to surface rather than particle to particle for generalization and specificity computation.  

* Specificity in particular can be quite slow, so it's parallelized across subjects.
* Specificity and Generalization jobs can now be aborted.  When switching between particle and surface distance, the other jobs are stopped.  Also stopped on shutdown for clean exit.

<img width="1470" alt="image" src="https://github.com/SCIInstitute/ShapeWorks/assets/1693349/8b9c6d2e-0b54-4300-b19f-6efbf3e2cb8b">
