### PR TITLE
Fix alignment setting.

### DIFF
--- a/Studio/Analysis/AnalysisTool.cpp
+++ b/Studio/Analysis/AnalysisTool.cpp
@@ -1714,8 +1714,8 @@ void AnalysisTool::handle_alignment_changed(int new_alignment) {
       transform = shape->get_groomed_transform(new_alignment);
     }
 
-    shape->set_particle_transform(transform);
     shape->set_alignment_type(new_alignment);
+    shape->set_particle_transform(transform);
   }
 
   evals_ready_ = false;


### PR DESCRIPTION
The alignment setting can in some cases lag behind, meaning that as you change the dropdown, you get the previous setting.