### PR TITLE
Studio analysis updates

### DIFF
--- a/Studio/Analysis/AnalysisTool.cpp
+++ b/Studio/Analysis/AnalysisTool.cpp
@@ -324,9 +324,6 @@ QSharedPointer<Session> AnalysisTool::get_session() { return session_; }
 void AnalysisTool::set_app(ShapeWorksStudioApp* app) { app_ = app; }
 
 //---------------------------------------------------------------------------
-void AnalysisTool::update_analysis_mode() { handle_analysis_options(); }
-
-//---------------------------------------------------------------------------
 void AnalysisTool::update_interface() {
   ui_->show_good_bad->setEnabled(session_->get_good_bad_particles().size() == session_->get_num_particles());
   ui_->show_good_bad->setChecked(ui_->show_good_bad->isEnabled() && session_->get_show_good_bad_particles());
@@ -393,6 +390,7 @@ void AnalysisTool::handle_analysis_options() {
 
   update_difference_particles();
 
+  Q_EMIT analysis_mode_changed();
   Q_EMIT update_view();
 }
 
@@ -978,7 +976,7 @@ bool AnalysisTool::pca_shape_plus_scalar_mode() { return ui_->pca_shape_and_scal
 bool AnalysisTool::pca_shape_only_mode() { return ui_->pca_scalar_shape_only->isChecked(); }
 
 //---------------------------------------------------------------------------
-void AnalysisTool::on_tabWidget_currentChanged() { update_analysis_mode(); }
+void AnalysisTool::on_tabWidget_currentChanged() { handle_analysis_options(); }
 
 //---------------------------------------------------------------------------
 void AnalysisTool::on_pcaSlider_valueChanged() {

--- a/Studio/Analysis/AnalysisTool.h
+++ b/Studio/Analysis/AnalysisTool.h
@@ -207,6 +207,7 @@ class AnalysisTool : public QWidget {
  Q_SIGNALS:
 
   void update_view();
+  void analysis_mode_changed();
   void pca_update();
   void progress(int);
   void reconstruction_complete();
@@ -217,7 +218,7 @@ class AnalysisTool : public QWidget {
   bool active_ = false;
 
   void pca_labels_changed(QString value, QString eigen, QString lambda);
-  void update_analysis_mode();
+
   void update_interface();
 
   bool group_pvalues_valid();

--- a/Studio/Data/Session.cpp
+++ b/Studio/Data/Session.cpp
@@ -1174,11 +1174,17 @@ bool Session::is_loading() { return is_loading_; }
 
 //---------------------------------------------------------------------------
 void Session::set_tool_state(std::string state) {
+  std::string current_state = get_tool_state();
+  if (state == current_state) {
+    return;
+  }
+
   parameters().set("tool_state", state);
   // these need to be updated so that the handles appear/disappear
   trigger_landmarks_changed();
   trigger_planes_changed();
   Q_EMIT ffc_paint_mode_changed();
+  Q_EMIT tool_state_changed();
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Data/Session.cpp
+++ b/Studio/Data/Session.cpp
@@ -945,6 +945,17 @@ void Session::set_feature_range_max(double value) {
 }
 
 //---------------------------------------------------------------------------
+void Session::set_feature_uniform_scale(bool value) {
+  if (!is_loading()) {
+    params_.set("feature_uniform_scale", value);
+    Q_EMIT feature_range_changed();
+  }
+}
+
+//---------------------------------------------------------------------------
+bool Session::get_feature_uniform_scale() { return params_.get("feature_uniform_scale", true); }
+
+//---------------------------------------------------------------------------
 void Session::handle_ctrl_click(PickResult result) {
   if (get_tool_state() != Session::DATA_C) {
     return;

--- a/Studio/Data/Session.h
+++ b/Studio/Data/Session.h
@@ -159,6 +159,9 @@ class Session : public QObject, public QEnableSharedFromThis<Session> {
   void set_feature_range_min(double value);
   void set_feature_range_max(double value);
 
+  void set_feature_uniform_scale(bool value);
+  bool get_feature_uniform_scale();
+
   void handle_ctrl_click(PickResult result);
 
   void trigger_landmarks_changed();

--- a/Studio/Data/Session.h
+++ b/Studio/Data/Session.h
@@ -286,6 +286,7 @@ class Session : public QObject, public QEnableSharedFromThis<Session> {
  Q_SIGNALS:
   /// signal that the data has changed
   void data_changed();
+  void tool_state_changed();
   void points_changed();
   void landmarks_changed();
   void planes_changed();

--- a/Studio/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/Interface/ShapeWorksStudioApp.cpp
@@ -116,6 +116,7 @@ ShapeWorksStudioApp::ShapeWorksStudioApp() {
   ui_->stacked_widget->addWidget(analysis_tool_.data());
   connect(analysis_tool_.data(), &AnalysisTool::update_view, this,
           &ShapeWorksStudioApp::handle_display_setting_changed);
+  connect(analysis_tool_.data(), &AnalysisTool::analysis_mode_changed, this, &ShapeWorksStudioApp::reset_num_viewers);
   connect(analysis_tool_.data(), &AnalysisTool::pca_update, this, &ShapeWorksStudioApp::handle_pca_update);
   connect(analysis_tool_.data(), &AnalysisTool::progress, this, &ShapeWorksStudioApp::handle_progress);
   connect(analysis_tool_.data(), &AnalysisTool::reconstruction_complete, this,
@@ -974,6 +975,7 @@ void ShapeWorksStudioApp::new_session() {
   connect(session_.data(), &Session::new_mesh, this, &ShapeWorksStudioApp::handle_new_mesh);
   connect(session_.data(), &Session::reinsert_shapes, this, [&]() { update_display(true); });
   connect(session_.data(), &Session::save, this, &ShapeWorksStudioApp::on_action_save_project_triggered);
+  connect(session_.data(), &Session::tool_state_changed, this, &ShapeWorksStudioApp::update_tool_mode);
 
   connect(ui_->feature_auto_scale, &QCheckBox::toggled, this, &ShapeWorksStudioApp::update_feature_map_scale);
   connect(ui_->feature_auto_scale, &QCheckBox::toggled, session_.data(), &Session::set_feature_auto_scale);
@@ -1077,6 +1079,9 @@ void ShapeWorksStudioApp::update_tool_mode() {
       ->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
   ui_->stacked_widget->adjustSize();
 
+  reset_num_viewers();
+  visualizer_->reset_camera();
+
   update_view_combo();
 
   on_actionShow_Tool_Window_triggered();
@@ -1148,37 +1153,19 @@ bool ShapeWorksStudioApp::is_view_combo_item_enabled(int item) {
 }
 
 //---------------------------------------------------------------------------
-void ShapeWorksStudioApp::on_action_import_mode_triggered() {
-  session_->set_tool_state(Session::DATA_C);
-  update_tool_mode();
-}
+void ShapeWorksStudioApp::on_action_import_mode_triggered() { session_->set_tool_state(Session::DATA_C); }
 
 //---------------------------------------------------------------------------
-void ShapeWorksStudioApp::on_action_groom_mode_triggered() {
-  session_->set_tool_state(Session::GROOM_C);
-  update_tool_mode();
-}
+void ShapeWorksStudioApp::on_action_groom_mode_triggered() { session_->set_tool_state(Session::GROOM_C); }
 
 //---------------------------------------------------------------------------
-void ShapeWorksStudioApp::on_action_optimize_mode_triggered() {
-  session_->set_tool_state(Session::OPTIMIZE_C);
-  update_tool_mode();
-  visualizer_->reset_camera();
-}
+void ShapeWorksStudioApp::on_action_optimize_mode_triggered() { session_->set_tool_state(Session::OPTIMIZE_C); }
 
 //---------------------------------------------------------------------------
-void ShapeWorksStudioApp::on_action_analysis_mode_triggered() {
-  session_->set_tool_state(Session::ANALYSIS_C);
-  update_tool_mode();
-  visualizer_->reset_camera();
-}
+void ShapeWorksStudioApp::on_action_analysis_mode_triggered() { session_->set_tool_state(Session::ANALYSIS_C); }
 
 //---------------------------------------------------------------------------
-void ShapeWorksStudioApp::on_action_deepssm_mode_triggered() {
-  session_->set_tool_state(Session::DEEPSSM_C);
-  update_tool_mode();
-  visualizer_->reset_camera();
-}
+void ShapeWorksStudioApp::on_action_deepssm_mode_triggered() { session_->set_tool_state(Session::DEEPSSM_C); }
 
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::handle_project_changed() {
@@ -1429,8 +1416,9 @@ void ShapeWorksStudioApp::update_display(bool force) {
 
   lightbox_->update_interactor_style();
 
-  if ((force || change) && !session_->is_loading()) {  // do not override if loading
-    reset_num_viewers();
+  //  if ((force || change) && !session_->is_loading()) {  // do not override if loading
+  if (change && !session_->is_loading()) {  // do not override if loading
+    // reset_num_viewers();
   }
 
   update_scrollbar();

--- a/Studio/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/Interface/ShapeWorksStudioApp.cpp
@@ -2038,6 +2038,7 @@ void ShapeWorksStudioApp::update_feature_map_scale() {
   bool auto_mode = ui_->feature_auto_scale->isChecked();
   ui_->feature_min->setEnabled(!auto_mode);
   ui_->feature_max->setEnabled(!auto_mode);
+  ui_->feature_auto_scale->setEnabled(ui_->feature_uniform_scale->isChecked());
   if (!auto_mode) {
     if (session_->get_feature_range_min() == 0 && session_->get_feature_range_max() == 0) {
       if (visualizer_->get_feature_range_valid()) {
@@ -2056,15 +2057,13 @@ void ShapeWorksStudioApp::image_combo_changed(int index) {
 
 //---------------------------------------------------------------------------
 bool ShapeWorksStudioApp::get_feature_uniform_scale() {
-  return session_->parameters().get("feature_uniform_scale", true);
+  return session_->get_feature_uniform_scale();
 }
 
 //---------------------------------------------------------------------------
 void ShapeWorksStudioApp::set_feature_uniform_scale(bool value) {
-  if (!session_->is_loading()) {
-    session_->parameters().set("feature_uniform_scale", value);
-    update_view_mode();
-  }
+  session_->set_feature_uniform_scale(value);
+  update_feature_map_scale();
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Visualization/Lightbox.cpp
+++ b/Studio/Visualization/Lightbox.cpp
@@ -509,8 +509,11 @@ void Lightbox::set_orientation_marker_viewport() {
 
 //-----------------------------------------------------------------------------
 void Lightbox::update_feature_range() {
+  if (visualizer_->get_feature_map() == "") {
+    return;
+  }
   for (int i = 0; i < viewers_.size(); i++) {
-    if (visualizer_->get_feature_map() != "" && visualizer_->get_uniform_feature_range()) {
+    if (visualizer_->get_uniform_feature_range()) {
       viewers_[i]->update_feature_range(visualizer_->get_feature_range());
     } else {
       viewers_[i]->reset_feature_range();

--- a/Studio/Visualization/Lightbox.cpp
+++ b/Studio/Visualization/Lightbox.cpp
@@ -509,9 +509,11 @@ void Lightbox::set_orientation_marker_viewport() {
 
 //-----------------------------------------------------------------------------
 void Lightbox::update_feature_range() {
-  if (visualizer_->get_feature_map() != "" && visualizer_->get_uniform_feature_range()) {
-    for (int i = 0; i < viewers_.size(); i++) {
+  for (int i = 0; i < viewers_.size(); i++) {
+    if (visualizer_->get_feature_map() != "" && visualizer_->get_uniform_feature_range()) {
       viewers_[i]->update_feature_range(visualizer_->get_feature_range());
+    } else {
+      viewers_[i]->reset_feature_range();
     }
   }
 }

--- a/Studio/Visualization/SliceView.cpp
+++ b/Studio/Visualization/SliceView.cpp
@@ -262,9 +262,13 @@ Point SliceView::get_slice_position() {
 
   // convert to world coordinates
   auto transform = viewer_->get_image_transform();
-  transform->Update();
-  transform->Inverse();
-  transform->TransformPoint(origin, origin);
+
+  // make a local copy
+  vtkSmartPointer<vtkTransform> transform_copy = vtkSmartPointer<vtkTransform>::New();
+  transform_copy->SetMatrix(transform->GetMatrix());
+  transform_copy->Update();
+  transform_copy->Inverse();
+  transform_copy->TransformPoint(origin, origin);
 
   return Point({origin[0], origin[1], origin[2]});
 }

--- a/Studio/Visualization/SliceView.cpp
+++ b/Studio/Visualization/SliceView.cpp
@@ -144,8 +144,15 @@ bool SliceView::is_image_loaded() { return volume_ != nullptr; }
 void SliceView::update_colormap() {
   for (auto &actor : cut_actors_) {
     auto mapper = actor->GetMapper();
-    mapper->SetLookupTable(viewer_->get_surface_lut());
-    mapper->SetScalarRange(viewer_->get_surface_lut()->GetTableRange());
+    if (viewer_->showing_feature_map()) {
+      mapper->SetScalarVisibility(true);
+      mapper->SetColorModeToMapScalars();
+      mapper->SetLookupTable(viewer_->get_surface_lut());
+      mapper->SetScalarRange(viewer_->get_surface_lut()->GetTableRange());
+    } else{
+      mapper->SetScalarVisibility(false);
+      mapper->SetScalarModeToDefault();
+    }
   }
 }
 

--- a/Studio/Visualization/SliceView.cpp
+++ b/Studio/Visualization/SliceView.cpp
@@ -6,6 +6,7 @@
 #include <vtkImageActorPointPlacer.h>
 #include <vtkImageProperty.h>
 #include <vtkImageSliceMapper.h>
+#include <vtkLookupTable.h>
 #include <vtkNamedColors.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkProperty.h>
@@ -30,8 +31,10 @@ vtkSmartPointer<vtkActor> SliceView::create_shape_actor(vtkSmartPointer<vtkPolyD
   auto cut_actor = vtkSmartPointer<vtkActor>::New();
 
   stripper->PassCellDataAsFieldDataOn();
-  cut_mapper->SetScalarVisibility(false);
+  cut_mapper->SetScalarVisibility(true);
+  cut_mapper->SetColorModeToMapScalars();
   cut_mapper->SetResolveCoincidentTopologyToPolygonOffset();
+  cut_mapper->SetLookupTable(viewer_->get_surface_lut());
   cut_actor->GetProperty()->SetColor(color.redF(), color.greenF(), color.blueF());
   cut_actor->GetProperty()->SetLineWidth(4);
   cut_actor->GetProperty()->SetAmbient(1.0);

--- a/Studio/Visualization/SliceView.cpp
+++ b/Studio/Visualization/SliceView.cpp
@@ -31,10 +31,8 @@ vtkSmartPointer<vtkActor> SliceView::create_shape_actor(vtkSmartPointer<vtkPolyD
   auto cut_actor = vtkSmartPointer<vtkActor>::New();
 
   stripper->PassCellDataAsFieldDataOn();
-  cut_mapper->SetScalarVisibility(true);
-  cut_mapper->SetColorModeToMapScalars();
+  cut_mapper->SetScalarVisibility(false);
   cut_mapper->SetResolveCoincidentTopologyToPolygonOffset();
-  update_colormap();
   cut_actor->GetProperty()->SetColor(color.redF(), color.greenF(), color.blueF());
   cut_actor->GetProperty()->SetLineWidth(4);
   cut_actor->GetProperty()->SetAmbient(1.0);

--- a/Studio/Visualization/SliceView.cpp
+++ b/Studio/Visualization/SliceView.cpp
@@ -34,7 +34,7 @@ vtkSmartPointer<vtkActor> SliceView::create_shape_actor(vtkSmartPointer<vtkPolyD
   cut_mapper->SetScalarVisibility(true);
   cut_mapper->SetColorModeToMapScalars();
   cut_mapper->SetResolveCoincidentTopologyToPolygonOffset();
-  cut_mapper->SetLookupTable(viewer_->get_surface_lut());
+  update_colormap();
   cut_actor->GetProperty()->SetColor(color.redF(), color.greenF(), color.blueF());
   cut_actor->GetProperty()->SetLineWidth(4);
   cut_actor->GetProperty()->SetAmbient(1.0);
@@ -60,9 +60,7 @@ vtkSmartPointer<vtkActor> SliceView::create_shape_actor(vtkSmartPointer<vtkPolyD
 //-----------------------------------------------------------------------------
 SliceView::SliceView(Viewer *viewer) : viewer_(viewer) {
   image_slice_ = vtkSmartPointer<vtkImageActor>::New();
-
   slice_mapper_ = vtkSmartPointer<vtkImageSliceMapper>::New();
-
   placer_ = vtkSmartPointer<vtkImageActorPointPlacer>::New();
   placer_->SetImageActor(image_slice_);
 }
@@ -141,6 +139,15 @@ void SliceView::set_orientation(int orientation) {
 
 //-----------------------------------------------------------------------------
 bool SliceView::is_image_loaded() { return volume_ != nullptr; }
+
+//-----------------------------------------------------------------------------
+void SliceView::update_colormap() {
+  for (auto &actor : cut_actors_) {
+    auto mapper = actor->GetMapper();
+    mapper->SetLookupTable(viewer_->get_surface_lut());
+    mapper->SetScalarRange(viewer_->get_surface_lut()->GetTableRange());
+  }
+}
 
 //-----------------------------------------------------------------------------
 void SliceView::update_renderer() {

--- a/Studio/Visualization/SliceView.h
+++ b/Studio/Visualization/SliceView.h
@@ -40,6 +40,7 @@ class SliceView {
 
   bool is_image_loaded();
 
+  void update_colormap();
   void update_renderer();
 
   void update_camera();
@@ -84,6 +85,7 @@ class SliceView {
   int current_slice_number_ = 0;
 
   std::vector<vtkSmartPointer<vtkActor>> cut_actors_;
+  ///std::vector<vtkSmartPointer<vtkPolyDataMapper>>
 
   std::vector<vtkSmartPointer<vtkPolyData>> poly_datas_;
 };

--- a/Studio/Visualization/Viewer.cpp
+++ b/Studio/Visualization/Viewer.cpp
@@ -1158,14 +1158,16 @@ void Viewer::update_image_volume(bool force) {
 
   if (meshes_.valid()) {
     slice_view_.clear_meshes();
-    auto poly_data = meshes_.meshes()[0]->get_poly_data();
-    slice_view_.add_mesh(poly_data);
+    for (size_t i = 0; i < meshes_.meshes().size(); i++) {
+      auto poly_data = meshes_.meshes()[i]->get_poly_data();
+      slice_view_.add_mesh(poly_data);
 
-    if (session_->get_image_thickness_feature()) {
-      auto target_feature = session_->get_feature_map();
-      if (target_feature != "" && target_feature != "-none-") {
-        Mesh inner = mesh::compute_inner_mesh(poly_data, target_feature);
-        slice_view_.add_mesh(inner.getVTKMesh());
+      if (session_->get_image_thickness_feature()) {
+        auto target_feature = session_->get_feature_map();
+        if (target_feature != "" && target_feature != "-none-") {
+          Mesh inner = mesh::compute_inner_mesh(poly_data, target_feature);
+          slice_view_.add_mesh(inner.getVTKMesh());
+        }
       }
     }
   }

--- a/Studio/Visualization/Viewer.cpp
+++ b/Studio/Visualization/Viewer.cpp
@@ -1038,16 +1038,14 @@ void Viewer::update_actors() {
     renderer_->RemoveActor(compare_actors_[i]);
   }
 
+  // now add back
+
   if (show_glyphs_) {
     renderer_->AddActor(glyph_actor_);
 
     if (arrows_visible_) {
       renderer_->AddActor(arrow_glyph_actor_);
     }
-  }
-
-  if ((show_glyphs_ && arrows_visible_) || showing_feature_map()) {
-    renderer_->AddActor(scalar_bar_actor_);
   }
 
   if (show_surface_ && meshes_.valid()) {
@@ -1069,6 +1067,10 @@ void Viewer::update_actors() {
         point_placer_->GetPolys()->AddItem(poly_data);
       }
     }
+  }
+
+  if ((show_glyphs_ && arrows_visible_) || showing_feature_map()) {
+    renderer_->AddActor(scalar_bar_actor_);
   }
 
   slice_view_.update_renderer();

--- a/Studio/Visualization/Viewer.cpp
+++ b/Studio/Visualization/Viewer.cpp
@@ -1141,6 +1141,8 @@ void Viewer::set_scalar_visibility(vtkSmartPointer<vtkPolyData> poly_data, vtkSm
   if (scalars) {
     double range[2];
     scalars->GetRange(range);
+    lut_min_ = range[0];
+    lut_max_ = range[1];
     update_difference_lut(range[0], range[1]);
     mapper->SetScalarRange(range[0], range[1]);
     visualizer_->update_feature_range(range);
@@ -1305,6 +1307,9 @@ bool Viewer::showing_feature_map() {
 
 //-----------------------------------------------------------------------------
 void Viewer::update_feature_range(double* range) { update_difference_lut(range[0], range[1]); }
+
+//-----------------------------------------------------------------------------
+void Viewer::reset_feature_range() { update_difference_lut(lut_min_, lut_max_); }
 
 //-----------------------------------------------------------------------------
 void Viewer::update_opacities() {

--- a/Studio/Visualization/Viewer.cpp
+++ b/Studio/Visualization/Viewer.cpp
@@ -1285,6 +1285,7 @@ void Viewer::update_difference_lut(float r0, float r1) {
   arrow_glyph_mapper_->SetScalarRange(range);
   glyph_mapper_->SetScalarRange(range);
   scalar_bar_actor_->SetLookupTable(surface_lut_);
+  slice_view_.update_colormap();
   if (rd > 100) {
     scalar_bar_actor_->SetLabelFormat("%.0f");
   } else if (rd > 1) {

--- a/Studio/Visualization/Viewer.h
+++ b/Studio/Visualization/Viewer.h
@@ -106,6 +106,7 @@ class Viewer {
   void set_visualizer(Visualizer* visualizer);
 
   void update_feature_range(double* range);
+  void reset_feature_range();
 
   void update_opacities();
 
@@ -239,6 +240,8 @@ class Viewer {
   Visualizer* visualizer_{nullptr};
 
   int number_of_domains_ = 0;
+  double lut_min_ = 0;
+  double lut_max_ = 0;
 
   std::shared_ptr<LandmarkWidget> landmark_widget_;
   std::shared_ptr<PlaneWidget> plane_widget_;

--- a/Studio/Visualization/Viewer.h
+++ b/Studio/Visualization/Viewer.h
@@ -156,7 +156,10 @@ class Viewer {
 
   void insert_compare_meshes();
 
-  void set_scalar_visibility(vtkSmartPointer<vtkPolyData> poly_data, vtkSmartPointer<vtkPolyDataMapper> mapper, std::string scalar);
+  void set_scalar_visibility(vtkSmartPointer<vtkPolyData> poly_data, vtkSmartPointer<vtkPolyDataMapper> mapper,
+                             std::string scalar);
+
+  vtkSmartPointer<vtkLookupTable> get_surface_lut() { return surface_lut_; }
 
  private:
   void initialize_surfaces();

--- a/Studio/Visualization/Viewer.h
+++ b/Studio/Visualization/Viewer.h
@@ -162,6 +162,8 @@ class Viewer {
 
   vtkSmartPointer<vtkLookupTable> get_surface_lut() { return surface_lut_; }
 
+  bool showing_feature_map();
+
  private:
   void initialize_surfaces();
 
@@ -174,7 +176,6 @@ class Viewer {
 
   void update_difference_lut(float r0, float r1);
 
-  bool showing_feature_map();
   std::string get_displayed_feature_map();
 
   vtkSmartPointer<vtkPlane> transform_plane(vtkSmartPointer<vtkPlane> plane, vtkSmartPointer<vtkTransform> transform);

--- a/Studio/Visualization/Visualizer.cpp
+++ b/Studio/Visualization/Visualizer.cpp
@@ -245,6 +245,8 @@ void Visualizer::update_viewer_properties() {
 
 //-----------------------------------------------------------------------------
 void Visualizer::handle_feature_range_changed() {
+  set_uniform_feature_range(session_->get_feature_uniform_scale());
+
   feature_manual_range_[0] = session_->get_feature_range_min();
   feature_manual_range_[1] = std::max<double>(feature_manual_range_[0], session_->get_feature_range_max());
   lightbox_->update_feature_range();


### PR DESCRIPTION
* #2321
* Add ability to show shape intersection with multiple domains.
* Fix display of non-feature contour
* Fix bug where transform is mistakenly inverted with slice change
* Fixing display of contours without feature maps.
* Fixing colormap issues.  No longer resetting view when changing uniform on/off
* Fixing colormap for contour slice view
* Adding ability to show colormap on slice contour. (#2321)
* Fix scalar bar text positioning changing by changing order of actor adding.  Not sure why this fixes it or what the original problem was.
* Reduce the number of places where the number of viewers gets reset as it is really annoying when yo
u are on a single viewer and change a setting and it goes back to 4x4.