### PR TITLE
2349 - Improve mesh domain memory usage

### DIFF
--- a/ExternalLibs/robin_hood/robin_hood.h
+++ b/ExternalLibs/robin_hood/robin_hood.h
@@ -192,13 +192,7 @@ static Counts& counts() {
 #    define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART() 1
 #endif
 
-// workaround missing "is_trivially_copyable" in g++ < 5.0
-// See https://stackoverflow.com/a/31798726/48181
-#if defined(__GNUC__) && __GNUC__ < 5
-#    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
-#else
-#    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
-#endif
+#define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
 
 // helpers for C++ versions, see https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
 #define ROBIN_HOOD_PRIVATE_DEFINITION_CXX() __cplusplus

--- a/Libs/Analyze/Analyze.cpp
+++ b/Libs/Analyze/Analyze.cpp
@@ -75,7 +75,7 @@ static void write_good_bad_angles(json& json_object, ProjectHandle project, Anal
   std::vector<json> good_bad_angles;
 
   for (int d = 0; d < project->get_number_of_domains_per_subject(); d++) {
-    std::vector<std::shared_ptr<MeshWrapper>> meshes;
+    std::vector<std::shared_ptr<Surface>> meshes;
     for (auto& shape : analyze.get_shapes()) {
       meshes.push_back(shape->get_groomed_mesh_wrappers()[d]);
     }

--- a/Libs/Analyze/Shape.cpp
+++ b/Libs/Analyze/Shape.cpp
@@ -16,7 +16,7 @@
 #include <vtkKdTreePointLocator.h>
 #include <vtkPointData.h>
 
-#include "Libs/Optimize/Domain/MeshWrapper.h"
+#include "Libs/Optimize/Domain/Surface.h"
 
 using ReaderType = itk::ImageFileReader<ImageType>;
 
@@ -931,14 +931,14 @@ bool Shape::has_planes() {
 }
 
 //---------------------------------------------------------------------------
-std::vector<std::shared_ptr<MeshWrapper>> Shape::get_groomed_mesh_wrappers() {
+std::vector<std::shared_ptr<Surface>> Shape::get_groomed_mesh_wrappers() {
   if (!groomed_mesh_wrappers_.empty()) {
     return groomed_mesh_wrappers_;
   }
 
   auto group = get_groomed_meshes(true /* wait */);
   for (auto& mesh : group.meshes()) {
-    auto wrapper = std::make_shared<MeshWrapper>(mesh->get_poly_data());
+    auto wrapper = std::make_shared<Surface>(mesh->get_poly_data());
     groomed_mesh_wrappers_.push_back(wrapper);
   }
   return groomed_mesh_wrappers_;

--- a/Libs/Analyze/Shape.h
+++ b/Libs/Analyze/Shape.h
@@ -22,7 +22,7 @@ namespace shapeworks {
 class Shape;
 using ShapeHandle = std::shared_ptr<Shape>;
 using ShapeList = std::vector<ShapeHandle>;
-class MeshWrapper;
+class Surface;
 
 //! Representation of a single shape/patient/subject.
 class Shape {
@@ -187,7 +187,7 @@ class Shape {
 
   bool has_planes();
 
-  std::vector<std::shared_ptr<MeshWrapper>> get_groomed_mesh_wrappers();
+  std::vector<std::shared_ptr<Surface>> get_groomed_mesh_wrappers();
 
   void recompute_original_surface();
 
@@ -208,7 +208,7 @@ class Shape {
   MeshGroup original_meshes_;
   MeshGroup groomed_meshes_;
   MeshGroup reconstructed_meshes_;
-  std::vector<std::shared_ptr<MeshWrapper>> groomed_mesh_wrappers_;
+  std::vector<std::shared_ptr<Surface>> groomed_mesh_wrappers_;
 
   std::string override_feature_;
 

--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -786,7 +786,7 @@ double Mesh::geodesicDistance(int source, int target) const {
   }
 
   MeshWrapper wrap(this->poly_data_, true);
-  return wrap.ComputeDistance(getPoint(source), -1, getPoint(target), -1);
+  return wrap.compute_distance(getPoint(source), -1, getPoint(target), -1);
 }
 
 Field Mesh::geodesicDistance(const Point3 landmark) const {
@@ -798,7 +798,7 @@ Field Mesh::geodesicDistance(const Point3 landmark) const {
   MeshWrapper wrap(this->poly_data_, true);
 
   for (int i = 0; i < numPoints(); i++) {
-    distance->SetValue(i, wrap.ComputeDistance(landmark, -1, getPoint(i), -1));
+    distance->SetValue(i, wrap.compute_distance(landmark, -1, getPoint(i), -1));
   }
 
   return distance;

--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -60,7 +60,7 @@
 
 #include "FEFixMesh.h"
 #include "Image.h"
-#include "Libs/Optimize/Domain/MeshWrapper.h"
+#include "Libs/Optimize/Domain/Surface.h"
 #include "Logging.h"
 #include "MeshComputeThickness.h"
 #include "MeshUtils.h"
@@ -785,8 +785,8 @@ double Mesh::geodesicDistance(int source, int target) const {
     throw std::invalid_argument("requested point ids outside range of points available in mesh");
   }
 
-  MeshWrapper wrap(this->poly_data_, true);
-  return wrap.compute_distance(getPoint(source), -1, getPoint(target), -1);
+  Surface surface(this->poly_data_, true);
+  return surface.compute_distance(getPoint(source), -1, getPoint(target), -1);
 }
 
 Field Mesh::geodesicDistance(const Point3 landmark) const {
@@ -795,10 +795,10 @@ Field Mesh::geodesicDistance(const Point3 landmark) const {
   distance->SetNumberOfTuples(numPoints());
   distance->SetName("GeodesicDistanceToLandmark");
 
-  MeshWrapper wrap(this->poly_data_, true);
+  Surface surface(this->poly_data_, true);
 
   for (int i = 0; i < numPoints(); i++) {
-    distance->SetValue(i, wrap.compute_distance(landmark, -1, getPoint(i), -1));
+    distance->SetValue(i, surface.compute_distance(landmark, -1, getPoint(i), -1));
   }
 
   return distance;
@@ -1767,7 +1767,7 @@ Eigen::Vector3d Mesh::getFFCGradient(Eigen::Vector3d query) const {
   return grad;
 }
 
-// WARNING: Copied directly from Meshwrapper. TODO: When refactoring, take this into account.
+// WARNING: Copied directly from Surface. TODO: When refactoring, take this into account.
 vtkSmartPointer<vtkPoints> Mesh::getIGLMesh(Eigen::MatrixXd& V, Eigen::MatrixXi& F) const {
   const int n_verts = this->poly_data_->GetNumberOfPoints();
   const int n_faces = this->poly_data_->GetNumberOfCells();

--- a/Libs/Mesh/Mesh.h
+++ b/Libs/Mesh/Mesh.h
@@ -277,8 +277,8 @@ class Mesh {
 
   //! Formats mesh into an IGL format
   vtkSmartPointer<vtkPoints> getIGLMesh(Eigen::MatrixXd& V, Eigen::MatrixXi& F)
-      const;  // Copied directly from MeshWrapper. this->poly_data_ becomes this->mesh. // WARNING: Copied directly
-              // from Meshwrapper. TODO: When refactoring, take this into account.
+      const;  // Copied directly from Surface. this->poly_data_ becomes this->mesh. // WARNING: Copied directly
+              // from Surface. TODO: When refactoring, take this into account.
 
   //! Clips the mesh according to a field value
   vtkSmartPointer<vtkPolyData> clipByField(const std::string& name, double value);
@@ -293,7 +293,7 @@ class Mesh {
 
   /// Computes baricentric coordinates given a query point and a face number
   Eigen::Vector3d computeBarycentricCoordinates(const Eigen::Vector3d& pt, int face)
-      const;  // // WARNING: Copied directly from Meshwrapper. TODO: When refactoring, take this into account.
+      const;  // // WARNING: Copied directly from Surface. TODO: When refactoring, take this into account.
 
   //! Interpolates scalar values at points (e.g. correspondence points) to the mesh, assign/create a field with the
   //! given name

--- a/Libs/Mesh/MeshUtils.h
+++ b/Libs/Mesh/MeshUtils.h
@@ -8,7 +8,6 @@
 class vtkActor;
 
 namespace shapeworks {
-
 /**
  * \class MeshUtils
  * \ingroup Group-Mesh
@@ -17,54 +16,65 @@ namespace shapeworks {
  *
  */
 class MeshUtils {
- public:
-  /// computes a rigid transformation from source to target using vtkIterativeClosestPointTransform
-  static const vtkSmartPointer<vtkMatrix4x4> createICPTransform(const Mesh source, const Mesh target,
-                                                                Mesh::AlignmentType align,
-                                                                const unsigned iterations = 20,
-                                                                bool meshTransform = false);
+  public:
+    /// computes a rigid transformation from source to target using vtkIterativeClosestPointTransform
+    static const vtkSmartPointer<vtkMatrix4x4> createICPTransform(const Mesh source,
+                                                                  const Mesh target,
+                                                                  Mesh::AlignmentType align,
+                                                                  const unsigned iterations = 20,
+                                                                  bool meshTransform = false);
 
-  /// Mesh from mesh or image file
-  static Mesh create_mesh_from_file(std::string filename, double iso_value = 0.5);
+    /// Mesh from mesh or image file
+    static Mesh create_mesh_from_file(std::string filename, double iso_value = 0.5);
 
-  /// Thread safe reading of a mesh, uses a lock
-  static Mesh threadSafeReadMesh(std::string filename);
+    /// Thread safe reading of a mesh, uses a lock
+    static Mesh threadSafeReadMesh(std::string filename);
 
-  /// Thread safe writing of a mesh, uses a lock
-  static void threadSafeWriteMesh(std::string filename, Mesh mesh);
+    /// Thread safe writing of a mesh, uses a lock
+    static void threadSafeWriteMesh(std::string filename, Mesh mesh);
 
-  /// calculate bounding box incrementally for meshes
-  static PhysicalRegion boundingBox(const std::vector<std::string>& filenames, bool center = false);
+    /// calculate bounding box incrementally for meshes
+    static PhysicalRegion boundingBox(const std::vector<std::string>& filenames, bool center = false);
 
-  /// calculate bounding box incrementally for meshes
-  static PhysicalRegion boundingBox(const std::vector<std::reference_wrapper<const Mesh>>& meshes, bool center = false);
+    /// calculate bounding box incrementally for meshes
+    static PhysicalRegion boundingBox(const std::vector<std::reference_wrapper<const Mesh> >& meshes,
+                                      bool center = false);
 
-  /// calculate bounding box incrementally for meshes
-  static PhysicalRegion boundingBox(const std::vector<Mesh>& meshes, bool center = false);
+    /// calculate bounding box incrementally for meshes
+    static PhysicalRegion boundingBox(const std::vector<Mesh>& meshes, bool center = false);
 
-  /// determine the reference mesh
-  static int findReferenceMesh(std::vector<Mesh>& meshes, int random_subset_size = -1);
+    /// determine the reference mesh
+    static int findReferenceMesh(std::vector<Mesh>& meshes, int random_subset_size = -1);
 
-  /// boundary loop extractor for a given mesh
-  static Mesh boundaryLoopExtractor(Mesh mesh);
+    /// boundary loop extractor for a given mesh
+    static Mesh boundaryLoopExtractor(Mesh mesh);
 
-  /// shared boundary extractor for the left and right mesh
-  static std::array<Mesh, 3> sharedBoundaryExtractor(const Mesh& mesh_l, const Mesh& mesh_r, double tol);
+    /// shared boundary extractor for the left and right mesh
+    static std::array<Mesh, 3> sharedBoundaryExtractor(const Mesh& mesh_l, const Mesh& mesh_r, double tol);
 
-  /// generates and adds normals for points and faces for each mesh in given set of meshes
-  static void generateNormals(const std::vector<std::reference_wrapper<Mesh>>& meshes, bool forceRegen = false);
+    /// generates and adds normals for points and faces for each mesh in given set of meshes
+    static void generateNormals(const std::vector<std::reference_wrapper<Mesh> >& meshes, bool forceRegen = false);
 
-  /// computes average normals for each point in given set of meshes
-  static Field computeMeanNormals(const std::vector<std::string>& filenames, bool autoGenerateNormals = true);
+    /// computes average normals for each point in given set of meshes
+    static Field computeMeanNormals(const std::vector<std::string>& filenames, bool autoGenerateNormals = true);
 
-  /// computes average normals for each point in given set of meshes
-  static Field computeMeanNormals(const std::vector<std::reference_wrapper<const Mesh>>& meshes);
+    /// computes average normals for each point in given set of meshes
+    static Field computeMeanNormals(const std::vector<std::reference_wrapper<const Mesh> >& meshes);
 
-  /// This function visualizes vector and scalar fields for FFCs
-  void visualizeVectorFieldForFFCs(std::shared_ptr<Mesh> mesh);
+    /// This function visualizes vector and scalar fields for FFCs
+    void visualizeVectorFieldForFFCs(std::shared_ptr<Mesh> mesh);
 
-  /// Used as an auxiliary function for vector field visualizations
-  vtkSmartPointer<vtkActor> getArrow(Eigen::Vector3d start, Eigen::Vector3d end);
+    /// Used as an auxiliary function for vector field visualizations
+    vtkSmartPointer<vtkActor> getArrow(Eigen::Vector3d start, Eigen::Vector3d end);
+
+    static int evaluate_triangle_position(const double x[3],
+                                          double closestPoint[3],
+                                          int& subId,
+                                          double pcoords[3],
+                                          double& dist2,
+                                          double weights[],
+                                          double pt3[3],
+                                          double pt1[3],
+                                          double pt2[3]);
 };
-
-}  // namespace shapeworks
+} // namespace shapeworks

--- a/Libs/Optimize/Domain/MeshDomain.cpp
+++ b/Libs/Optimize/Domain/MeshDomain.cpp
@@ -7,7 +7,7 @@ bool MeshDomain::ApplyConstraints(PointType &p, int idx, bool dbg) const {
   if (!mesh_wrapper_) {
     return true;
   }
-  p = mesh_wrapper_->SnapToMesh(p, idx);
+  p = mesh_wrapper_->snap_to_mesh(p, idx);
   return true;
 }
 
@@ -21,7 +21,7 @@ bool MeshDomain::ApplyVectorConstraints(vnl_vector_fixed<double, DIMENSION> &gra
 //-------------------------------------------------------------------
 vnl_vector_fixed<double, DIMENSION> MeshDomain::ProjectVectorToSurfaceTangent(
     vnl_vector_fixed<double, DIMENSION> &gradE, const PointType &pos, int idx) const {
-  return mesh_wrapper_->ProjectVectorToSurfaceTangent(pos, idx, gradE);
+  return mesh_wrapper_->project_vector_to_surface_tangent(pos, idx, gradE);
 }
 
 //-------------------------------------------------------------------
@@ -31,14 +31,14 @@ MeshDomain::PointType MeshDomain::UpdateParticlePosition(const PointType &point,
   for (unsigned int i = 0; i < DIMENSION; i++) {
     negativeUpdate[i] = -update[i];
   }
-  PointType newPoint = mesh_wrapper_->GeodesicWalk(point, idx, negativeUpdate);
+  PointType newPoint = mesh_wrapper_->geodesic_walk(point, idx, negativeUpdate);
   return newPoint;
 }
 
 //-------------------------------------------------------------------
 double MeshDomain::GetMaxDiameter() const {
   // todo should this not be the length of the bounding box diagonal?
-  PointType boundingBoxSize = mesh_wrapper_->GetMeshUpperBound() - mesh_wrapper_->GetMeshLowerBound();
+  PointType boundingBoxSize = mesh_wrapper_->get_mesh_upper_bound() - mesh_wrapper_->get_mesh_lower_bound();
   double max = 0;
   for (int d = 0; d < 3; d++) {
     max = max > boundingBoxSize[d] ? max : boundingBoxSize[d];
@@ -48,17 +48,17 @@ double MeshDomain::GetMaxDiameter() const {
 
 //-------------------------------------------------------------------
 vnl_vector_fixed<float, 3> MeshDomain::SampleGradientAtPoint(const PointType &point, int idx) const {
-  return mesh_wrapper_->SampleNormalAtPoint(point, idx);
+  return mesh_wrapper_->sample_normal_at_point(point, idx);
 }
 
 //-------------------------------------------------------------------
 vnl_vector_fixed<float, 3> MeshDomain::SampleNormalAtPoint(const PointType &point, int idx) const {
-  return mesh_wrapper_->SampleNormalAtPoint(point, idx);
+  return mesh_wrapper_->sample_normal_at_point(point, idx);
 }
 
 //-------------------------------------------------------------------
 ParticleDomain::GradNType MeshDomain::SampleGradNAtPoint(const PointType &p, int idx) const {
-  return mesh_wrapper_->SampleGradNAtPoint(p, idx);
+  return mesh_wrapper_->sample_gradient_normal_at_point(p, idx);
 }
 
 //-------------------------------------------------------------------
@@ -76,19 +76,19 @@ double MeshDomain::SquaredDistance(const PointType &a, int idx_a, const PointTyp
 //-------------------------------------------------------------------
 bool MeshDomain::IsWithinDistance(const PointType &a, int idx_a, const PointType &b, int idx_b, double test_dist,
                                   double &dist) const {
-  return geodesics_mesh_->IsWithinDistance(a, idx_a, b, idx_b, test_dist, dist);
+  return geodesics_mesh_->is_within_distance(a, idx_a, b, idx_b, test_dist, dist);
 }
 
 //-------------------------------------------------------------------
 void MeshDomain::SetMesh(std::shared_ptr<MeshWrapper> mesh, double geodesic_remesh_percent) {
   m_FixedDomain = false;
   mesh_wrapper_ = mesh;
-  sw_mesh_ = std::make_shared<Mesh>(mesh_wrapper_->GetPolydata());
+  sw_mesh_ = std::make_shared<Mesh>(mesh_wrapper_->get_polydata());
 
   if (geodesic_remesh_percent >= 100.0) { // no remeshing
     geodesics_mesh_ = mesh_wrapper_;
   } else {
-    auto poly_data = mesh_wrapper_->GetPolydata();
+    auto poly_data = mesh_wrapper_->get_polydata();
     Mesh mesh_copy(poly_data);
     mesh_copy.remeshPercent(geodesic_remesh_percent, 1.0);
     geodesics_mesh_ = std::make_shared<MeshWrapper>(mesh_copy.getVTKMesh());
@@ -96,7 +96,7 @@ void MeshDomain::SetMesh(std::shared_ptr<MeshWrapper> mesh, double geodesic_reme
 }
 
 //-------------------------------------------------------------------
-void MeshDomain::InvalidateParticlePosition(int idx) const { this->mesh_wrapper_->InvalidateParticle(idx); }
+void MeshDomain::InvalidateParticlePosition(int idx) const { this->mesh_wrapper_->invalidate_particle(idx); }
 
 //-------------------------------------------------------------------
 ParticleDomain::PointType MeshDomain::GetZeroCrossingPoint() const {
@@ -108,7 +108,7 @@ ParticleDomain::PointType MeshDomain::GetZeroCrossingPoint() const {
     p[0] = p[1] = p[2] = 0;
     return p;
   }
-  return mesh_wrapper_->GetPointOnMesh();
+  return mesh_wrapper_->get_point_on_mesh();
 }
 
 //-------------------------------------------------------------------

--- a/Libs/Optimize/Domain/MeshDomain.cpp
+++ b/Libs/Optimize/Domain/MeshDomain.cpp
@@ -64,12 +64,12 @@ ParticleDomain::GradNType MeshDomain::SampleGradNAtPoint(const PointType &p, int
 //-------------------------------------------------------------------
 double MeshDomain::Distance(const PointType &a, int idx_a, const PointType &b, int idx_b,
                             vnl_vector_fixed<double, 3> *out_grad) const {
-  return geodesics_mesh_->ComputeDistance(a, idx_a, b, idx_b, out_grad);
+  return geodesics_mesh_->compute_distance(a, idx_a, b, idx_b, out_grad);
 }
 
 //-------------------------------------------------------------------
 double MeshDomain::SquaredDistance(const PointType &a, int idx_a, const PointType &b, int idx_b) const {
-  double dist = geodesics_mesh_->ComputeDistance(a, idx_a, b, idx_b);
+  double dist = geodesics_mesh_->compute_distance(a, idx_a, b, idx_b);
   return dist * dist;
 }
 

--- a/Libs/Optimize/Domain/MeshDomain.h
+++ b/Libs/Optimize/Domain/MeshDomain.h
@@ -37,8 +37,8 @@ class MeshDomain : public ParticleDomain {
     return 0.02;
   }
 
-  const PointType &GetLowerBound() const override { return mesh_wrapper_->GetMeshLowerBound(); }
-  const PointType &GetUpperBound() const override { return mesh_wrapper_->GetMeshUpperBound(); }
+  const PointType &GetLowerBound() const override { return mesh_wrapper_->get_mesh_lower_bound(); }
+  const PointType &GetUpperBound() const override { return mesh_wrapper_->get_mesh_upper_bound(); }
 
   PointType GetZeroCrossingPoint() const override;
 

--- a/Libs/Optimize/Domain/MeshDomain.h
+++ b/Libs/Optimize/Domain/MeshDomain.h
@@ -2,7 +2,7 @@
 
 #include <itkObjectFactory.h>
 
-#include "MeshWrapper.h"
+#include "Surface.h"
 #include "ParticleDomain.h"
 
 namespace shapeworks {
@@ -37,8 +37,8 @@ class MeshDomain : public ParticleDomain {
     return 0.02;
   }
 
-  const PointType &GetLowerBound() const override { return mesh_wrapper_->get_mesh_lower_bound(); }
-  const PointType &GetUpperBound() const override { return mesh_wrapper_->get_mesh_upper_bound(); }
+  const PointType &GetLowerBound() const override { return surface_->get_mesh_lower_bound(); }
+  const PointType &GetUpperBound() const override { return surface_->get_mesh_upper_bound(); }
 
   PointType GetZeroCrossingPoint() const override;
 
@@ -73,17 +73,17 @@ class MeshDomain : public ParticleDomain {
     // TODO Change this to a generic delete function
   }
 
-  void SetMesh(std::shared_ptr<MeshWrapper> mesh_, double geodesic_remesh_percent);
+  void SetMesh(std::shared_ptr<Surface> mesh_, double geodesic_remesh_percent);
 
   std::shared_ptr<Mesh> GetSWMesh() const { return sw_mesh_; }
 
   void UpdateZeroCrossingPoint() override {}
 
-  std::shared_ptr<MeshWrapper> GetMeshWrapper() const { return mesh_wrapper_; }
+  std::shared_ptr<Surface> get_surface() const { return surface_; }
 
  private:
-  std::shared_ptr<MeshWrapper> mesh_wrapper_;
-  std::shared_ptr<MeshWrapper> geodesics_mesh_;
+  std::shared_ptr<Surface> surface_;
+  std::shared_ptr<Surface> geodesics_mesh_;
   std::shared_ptr<Mesh> sw_mesh_;
   PointType zero_crossing_point_;
 };

--- a/Libs/Optimize/Domain/MeshWrapper.h
+++ b/Libs/Optimize/Domain/MeshWrapper.h
@@ -17,6 +17,26 @@ class vtkCellLocator;
 
 namespace shapeworks {
 
+//! Simple struct to represent a triangle in 3D space
+class Triangle {
+ public:
+  Triangle() = default;
+  Triangle(int a, int b, int c) : a_(a), b_(b), c_(c) {}
+
+  int get_point(int id) const {
+    if (id == 0) {
+      return a_;
+    } else if (id == 1) {
+      return b_;
+    } else if (id == 2) {
+      return c_;
+    }
+    throw std::runtime_error("Invalid point id");
+  }
+
+  int a_, b_, c_;
+};
+
 class MeshWrapper {
  public:
   using PointType = ParticleDomain::PointType;
@@ -105,7 +125,7 @@ class MeshWrapper {
   std::vector<GradNType> grad_normals_;
 
   // cache of specialized cells for direct access
-  std::vector<vtkSmartPointer<vtkTriangle>> triangles_;
+  std::vector<Triangle> triangles_;
 
   // bounds of the mesh plus some buffer
   PointType mesh_lower_bound_;

--- a/Libs/Optimize/Domain/MeshWrapper.h
+++ b/Libs/Optimize/Domain/MeshWrapper.h
@@ -14,169 +14,183 @@
 class vtkCellLocator;
 
 namespace shapeworks {
-
 //! Simple struct to represent a triangle in 3D space
 class Triangle {
- public:
-  Triangle() = default;
-  Triangle(int a, int b, int c) : a_(a), b_(b), c_(c) {}
-
-  int get_point(int id) const {
-    if (id == 0) {
-      return a_;
-    } else if (id == 1) {
-      return b_;
-    } else if (id == 2) {
-      return c_;
+  public:
+    Triangle() = default;
+    Triangle(const int a, const int b, const int c) : a_(a), b_(b), c_(c) {
     }
-    throw std::runtime_error("Invalid point id");
-  }
 
-  int a_, b_, c_;
+    int get_point(const int id) const {
+      if (id == 0) {
+        return a_;
+      } else if (id == 1) {
+        return b_;
+      } else if (id == 2) {
+        return c_;
+      }
+      throw std::runtime_error("Invalid point id");
+    }
+
+    int a_, b_, c_;
 };
 
 class MeshWrapper {
- public:
-  using PointType = ParticleDomain::PointType;
-  using GradNType = ParticleDomain::GradNType;
+  public:
+    using PointType = ParticleDomain::PointType;
+    using GradNType = ParticleDomain::GradNType;
 
-  using NormalType = vnl_vector_fixed<float, 3>;
-  using VectorType = vnl_vector_fixed<double, 3>;
+    using NormalType = vnl_vector_fixed<float, 3>;
+    using VectorType = vnl_vector_fixed<double, 3>;
 
-  explicit MeshWrapper(vtkSmartPointer<vtkPolyData> mesh, bool geodesics_enabled = false,
-                       size_t geodesics_cache_multiplier_size = 0);  // 0 => MeshWrapper will choose a heuristic
+    explicit MeshWrapper(vtkSmartPointer<vtkPolyData> mesh,
+                         bool geodesics_enabled = false,
+                         size_t geodesics_cache_multiplier_size = 0); // 0 => MeshWrapper will choose a heuristic
 
-  ~MeshWrapper() = default;
+    ~MeshWrapper() = default;
 
-  double compute_distance(const PointType& pointa, int idxa, const PointType& pointb, int idxb,
-                         VectorType* out_grad = nullptr) const;
+    double compute_distance(const PointType& pointa,
+                            int idxa,
+                            const PointType& pointb,
+                            int idxb,
+                            VectorType* out_grad = nullptr) const;
 
-  bool IsWithinDistance(const PointType& pointa, int idxa, const PointType& pointb, int idxb, double test_dist,
-                        double& dist) const;
+    bool is_within_distance(const PointType& pointa,
+                            int idxa,
+                            const PointType& pointb,
+                            int idxb,
+                            double test_dist,
+                            double& dist) const;
 
-  PointType GeodesicWalk(PointType p, int idx, VectorType vector) const;
+    PointType geodesic_walk(PointType p, int idx, VectorType vector) const;
 
-  VectorType ProjectVectorToSurfaceTangent(const PointType& pointa, int idx, VectorType& vector) const;
+    VectorType project_vector_to_surface_tangent(const PointType& pointa, int idx, VectorType& vector) const;
 
-  NormalType SampleNormalAtPoint(PointType p, int idx = -1) const;
-  GradNType SampleGradNAtPoint(PointType p, int idx) const;
+    NormalType sample_normal_at_point(PointType p, int idx = -1) const;
+    GradNType sample_gradient_normal_at_point(PointType p, int idx) const;
 
-  PointType SnapToMesh(PointType pointa, int idx) const;
+    PointType snap_to_mesh(PointType pointa, int idx) const;
 
-  PointType GetPointOnMesh() const;
+    PointType get_point_on_mesh() const;
 
-  inline const PointType& GetMeshLowerBound() const { return mesh_lower_bound_; }
+    inline const PointType& get_mesh_lower_bound() const { return mesh_lower_bound_; }
 
-  inline const PointType& GetMeshUpperBound() const { return mesh_upper_bound_; }
+    inline const PointType& get_mesh_upper_bound() const { return mesh_upper_bound_; }
 
-  virtual void InvalidateParticle(int idx);
+    virtual void invalidate_particle(int idx);
 
-  inline vtkSmartPointer<vtkPolyData> GetPolydata() const { return original_mesh_; }
+    inline vtkSmartPointer<vtkPolyData> get_polydata() const { return original_mesh_; }
 
-  bool IsGeodesicsEnabled() const { return this->is_geodesics_enabled_; }
+    bool is_geodesics_enabled() const { return this->is_geodesics_enabled_; }
 
- private:
-  void ComputeMeshBounds();
-  void ComputeGradN(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F);
+  private:
+    void compute_mesh_bounds();
+    void compute_grad_normals(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F);
 
-  int GetTriangleForPoint(const double pt[3], int idx, double closest_point[3]) const;
+    int get_triangle_for_point(const double pt[3], int idx, double closest_point[3]) const;
 
-  Eigen::Vector3d ProjectVectorToFace(const Eigen::Vector3d& normal, const Eigen::Vector3d& vector) const;
+    Eigen::Vector3d project_vector_to_face(const Eigen::Vector3d& normal, const Eigen::Vector3d& vector) const;
 
-  const Eigen::Vector3d GetFaceNormal(int face_index) const;
+    const Eigen::Vector3d get_face_normal(int face_index) const;
 
-  bool IsInTriangle(const double pt[3], int face_index) const;
+    bool is_in_triangle(const double pt[3], int face_index) const;
 
-  Eigen::Vector3d ComputeBarycentricCoordinates(const Eigen::Vector3d& pt, int face) const;
+    Eigen::Vector3d compute_barycentric_coordinates(const Eigen::Vector3d& pt, int face) const;
 
-  int ComputeFaceAndWeights(const PointType& p, int idx, Eigen::Vector3d& weights) const;
+    int compute_face_and_weights(const PointType& p, int idx, Eigen::Vector3d& weights) const;
 
-  Eigen::Vector3d GeodesicWalkOnFace(Eigen::Vector3d point_a, Eigen::Vector3d projected_vector, int face_index,
-                                     int& ending_face) const;
+    Eigen::Vector3d geodesic_walk_on_face(Eigen::Vector3d point_a,
+                                          Eigen::Vector3d projected_vector,
+                                          int face_index,
+                                          int& ending_face) const;
 
-  Eigen::Vector3d GetBarycentricIntersection(Eigen::Vector3d start, Eigen::Vector3d end, int currentFace,
-                                             int edge) const;
+    Eigen::Vector3d get_barycentric_intersection(Eigen::Vector3d start,
+                                                 Eigen::Vector3d end,
+                                                 int currentFace,
+                                                 int edge) const;
 
-  int GetAcrossEdge(int face, int edge) const;
+    int get_across_edge(int face, int edge) const;
 
-  int GetFacePointID(int face, int point_id) const;
+    int get_face_point_id(int face, int point_id) const;
 
-  int SlideAlongEdge(Eigen::Vector3d& point, Eigen::Vector3d& remainingVector_, int face_, int edge_) const;
+    int slide_along_edge(Eigen::Vector3d& point, Eigen::Vector3d& remainingVector_, int face_, int edge_) const;
 
-  Eigen::Vector3d GetVertexCoords(int vertex_id) const;
+    Eigen::Vector3d get_vertex_coords(int vertex_id) const;
 
-  Eigen::Vector3d RotateVectorToFace(const Eigen::Vector3d& prev_normal, const Eigen::Vector3d& next_normal,
-                                     const Eigen::Vector3d& vector) const;
+    Eigen::Vector3d rotate_vector_to_face(const Eigen::Vector3d& prev_normal,
+                                          const Eigen::Vector3d& next_normal,
+                                          const Eigen::Vector3d& vector) const;
 
-  vtkSmartPointer<vtkPolyData> poly_data_;
-  vtkSmartPointer<vtkPolyData> original_mesh_;
+    vtkSmartPointer<vtkPolyData> poly_data_;
+    vtkSmartPointer<vtkPolyData> original_mesh_;
 
-  NormalType CalculateNormalAtPoint(MeshWrapper::PointType p, int idx) const;
+    NormalType calculate_normal_at_point(MeshWrapper::PointType p, int idx) const;
 
-  // Caches of triangle, normal and position
-  // Has to be mutable because all of the accessor APIs are const
-  mutable std::vector<int> particle_triangles_;
-  mutable std::vector<NormalType> particle_normals_;
-  mutable std::vector<PointType> particle_positions_;
-  mutable std::vector<double> particle_neighboorhood_;
+    // Caches of triangle, normal and position
+    // Has to be mutable because all of the accessor APIs are const
+    mutable std::vector<int> particle_triangles_;
+    mutable std::vector<NormalType> particle_normals_;
+    mutable std::vector<PointType> particle_positions_;
+    mutable std::vector<double> particle_neighboorhood_;
 
-  std::vector<GradNType> grad_normals_;
+    std::vector<GradNType> grad_normals_;
 
-  // cache of specialized cells for direct access
-  std::vector<Triangle> triangles_;
+    // cache of specialized cells for direct access
+    std::vector<Triangle> triangles_;
 
-  // bounds of the mesh plus some buffer
-  PointType mesh_lower_bound_;
-  PointType mesh_upper_bound_;
+    // bounds of the mesh plus some buffer
+    PointType mesh_lower_bound_;
+    PointType mesh_upper_bound_;
 
-  // cell locator to find closest point on mesh
-  vtkSmartPointer<vtkCellLocator> cell_locator_;
+    // cell locator to find closest point on mesh
+    vtkSmartPointer<vtkCellLocator> cell_locator_;
 
-  /////////////////////////
-  // Geodesic distances
+    /////////////////////////
+    // Geodesic distances
 
-  bool is_geodesics_enabled_{false};
+    bool is_geodesics_enabled_{false};
 
-  // Geometry Central data structures
-  std::unique_ptr<geometrycentral::surface::SurfaceMesh> gc_mesh_;
-  std::unique_ptr<geometrycentral::surface::VertexPositionGeometry> gc_geometry_;
-  std::unique_ptr<geometrycentral::surface::HeatMethodDistanceSolver> gc_heatsolver_;
+    // Geometry Central data structures
+    std::unique_ptr<geometrycentral::surface::SurfaceMesh> gc_mesh_;
+    std::unique_ptr<geometrycentral::surface::VertexPositionGeometry> gc_geometry_;
+    std::unique_ptr<geometrycentral::surface::HeatMethodDistanceSolver> gc_heatsolver_;
 
-  size_t geo_max_cache_entries_{0};
-  mutable size_t geo_cache_size_{0};
+    size_t geo_max_cache_entries_{0};
+    mutable size_t geo_cache_size_{0};
 
-  // Flattened version of libigl's gradient operator
-  std::vector<Eigen::Matrix3d> face_grad_;
+    // Flattened version of libigl's gradient operator
+    std::vector<Eigen::Matrix3d> face_grad_;
 
-  std::vector<std::unordered_set<int>> face_kring_;
+    std::vector<std::unordered_set<int> > face_kring_;
 
-  // Cache for geodesic distances from a triangle
-  mutable std::vector<MeshGeoEntry> geo_dist_cache_;
+    // Cache for geodesic distances from a triangle
+    mutable std::vector<MeshGeoEntry> geo_dist_cache_;
 
-  // Returns true if face f_a is in the K-ring of face f_b
-  bool AreFacesInKRing(int f_a, int f_b) const;
-  const size_t kring_{1};
+    // Returns true if face f_a is in the K-ring of face f_b
+    bool are_faces_in_k_ring(int f_a, int f_b) const;
+    const size_t kring_{1};
 
-  // Convert the mesh to libigl data structures
-  void GetIGLMesh(Eigen::MatrixXd& V, Eigen::MatrixXi& F) const;
+    // Convert the mesh to libigl data structures
+    void get_igl_mesh(Eigen::MatrixXd& V, Eigen::MatrixXi& F) const;
 
-  // Precompute heat data structures for faster geodesic lookups
-  void PrecomputeGeodesics(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F);
+    // Precompute heat data structures for faster geodesic lookups
+    void precompute_geodesics(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F);
 
-  void ComputeKRing(int f, int k, std::unordered_set<int>& ring) const;
+    void compute_k_ring(int f, int k, std::unordered_set<int>& ring) const;
 
-  const MeshGeoEntry& GeodesicsFromTriangle(int f, double max_dist = std::numeric_limits<double>::max(),
-                                            int req_target_f = -1) const;
-  const Eigen::Matrix3d GeodesicsFromTriangleToTriangle(int f_a, int f_b) const;
-  void ClearGeodesicCache() const;
+    const MeshGeoEntry& geodesics_from_triangle(int f,
+                                                double max_dist = std::numeric_limits<double>::max(),
+                                                int req_target_f = -1) const;
+    const Eigen::Matrix3d geodesics_from_triangle_to_triangle(int f_a, int f_b) const;
+    void clear_geodesic_cache() const;
 
-  // Store some info about the last query. This accelerates the computation
-  // because the optimizer generally asks for the distances _from_ the same
-  // point as the previous query.
-  mutable bool geo_lq_cached_{false};
-  mutable PointType geo_lq_pt_a_{-1};
-  mutable int geo_lq_face_{-1};
-  mutable Eigen::Vector3d geo_lq_bary_;
-  void FetchAndCacheFirstPoint(const PointType pt_a, int idx_a, int& face_a, Eigen::Vector3d& bary_a) const;
+    // Store some info about the last query. This accelerates the computation
+    // because the optimizer generally asks for the distances _from_ the same
+    // point as the previous query.
+    mutable bool geo_lq_cached_{false};
+    mutable PointType geo_lq_pt_a_{-1};
+    mutable int geo_lq_face_{-1};
+    mutable Eigen::Vector3d geo_lq_bary_;
+    void fetch_and_cache_first_point(const PointType pt_a, int idx_a, int& face_a, Eigen::Vector3d& bary_a) const;
 };
-}  // namespace shapeworks
+} // namespace shapeworks

--- a/Libs/Optimize/Domain/MeshWrapper.h
+++ b/Libs/Optimize/Domain/MeshWrapper.h
@@ -6,12 +6,10 @@
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>
 
-#include <unordered_map>
 #include <unordered_set>
 
 #include "Libs/Optimize/Domain/ParticleDomain.h"
 #include "MeshGeoEntry.h"
-#include "MeshWrapper.h"
 
 class vtkCellLocator;
 
@@ -50,7 +48,7 @@ class MeshWrapper {
 
   ~MeshWrapper() = default;
 
-  double ComputeDistance(const PointType& pointa, int idxa, const PointType& pointb, int idxb,
+  double compute_distance(const PointType& pointa, int idxa, const PointType& pointb, int idxb,
                          VectorType* out_grad = nullptr) const;
 
   bool IsWithinDistance(const PointType& pointa, int idxa, const PointType& pointb, int idxb, double test_dist,

--- a/Libs/Optimize/Domain/Surface.cpp
+++ b/Libs/Optimize/Domain/Surface.cpp
@@ -81,7 +81,6 @@ Surface::Surface(vtkSmartPointer<vtkPolyData> poly_data,
   compute_mesh_bounds();
 
   get_igl_mesh(vertices_, faces_);
-  compute_grad_normals(vertices_, faces_);
 
   is_geodesics_enabled_ = is_geodesics_enabled;
   if (is_geodesics_enabled_) {
@@ -326,6 +325,10 @@ GradNType Surface::sample_gradient_normal_at_point(PointType p, int idx) const {
 
   GradNType weighted_grad_normal = GradNType(0.0);
 
+  if (grad_normals_.size() == 0) {
+    compute_grad_normals(vertices_, faces_);
+  }
+
   for (int i = 0; i < 3; i++) {
     auto id = faces_(face_index, i);
     GradNType grad_normal = grad_normals_[id];
@@ -418,7 +421,7 @@ void Surface::compute_mesh_bounds() {
 }
 
 //---------------------------------------------------------------------------
-void Surface::compute_grad_normals(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F) {
+void Surface::compute_grad_normals(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F) const {
   const int n_verts = V.rows();
   const int n_faces = F.rows();
 

--- a/Libs/Optimize/Domain/Surface.cpp
+++ b/Libs/Optimize/Domain/Surface.cpp
@@ -640,28 +640,11 @@ void Surface::compute_grad_normals(const Eigen::MatrixXd& V, const Eigen::Matrix
 
 //---------------------------------------------------------------------------
 bool Surface::is_in_triangle(const double* pt, int face_index) const {
-  /*
   double dist2;
   Eigen::Vector3d bary;
 
   Eigen::Vector3d pt_eigen(pt[0], pt[1], pt[2]);
   int ret = compute_barycentric_coordinates(pt_eigen, face_index, dist2, bary);
-*/
-
-  double closest[3];
-  int sub_id;
-  double pcoords[3];
-  double dist2;
-  double bary[3];
-
-  vtkTriangle* triangle = vtkTriangle::New();
-  triangle->GetPoints()->SetPoint(0, poly_data_->GetPoint(triangles_[face_index].a_));
-  triangle->GetPoints()->SetPoint(1, poly_data_->GetPoint(triangles_[face_index].b_));
-  triangle->GetPoints()->SetPoint(2, poly_data_->GetPoint(triangles_[face_index].c_));
-
-  int ret = triangle->EvaluatePosition(pt, closest, sub_id, pcoords, dist2, bary);
-
-  triangle->Delete();
 
   if (ret && dist2 < epsilon) {
     bool bary_check = ((bary[0] >= -epsilon) && (bary[0] <= 1 + epsilon)) &&
@@ -685,35 +668,17 @@ int Surface::compute_barycentric_coordinates(const Eigen::Vector3d& pt,
                                              int face,
                                              double& dist2,
                                              Eigen::Vector3d& bary) const {
+  double pt1[3], pt2[3], pt3[3];
   double closest[3];
   int sub_id;
   double pcoords[3];
 
-  double pt1[3], pt2[3], pt3[3];
-
-  vtkTriangle* triangle = vtkTriangle::New();
-  triangle->GetPoints()->SetPoint(0, poly_data_->GetPoint(triangles_[face].a_));
-  triangle->GetPoints()->SetPoint(1, poly_data_->GetPoint(triangles_[face].b_));
-  triangle->GetPoints()->SetPoint(2, poly_data_->GetPoint(triangles_[face].c_));
-
-  double pto[3] = {pt[0], pt[1], pt[2]};
-  double bary_array[3];
-
-  int ret = triangle->EvaluatePosition(pto, closest, sub_id, pcoords, dist2, bary_array);
-  bary = Eigen::Vector3d(bary_array[0], bary_array[1], bary_array[2]);
-
-  return ret;
-
-  /*
-
   poly_data_->GetPoint(triangles_[face].a_, pt1);
   poly_data_->GetPoint(triangles_[face].b_, pt2);
   poly_data_->GetPoint(triangles_[face].c_, pt3);
-  ???
 
   int rc = evaluate_position(pt.data(), closest, sub_id, pcoords, dist2, bary.data(), pt1, pt2, pt3);
   return rc;
-  */
 }
 
 //---------------------------------------------------------------------------
@@ -779,94 +744,90 @@ Eigen::Vector3d Surface::geodesic_walk_on_face(Eigen::Vector3d point_a,
         std::cerr << "targetBary: " << PrintValue<vec3>(targetBary) << "\n";
         std::cerr << std::endl;
         */
-  break;
-}
+      break;
+    }
 
-if
-(target_bary[0]
-+
-barycentric_epsilon
->=
-0
-&&
-target_bary [1]
-+
-barycentric_epsilon
->=
-0
-&&
-target_bary [2]
-+
-barycentric_epsilon
->=
-0
-&&
-target_bary [0]
--
-barycentric_epsilon
-<=
-1
-&&
-target_bary [1]
--
-barycentric_epsilon
-<=
-1
-&&
-target_bary [2]
--
-barycentric_epsilon
-<=
-1
-)
- {
+    if
+    (target_bary[0]
+      +
+      barycentric_epsilon
+      >=
+      0
+      &&
+      target_bary[1]
+      +
+      barycentric_epsilon
+      >=
+      0
+      &&
+      target_bary[2]
+      +
+      barycentric_epsilon
+      >=
+      0
+      &&
+      target_bary[0]
+      -
+      barycentric_epsilon
+      <=
+      1
+      &&
+      target_bary[1]
+      -
+      barycentric_epsilon
+      <=
+      1
+      &&
+      target_bary[2]
+      -
+      barycentric_epsilon
+      <=
+      1
+    ) {
       current_point = target_point;
       break;
     }
 
-std::vector<int> negative_vertices;
-for
-(
-int i = 0;
-i<3;
-i
-++
-)
- {
+    std::vector<int> negative_vertices;
+    for
+    (
+      int i = 0;
+      i < 3;
+      i
+      ++
+    ) {
       if (target_bary[i] < 0) {
         negative_vertices.push_back(i);
       }
     }
 
-if
-(negative_vertices
-.
-size()
-==
-0
-||
-negative_vertices
-.
-size()
->
-2
-)
- {
+    if
+    (negative_vertices
+      .
+      size()
+      ==
+      0
+      ||
+      negative_vertices
+      .
+      size()
+      >
+      2
+    ) {
       std::cerr << "ERROR: invalid number of negative vertices. Point is not on surface.\n";
       break;
     }
-int negativeEdge = negative_vertices[0];
-Eigen::Vector3d intersect = get_barycentric_intersection(current_bary, target_bary, current_face, negativeEdge);
+    int negativeEdge = negative_vertices[0];
+    Eigen::Vector3d intersect = get_barycentric_intersection(current_bary, target_bary, current_face, negativeEdge);
 
-// When more than 1 negative barycentric coordinate, compute both intersections and take the closest one.
-if
-(negative_vertices
-.
-size()
-==
-2
-)
- {
+    // When more than 1 negative barycentric coordinate, compute both intersections and take the closest one.
+    if
+    (negative_vertices
+      .
+      size()
+      ==
+      2
+    ) {
       int negativeEdge1 = negative_vertices[1];
       Eigen::Vector3d intersect1 = get_barycentric_intersection(current_bary, target_bary, current_face, negativeEdge1);
 
@@ -882,56 +843,52 @@ size()
       }
     }
 
-Eigen::Vector3d remaining = target_point - intersect;
-int next_face = get_across_edge(current_face, negativeEdge);
-if
-(next_face
-==
--
-1
-)
- {
+    Eigen::Vector3d remaining = target_point - intersect;
+    int next_face = get_across_edge(current_face, negativeEdge);
+    if
+    (next_face
+      ==
+      -
+      1
+    ) {
       next_face = slide_along_edge(intersect, remaining, current_face, negativeEdge);
     }
-remaining_vector= remaining;
-if
-(next_face
-!=
--
-1
-)
- {
+    remaining_vector = remaining;
+    if
+    (next_face
+      !=
+      -
+      1
+    ) {
       remaining_vector = rotate_vector_to_face(get_face_normal(current_face),
                                                get_face_normal(next_face),
                                                remaining_vector);
     }
-current_point= intersect;
-current_face= next_face;
-if
-(current_face
-!=
--
-1
-)
- {
+    current_point = intersect;
+    current_face = next_face;
+    if
+    (current_face
+      !=
+      -
+      1
+    ) {
       prev_face = current_face;
     }
-}
+  }
 
-if
-(current_face
-!=
--
-1
-)
- {
+  if
+  (current_face
+    !=
+    -
+    1
+  ) {
     prev_face = current_face;
   }
 
-ending_face= prev_face;
-assert(ending_face != -1);
-return
-current_point;
+  ending_face = prev_face;
+  assert(ending_face != -1);
+  return
+      current_point;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Optimize/Domain/Surface.cpp
+++ b/Libs/Optimize/Domain/Surface.cpp
@@ -13,6 +13,7 @@
 #include <vtkPolyDataNormals.h>
 #include <vtkTriangle.h>
 #include <vtkTriangleFilter.h>
+#include <vtkLine.h>
 
 #include "ExternalLibs/robin_hood/robin_hood.h"
 
@@ -44,6 +45,157 @@ using NormalType = Surface::NormalType;
 using VectorType = Surface::VectorType;
 using PointType = Surface::PointType;
 using GradNType = Surface::GradNType;
+
+//------------------------------------------------------------------------------
+//! From vtkTriangle::EvaluatePosition
+int evaluate_position(const double x[3],
+                      double closestPoint[3],
+                      int& subId,
+                      double pcoords[3],
+                      double& dist2,
+                      double weights[],
+                      double pt3[3],
+                      double pt1[3],
+                      double pt2[3]) {
+  int i, j;
+  double n[3], fabsn;
+  double rhs[2], c1[2], c2[2];
+  double det;
+  double maxComponent;
+  int idx = 0, indices[2];
+  double dist2Point, dist2Line1, dist2Line2;
+  double* closest, closestPoint1[3], closestPoint2[3], cp[3];
+
+  subId = 0;
+  pcoords[2] = 0.0;
+
+  // Get normal for triangle, only the normal direction is needed, i.e. the
+  // normal need not be normalized (unit length)
+  vtkTriangle::ComputeNormalDirection(pt1, pt2, pt3, n);
+
+  // Project point to plane
+  vtkPlane::GeneralizedProjectPoint(x, pt1, n, cp);
+
+  // Construct matrices.  Since we have over determined system, need to find
+  // which 2 out of 3 equations to use to develop equations. (Any 2 should
+  // work since we've projected point to plane.)
+  //
+  for (maxComponent = 0.0, i = 0; i < 3; i++) {
+    // trying to avoid an expensive call to fabs()
+    if (n[i] < 0) {
+      fabsn = -n[i];
+    } else {
+      fabsn = n[i];
+    }
+    if (fabsn > maxComponent) {
+      maxComponent = fabsn;
+      idx = i;
+    }
+  }
+  for (j = 0, i = 0; i < 3; i++) {
+    if (i != idx) {
+      indices[j++] = i;
+    }
+  }
+
+  for (i = 0; i < 2; i++) {
+    rhs[i] = cp[indices[i]] - pt3[indices[i]];
+    c1[i] = pt1[indices[i]] - pt3[indices[i]];
+    c2[i] = pt2[indices[i]] - pt3[indices[i]];
+  }
+
+  if ((det = vtkMath::Determinant2x2(c1, c2)) == 0.0) {
+    pcoords[0] = pcoords[1] = 0.0;
+    return -1;
+  }
+
+  pcoords[0] = vtkMath::Determinant2x2(rhs, c2) / det;
+  pcoords[1] = vtkMath::Determinant2x2(c1, rhs) / det;
+
+  // Okay, now find closest point to element
+  //
+  weights[0] = 1 - (pcoords[0] + pcoords[1]);
+  weights[1] = pcoords[0];
+  weights[2] = pcoords[1];
+
+  if (weights[0] >= 0.0 && weights[0] <= 1.0 && weights[1] >= 0.0 && weights[1] <= 1.0 &&
+    weights[2] >= 0.0 && weights[2] <= 1.0) {
+    // projection distance
+    if (closestPoint) {
+      dist2 = vtkMath::Distance2BetweenPoints(cp, x);
+      closestPoint[0] = cp[0];
+      closestPoint[1] = cp[1];
+      closestPoint[2] = cp[2];
+    }
+    return 1;
+  } else {
+    double t;
+    if (closestPoint) {
+      if (weights[1] < 0.0 && weights[2] < 0.0) {
+        dist2Point = vtkMath::Distance2BetweenPoints(x, pt3);
+        dist2Line1 = vtkLine::DistanceToLine(x, pt1, pt3, t, closestPoint1);
+        dist2Line2 = vtkLine::DistanceToLine(x, pt3, pt2, t, closestPoint2);
+        if (dist2Point < dist2Line1) {
+          dist2 = dist2Point;
+          closest = pt3;
+        } else {
+          dist2 = dist2Line1;
+          closest = closestPoint1;
+        }
+        if (dist2Line2 < dist2) {
+          dist2 = dist2Line2;
+          closest = closestPoint2;
+        }
+        for (i = 0; i < 3; i++) {
+          closestPoint[i] = closest[i];
+        }
+      } else if (weights[2] < 0.0 && weights[0] < 0.0) {
+        dist2Point = vtkMath::Distance2BetweenPoints(x, pt1);
+        dist2Line1 = vtkLine::DistanceToLine(x, pt1, pt3, t, closestPoint1);
+        dist2Line2 = vtkLine::DistanceToLine(x, pt1, pt2, t, closestPoint2);
+        if (dist2Point < dist2Line1) {
+          dist2 = dist2Point;
+          closest = pt1;
+        } else {
+          dist2 = dist2Line1;
+          closest = closestPoint1;
+        }
+        if (dist2Line2 < dist2) {
+          dist2 = dist2Line2;
+          closest = closestPoint2;
+        }
+        for (i = 0; i < 3; i++) {
+          closestPoint[i] = closest[i];
+        }
+      } else if (weights[1] < 0.0 && weights[0] < 0.0) {
+        dist2Point = vtkMath::Distance2BetweenPoints(x, pt2);
+        dist2Line1 = vtkLine::DistanceToLine(x, pt2, pt3, t, closestPoint1);
+        dist2Line2 = vtkLine::DistanceToLine(x, pt1, pt2, t, closestPoint2);
+        if (dist2Point < dist2Line1) {
+          dist2 = dist2Point;
+          closest = pt2;
+        } else {
+          dist2 = dist2Line1;
+          closest = closestPoint1;
+        }
+        if (dist2Line2 < dist2) {
+          dist2 = dist2Line2;
+          closest = closestPoint2;
+        }
+        for (i = 0; i < 3; i++) {
+          closestPoint[i] = closest[i];
+        }
+      } else if (weights[0] < 0.0) {
+        dist2 = vtkLine::DistanceToLine(x, pt1, pt2, t, closestPoint);
+      } else if (weights[1] < 0.0) {
+        dist2 = vtkLine::DistanceToLine(x, pt2, pt3, t, closestPoint);
+      } else if (weights[2] < 0.0) {
+        dist2 = vtkLine::DistanceToLine(x, pt1, pt3, t, closestPoint);
+      }
+    }
+    return 0;
+  }
+}
 
 //---------------------------------------------------------------------------
 Surface::Surface(vtkSmartPointer<vtkPolyData> poly_data,
@@ -488,6 +640,14 @@ void Surface::compute_grad_normals(const Eigen::MatrixXd& V, const Eigen::Matrix
 
 //---------------------------------------------------------------------------
 bool Surface::is_in_triangle(const double* pt, int face_index) const {
+  /*
+  double dist2;
+  Eigen::Vector3d bary;
+
+  Eigen::Vector3d pt_eigen(pt[0], pt[1], pt[2]);
+  int ret = compute_barycentric_coordinates(pt_eigen, face_index, dist2, bary);
+*/
+
   double closest[3];
   int sub_id;
   double pcoords[3];
@@ -514,38 +674,45 @@ bool Surface::is_in_triangle(const double* pt, int face_index) const {
 
 //---------------------------------------------------------------------------
 Eigen::Vector3d Surface::compute_barycentric_coordinates(const Eigen::Vector3d& pt, int face) const {
+  Eigen::Vector3d bary;
+  double dist2;
+  compute_barycentric_coordinates(pt, face, dist2, bary);
+  return bary;
+}
 
+//---------------------------------------------------------------------------
+int Surface::compute_barycentric_coordinates(const Eigen::Vector3d& pt,
+                                             int face,
+                                             double& dist2,
+                                             Eigen::Vector3d& bary) const {
   double closest[3];
   int sub_id;
   double pcoords[3];
-  double dist2;
-  Eigen::Vector3d bary;
+
+  double pt1[3], pt2[3], pt3[3];
 
   vtkTriangle* triangle = vtkTriangle::New();
   triangle->GetPoints()->SetPoint(0, poly_data_->GetPoint(triangles_[face].a_));
   triangle->GetPoints()->SetPoint(1, poly_data_->GetPoint(triangles_[face].b_));
   triangle->GetPoints()->SetPoint(2, poly_data_->GetPoint(triangles_[face].c_));
-  triangle->EvaluatePosition(pt.data(), closest, sub_id, pcoords, dist2, bary.data());
-  triangle->Delete();
 
-  return bary;
+  double pto[3] = {pt[0], pt[1], pt[2]};
+  double bary_array[3];
 
-/*
-  // Validate the face ID
-  if (face < 0 || face >= faces_.rows()) {
-    throw std::invalid_argument("Invalid face ID");
-  }
+  int ret = triangle->EvaluatePosition(pto, closest, sub_id, pcoords, dist2, bary_array);
+  bary = Eigen::Vector3d(bary_array[0], bary_array[1], bary_array[2]);
 
-  // Extract vertices of the specified face as Eigen::Vector3d
-  Eigen::Vector3d v0 = vertices_.row(faces_(face, 0));
-  Eigen::Vector3d v1 = vertices_.row(faces_(face, 1));
-  Eigen::Vector3d v2 = vertices_.row(faces_(face, 2));
+  return ret;
 
-  // Compute barycentric coordinates
-  Eigen::Vector3d barycentric_coords;
-  igl::barycentric_coordinates(pt, v0, v1, v2, barycentric_coords);
+  /*
 
-  return barycentric_coords;
+  poly_data_->GetPoint(triangles_[face].a_, pt1);
+  poly_data_->GetPoint(triangles_[face].b_, pt2);
+  poly_data_->GetPoint(triangles_[face].c_, pt3);
+  ???
+
+  int rc = evaluate_position(pt.data(), closest, sub_id, pcoords, dist2, bary.data(), pt1, pt2, pt3);
+  return rc;
   */
 }
 
@@ -612,32 +779,94 @@ Eigen::Vector3d Surface::geodesic_walk_on_face(Eigen::Vector3d point_a,
         std::cerr << "targetBary: " << PrintValue<vec3>(targetBary) << "\n";
         std::cerr << std::endl;
         */
-      break;
-    }
+  break;
+}
 
-    if (target_bary[0] + barycentric_epsilon >= 0 && target_bary[1] + barycentric_epsilon >= 0 &&
-      target_bary[2] + barycentric_epsilon >= 0 && target_bary[0] - barycentric_epsilon <= 1 &&
-      target_bary[1] - barycentric_epsilon <= 1 && target_bary[2] - barycentric_epsilon <= 1) {
+if
+(target_bary[0]
++
+barycentric_epsilon
+>=
+0
+&&
+target_bary [1]
++
+barycentric_epsilon
+>=
+0
+&&
+target_bary [2]
++
+barycentric_epsilon
+>=
+0
+&&
+target_bary [0]
+-
+barycentric_epsilon
+<=
+1
+&&
+target_bary [1]
+-
+barycentric_epsilon
+<=
+1
+&&
+target_bary [2]
+-
+barycentric_epsilon
+<=
+1
+)
+ {
       current_point = target_point;
       break;
     }
 
-    std::vector<int> negative_vertices;
-    for (int i = 0; i < 3; i++) {
+std::vector<int> negative_vertices;
+for
+(
+int i = 0;
+i<3;
+i
+++
+)
+ {
       if (target_bary[i] < 0) {
         negative_vertices.push_back(i);
       }
     }
 
-    if (negative_vertices.size() == 0 || negative_vertices.size() > 2) {
+if
+(negative_vertices
+.
+size()
+==
+0
+||
+negative_vertices
+.
+size()
+>
+2
+)
+ {
       std::cerr << "ERROR: invalid number of negative vertices. Point is not on surface.\n";
       break;
     }
-    int negativeEdge = negative_vertices[0];
-    Eigen::Vector3d intersect = get_barycentric_intersection(current_bary, target_bary, current_face, negativeEdge);
+int negativeEdge = negative_vertices[0];
+Eigen::Vector3d intersect = get_barycentric_intersection(current_bary, target_bary, current_face, negativeEdge);
 
-    // When more than 1 negative barycentric coordinate, compute both intersections and take the closest one.
-    if (negative_vertices.size() == 2) {
+// When more than 1 negative barycentric coordinate, compute both intersections and take the closest one.
+if
+(negative_vertices
+.
+size()
+==
+2
+)
+ {
       int negativeEdge1 = negative_vertices[1];
       Eigen::Vector3d intersect1 = get_barycentric_intersection(current_bary, target_bary, current_face, negativeEdge1);
 
@@ -653,31 +882,56 @@ Eigen::Vector3d Surface::geodesic_walk_on_face(Eigen::Vector3d point_a,
       }
     }
 
-    Eigen::Vector3d remaining = target_point - intersect;
-    int next_face = get_across_edge(current_face, negativeEdge);
-    if (next_face == -1) {
+Eigen::Vector3d remaining = target_point - intersect;
+int next_face = get_across_edge(current_face, negativeEdge);
+if
+(next_face
+==
+-
+1
+)
+ {
       next_face = slide_along_edge(intersect, remaining, current_face, negativeEdge);
     }
-    remaining_vector = remaining;
-    if (next_face != -1) {
+remaining_vector= remaining;
+if
+(next_face
+!=
+-
+1
+)
+ {
       remaining_vector = rotate_vector_to_face(get_face_normal(current_face),
                                                get_face_normal(next_face),
                                                remaining_vector);
     }
-    current_point = intersect;
-    current_face = next_face;
-    if (current_face != -1) {
+current_point= intersect;
+current_face= next_face;
+if
+(current_face
+!=
+-
+1
+)
+ {
       prev_face = current_face;
     }
-  }
+}
 
-  if (current_face != -1) {
+if
+(current_face
+!=
+-
+1
+)
+ {
     prev_face = current_face;
   }
 
-  ending_face = prev_face;
-  assert(ending_face != -1);
-  return current_point;
+ending_face= prev_face;
+assert(ending_face != -1);
+return
+current_point;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Optimize/Domain/Surface.h
+++ b/Libs/Optimize/Domain/Surface.h
@@ -97,6 +97,8 @@ class Surface {
 
     Eigen::Vector3d compute_barycentric_coordinates(const Eigen::Vector3d& pt, int face) const;
 
+    int compute_barycentric_coordinates(const Eigen::Vector3d& pt, int face, double& dist2, Eigen::Vector3d& bary) const;
+
     int compute_face_and_weights(const PointType& p, int idx, Eigen::Vector3d& weights) const;
 
     Eigen::Vector3d geodesic_walk_on_face(Eigen::Vector3d point_a,

--- a/Libs/Optimize/Domain/Surface.h
+++ b/Libs/Optimize/Domain/Surface.h
@@ -14,27 +14,6 @@
 class vtkCellLocator;
 
 namespace shapeworks {
-//! Simple struct to represent a triangle in 3D space
-class Triangle {
-  public:
-    Triangle() = default;
-    Triangle(const int a, const int b, const int c) : a_(a), b_(b), c_(c) {
-    }
-
-    int get_point(const int id) const {
-      if (id == 0) {
-        return a_;
-      } else if (id == 1) {
-        return b_;
-      } else if (id == 2) {
-        return c_;
-      }
-      throw std::runtime_error("Invalid point id");
-    }
-
-    int a_, b_, c_;
-};
-
 class Surface {
   public:
     using PointType = ParticleDomain::PointType;
@@ -67,7 +46,7 @@ class Surface {
     VectorType project_vector_to_surface_tangent(const PointType& pointa, int idx, VectorType& vector) const;
 
     NormalType sample_normal_at_point(PointType p, int idx = -1) const;
-    GradNType sample_gradient_normal_at_point(PointType p, int idx) const;
+    GradNType sample_gradient_normal_at_point(PointType p, int idx);
 
     PointType snap_to_mesh(PointType pointa, int idx) const;
 
@@ -84,7 +63,6 @@ class Surface {
     bool is_geodesics_enabled() const { return this->is_geodesics_enabled_; }
 
   private:
-
     int get_num_faces();
     void compute_mesh_bounds();
     void compute_grad_normals(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F);

--- a/Libs/Optimize/Domain/Surface.h
+++ b/Libs/Optimize/Domain/Surface.h
@@ -35,7 +35,7 @@ class Triangle {
     int a_, b_, c_;
 };
 
-class MeshWrapper {
+class Surface {
   public:
     using PointType = ParticleDomain::PointType;
     using GradNType = ParticleDomain::GradNType;
@@ -43,11 +43,11 @@ class MeshWrapper {
     using NormalType = vnl_vector_fixed<float, 3>;
     using VectorType = vnl_vector_fixed<double, 3>;
 
-    explicit MeshWrapper(vtkSmartPointer<vtkPolyData> mesh,
-                         bool geodesics_enabled = false,
-                         size_t geodesics_cache_multiplier_size = 0); // 0 => MeshWrapper will choose a heuristic
+    explicit Surface(vtkSmartPointer<vtkPolyData> mesh,
+                     bool geodesics_enabled = false,
+                     size_t geodesics_cache_multiplier_size = 0); // 0 => MeshWrapper will choose a heuristic
 
-    ~MeshWrapper() = default;
+    ~Surface() = default;
 
     double compute_distance(const PointType& pointa,
                             int idxa,
@@ -124,7 +124,7 @@ class MeshWrapper {
     vtkSmartPointer<vtkPolyData> poly_data_;
     vtkSmartPointer<vtkPolyData> original_mesh_;
 
-    NormalType calculate_normal_at_point(MeshWrapper::PointType p, int idx) const;
+    NormalType calculate_normal_at_point(Surface::PointType p, int idx) const;
 
     // Caches of triangle, normal and position
     // Has to be mutable because all of the accessor APIs are const
@@ -192,5 +192,8 @@ class MeshWrapper {
     mutable int geo_lq_face_{-1};
     mutable Eigen::Vector3d geo_lq_bary_;
     void fetch_and_cache_first_point(const PointType pt_a, int idx_a, int& face_a, Eigen::Vector3d& bary_a) const;
+
+    Eigen::MatrixXd vertices_;
+    Eigen::MatrixXi faces_;
 };
 } // namespace shapeworks

--- a/Libs/Optimize/Domain/Surface.h
+++ b/Libs/Optimize/Domain/Surface.h
@@ -46,7 +46,7 @@ class Surface {
     VectorType project_vector_to_surface_tangent(const PointType& pointa, int idx, VectorType& vector) const;
 
     NormalType sample_normal_at_point(PointType p, int idx = -1) const;
-    GradNType sample_gradient_normal_at_point(PointType p, int idx);
+    GradNType sample_gradient_normal_at_point(PointType p, int idx) const;
 
     PointType snap_to_mesh(PointType pointa, int idx) const;
 

--- a/Libs/Optimize/Domain/Surface.h
+++ b/Libs/Optimize/Domain/Surface.h
@@ -65,7 +65,7 @@ class Surface {
   private:
     int get_num_faces();
     void compute_mesh_bounds();
-    void compute_grad_normals(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F);
+    void compute_grad_normals(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F) const;
 
     int get_triangle_for_point(const double pt[3], int idx, double closest_point[3]) const;
 
@@ -118,7 +118,7 @@ class Surface {
     mutable std::vector<PointType> particle_positions_;
     mutable std::vector<double> particle_neighboorhood_;
 
-    std::vector<GradNType> grad_normals_;
+    mutable std::vector<GradNType> grad_normals_;
 
     // bounds of the mesh plus some buffer
     PointType mesh_lower_bound_;

--- a/Libs/Optimize/Domain/Surface.h
+++ b/Libs/Optimize/Domain/Surface.h
@@ -84,6 +84,8 @@ class Surface {
     bool is_geodesics_enabled() const { return this->is_geodesics_enabled_; }
 
   private:
+
+    int get_num_faces();
     void compute_mesh_bounds();
     void compute_grad_normals(const Eigen::MatrixXd& V, const Eigen::MatrixXi& F);
 
@@ -97,7 +99,10 @@ class Surface {
 
     Eigen::Vector3d compute_barycentric_coordinates(const Eigen::Vector3d& pt, int face) const;
 
-    int compute_barycentric_coordinates(const Eigen::Vector3d& pt, int face, double& dist2, Eigen::Vector3d& bary) const;
+    int compute_barycentric_coordinates(const Eigen::Vector3d& pt,
+                                        int face,
+                                        double& dist2,
+                                        Eigen::Vector3d& bary) const;
 
     int compute_face_and_weights(const PointType& p, int idx, Eigen::Vector3d& weights) const;
 
@@ -136,9 +141,6 @@ class Surface {
     mutable std::vector<double> particle_neighboorhood_;
 
     std::vector<GradNType> grad_normals_;
-
-    // cache of specialized cells for direct access
-    std::vector<Triangle> triangles_;
 
     // bounds of the mesh plus some buffer
     PointType mesh_lower_bound_;

--- a/Libs/Optimize/Neighborhood/ParticleNeighborhood.cpp
+++ b/Libs/Optimize/Neighborhood/ParticleNeighborhood.cpp
@@ -53,7 +53,7 @@ std::vector<ParticlePointIndexPair> ParticleNeighborhood::find_neighborhood_poin
   if (domain_->GetDomainType() == DomainType::Mesh) {
     // cast to MeshDomain to ask if geodesics are enabled
     auto mesh_domain = std::dynamic_pointer_cast<MeshDomain>(domain_);
-    use_euclidean = !mesh_domain->GetMeshWrapper()->is_geodesics_enabled();
+    use_euclidean = !mesh_domain->get_surface()->is_geodesics_enabled();
   } else if (domain_->GetDomainType() == DomainType::Contour) {
     use_euclidean = false;
   }

--- a/Libs/Optimize/Neighborhood/ParticleNeighborhood.cpp
+++ b/Libs/Optimize/Neighborhood/ParticleNeighborhood.cpp
@@ -53,7 +53,7 @@ std::vector<ParticlePointIndexPair> ParticleNeighborhood::find_neighborhood_poin
   if (domain_->GetDomainType() == DomainType::Mesh) {
     // cast to MeshDomain to ask if geodesics are enabled
     auto mesh_domain = std::dynamic_pointer_cast<MeshDomain>(domain_);
-    use_euclidean = !mesh_domain->GetMeshWrapper()->IsGeodesicsEnabled();
+    use_euclidean = !mesh_domain->GetMeshWrapper()->is_geodesics_enabled();
   } else if (domain_->GetDomainType() == DomainType::Contour) {
     use_euclidean = false;
   }

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -25,7 +25,7 @@
 #include <Libs/Particles/ParticleFile.h>
 #include <Project/Project.h>
 
-#include "Libs/Optimize/Domain/MeshWrapper.h"
+#include "Libs/Optimize/Domain/Surface.h"
 #include "Libs/Optimize/Utils/ObjectReader.h"
 #include "Libs/Optimize/Utils/ObjectWriter.h"
 #include "Libs/Optimize/Utils/ParticleGoodBadAssessment.h"
@@ -1771,7 +1771,7 @@ void Optimize::AddMesh(vtkSmartPointer<vtkPolyData> poly_data) {
     double geodesic_remesh_percent = m_geodesics_enabled ? m_geodesic_remesh_percent : 100;
 
     const auto mesh =
-        std::make_shared<shapeworks::MeshWrapper>(poly_data, m_geodesics_enabled, m_geodesic_cache_size_multiplier);
+        std::make_shared<shapeworks::Surface>(poly_data, m_geodesics_enabled, m_geodesic_cache_size_multiplier);
     m_sampler->AddMesh(mesh, geodesic_remesh_percent);
   }
   this->m_num_shapes++;

--- a/Libs/Optimize/OptimizeParameterFile.cpp
+++ b/Libs/Optimize/OptimizeParameterFile.cpp
@@ -7,7 +7,7 @@
 
 #include "ExternalLibs/tinyxml/tinyxml.h"
 #include "Libs/Optimize/Domain/DomainType.h"
-#include "Libs/Optimize/Domain/MeshWrapper.h"
+#include "Libs/Optimize/Domain/Surface.h"
 #include "Optimize.h"
 
 namespace shapeworks {

--- a/Libs/Optimize/Sampler.cpp
+++ b/Libs/Optimize/Sampler.cpp
@@ -110,7 +110,7 @@ void Sampler::AllocateDomainsAndNeighborhoods() {
       // cast to MeshDomain
       auto mesh_domain = std::dynamic_pointer_cast<MeshDomain>(domain);
 
-      m_ParticleSystem->GetNeighborhood(i)->set_weighting_enabled(!mesh_domain->GetMeshWrapper()->IsGeodesicsEnabled());
+      m_ParticleSystem->GetNeighborhood(i)->set_weighting_enabled(!mesh_domain->GetMeshWrapper()->is_geodesics_enabled());
     } else if (domain->GetDomainType() == DomainType::Contour) {
       m_ParticleSystem->GetNeighborhood(i)->set_weighting_enabled(false);
     }
@@ -275,7 +275,7 @@ void Sampler::AddMesh(std::shared_ptr<shapeworks::MeshWrapper> mesh, double geod
   if (mesh) {
     this->m_Spacing = 1;
     domain->SetMesh(mesh, geodesic_remesh_percent);
-    this->m_meshes.push_back(mesh->GetPolydata());
+    this->m_meshes.push_back(mesh->get_polydata());
   }
   m_DomainList.push_back(domain);
 }

--- a/Libs/Optimize/Sampler.cpp
+++ b/Libs/Optimize/Sampler.cpp
@@ -110,7 +110,7 @@ void Sampler::AllocateDomainsAndNeighborhoods() {
       // cast to MeshDomain
       auto mesh_domain = std::dynamic_pointer_cast<MeshDomain>(domain);
 
-      m_ParticleSystem->GetNeighborhood(i)->set_weighting_enabled(!mesh_domain->GetMeshWrapper()->is_geodesics_enabled());
+      m_ParticleSystem->GetNeighborhood(i)->set_weighting_enabled(!mesh_domain->get_surface()->is_geodesics_enabled());
     } else if (domain->GetDomainType() == DomainType::Contour) {
       m_ParticleSystem->GetNeighborhood(i)->set_weighting_enabled(false);
     }
@@ -269,7 +269,7 @@ void Sampler::ReInitialize() {
   this->m_Sigma1Cache->ZeroAllValues();
 }
 
-void Sampler::AddMesh(std::shared_ptr<shapeworks::MeshWrapper> mesh, double geodesic_remesh_percent) {
+void Sampler::AddMesh(std::shared_ptr<shapeworks::Surface> mesh, double geodesic_remesh_percent) {
   auto domain = std::make_shared<MeshDomain>();
 
   if (mesh) {

--- a/Libs/Optimize/Sampler.h
+++ b/Libs/Optimize/Sampler.h
@@ -7,7 +7,7 @@
 #include "GradientDescentOptimizer.h"
 #include "Libs/Optimize/Container/GenericContainerArray.h"
 #include "Libs/Optimize/Container/MeanCurvatureContainer.h"
-#include "Libs/Optimize/Domain/MeshWrapper.h"
+#include "Libs/Optimize/Domain/Surface.h"
 #include "Libs/Optimize/Function/CorrespondenceFunction.h"
 #include "Libs/Optimize/Function/SamplingFunction.h"
 #include "Libs/Optimize/Function/DisentangledCorrespondenceFunction.h"
@@ -97,7 +97,7 @@ class Sampler {
     }
   }
 
-  void AddMesh(std::shared_ptr<shapeworks::MeshWrapper> mesh, double geodesic_remesh_percent = 100);
+  void AddMesh(std::shared_ptr<shapeworks::Surface> mesh, double geodesic_remesh_percent = 100);
 
   void AddContour(vtkSmartPointer<vtkPolyData> poly_data);
 

--- a/Libs/Particles/ParticleNormalEvaluation.cpp
+++ b/Libs/Particles/ParticleNormalEvaluation.cpp
@@ -3,7 +3,7 @@
 #include <Logging.h>
 #include <Utils.h>
 
-#include "Libs/Optimize/Domain/MeshWrapper.h"
+#include "Libs/Optimize/Domain/Surface.h"
 
 namespace shapeworks {
 
@@ -112,7 +112,7 @@ std::vector<bool> ParticleNormalEvaluation::threshold_particle_normals(std::vect
 
 //---------------------------------------------------------------------------
 Eigen::MatrixXd ParticleNormalEvaluation::compute_particle_normals(
-    const Eigen::MatrixXd &particles, std::vector<std::shared_ptr<MeshWrapper>> meshes) {
+    const Eigen::MatrixXd &particles, std::vector<std::shared_ptr<Surface>> meshes) {
   Eigen::MatrixXd normals;
   normals.resize(particles.rows(), particles.cols());
 

--- a/Libs/Particles/ParticleNormalEvaluation.cpp
+++ b/Libs/Particles/ParticleNormalEvaluation.cpp
@@ -129,7 +129,7 @@ Eigen::MatrixXd ParticleNormalEvaluation::compute_particle_normals(
       position[1] = particles(j * 3 + 1, shape);
       position[2] = particles(j * 3 + 2, shape);
 
-      auto normal = meshes[shape]->SampleNormalAtPoint(position);
+      auto normal = meshes[shape]->sample_normal_at_point(position);
       normals(j * 3 + 0, shape) = normal[0];
       normals(j * 3 + 1, shape) = normal[1];
       normals(j * 3 + 2, shape) = normal[2];

--- a/Libs/Particles/ParticleNormalEvaluation.h
+++ b/Libs/Particles/ParticleNormalEvaluation.h
@@ -13,7 +13,7 @@ namespace shapeworks {
  *
  */
 
-class MeshWrapper;
+class Surface;
 class ParticleNormalEvaluation {
  public:
   static std::vector<double> evaluate_particle_normals(const Eigen::MatrixXd& particles,
@@ -23,7 +23,7 @@ class ParticleNormalEvaluation {
 
   //! Compute normals at particle positions
   static Eigen::MatrixXd compute_particle_normals(const Eigen::MatrixXd& particles,
-                                                  std::vector<std::shared_ptr<MeshWrapper>> meshes);
+                                                  std::vector<std::shared_ptr<Surface>> meshes);
 
  private:
 };

--- a/Studio/Job/ParticleNormalEvaluationJob.cpp
+++ b/Studio/Job/ParticleNormalEvaluationJob.cpp
@@ -27,7 +27,7 @@ void ParticleNormalEvaluationJob::run() {
   for (int domain = 0; domain < num_domains; domain++) {
     ParticleSystemEvaluation particles = session_->get_local_particle_system(domain);
 
-    std::vector<std::shared_ptr<MeshWrapper>> meshes;
+    std::vector<std::shared_ptr<Surface>> meshes;
     for (auto& shape : session_->get_shapes()) {
       meshes.push_back(shape->get_groomed_mesh_wrappers()[domain]);
       count++;

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -507,7 +507,7 @@ TEST(OptimizeTests, mesh_geodesics_test) {
       const auto pt_b = polar2cart(theta1, phi1);
       const double a_dot_b = std::max(std::min(dot_product(pt_a.GetVnlVector(), pt_b.GetVnlVector()), 1.0), -1.0);
 
-      const double computed = mesh.ComputeDistance(pt_a, -1, pt_b, -1);
+      const double computed = mesh.compute_distance(pt_a, -1, pt_b, -1);
       const double truth = acos(a_dot_b);
 
       // std::cerr << "Geodesics test: " << computed << " " << truth << "\n";

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -7,7 +7,7 @@
 
 #include <cstdio>
 
-#include "Libs/Optimize/Domain/MeshWrapper.h"
+#include "Libs/Optimize/Domain/Surface.h"
 #include "Optimize.h"
 #include "OptimizeParameterFile.h"
 #include "ParticleShapeStatistics.h"
@@ -484,7 +484,7 @@ TEST(OptimizeTests, procrustes_scale_only_test) {
 TEST(OptimizeTests, mesh_geodesics_test) {
   const std::string sphere_mesh_path = std::string(TEST_DATA_DIR) + "/sphere_highres.ply";
   const auto sw_mesh = MeshUtils::threadSafeReadMesh(sphere_mesh_path);
-  MeshWrapper mesh(sw_mesh.getVTKMesh(), true, 1000000);
+  Surface mesh(sw_mesh.getVTKMesh(), true, 1000000);
 
   auto polar2cart = [](double theta, double phi) {
     const double x = sin(theta) * cos(phi);

--- a/Testing/ParticlesTests/ParticlesTests.cpp
+++ b/Testing/ParticlesTests/ParticlesTests.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <vector>
 
-#include "Libs/Optimize/Domain/MeshWrapper.h"
+#include "Libs/Optimize/Domain/Surface.h"
 #include "ParticleNormalEvaluation.h"
 #include "ParticleShapeStatistics.h"
 #include "ParticleSystemEvaluation.h"
@@ -266,10 +266,10 @@ TEST(ParticlesTests, particle_normal_evaluation_test)
   Mesh mesh2(std::string(TEST_DATA_DIR) + "/particle_normals/particle_normals2_groomed.vtk");
   Mesh mesh3(std::string(TEST_DATA_DIR) + "/particle_normals/particle_normals3_groomed.vtk");
 
-  std::vector<std::shared_ptr<MeshWrapper>> meshes;
-  meshes.push_back(std::make_shared<MeshWrapper>(mesh1.getVTKMesh()));
-  meshes.push_back(std::make_shared<MeshWrapper>(mesh2.getVTKMesh()));
-  meshes.push_back(std::make_shared<MeshWrapper>(mesh3.getVTKMesh()));
+  std::vector<std::shared_ptr<Surface>> meshes;
+  meshes.push_back(std::make_shared<Surface>(mesh1.getVTKMesh()));
+  meshes.push_back(std::make_shared<Surface>(mesh2.getVTKMesh()));
+  meshes.push_back(std::make_shared<Surface>(mesh3.getVTKMesh()));
 
   std::vector<std::string> particle_files = {
     std::string(TEST_DATA_DIR) + "/particle_normals/particle_normals_particles/particle_normals1_groomed_groomed_local.particles",


### PR DESCRIPTION
* #2349 

This PR reduces the per triangle memory usage of mesh domains significantly.

It also generates gradient normals on demand, so if they are not needed, they are not computed, saving further memory and computation time.