### PR TITLE
2356 - Segmentation Tool Updates

### DIFF
--- a/Libs/Analyze/Shape.cpp
+++ b/Libs/Analyze/Shape.cpp
@@ -118,7 +118,7 @@ void Shape::recompute_original_surface() {
   }
   auto meshes = original_meshes_.meshes();
   Image copy = *seg;
-  copy.binarize(0, 1);
+  copy.binarize(0, 2);
   Mesh mesh = copy.toMesh(0.001);
   MeshHandle mesh_handle = std::make_shared<StudioMesh>();
   mesh_handle->set_poly_data(mesh.getVTKMesh());

--- a/Studio/CMakeLists.txt
+++ b/Studio/CMakeLists.txt
@@ -228,6 +228,7 @@ SET(STUDIO_VISUALIZATION_SRCS
   Visualization/ParticleColors.cpp
   Visualization/StudioInteractorStyle.cpp
   Visualization/StudioSliceInteractorStyle.cpp
+  Visualization/StudioImageActorPointPlacer.cpp
   Visualization/SliceView.cpp
   Visualization/MeshSlice.cpp
   Visualization/Viewer.cpp

--- a/Studio/Data/SegmentationToolPanel.cpp
+++ b/Studio/Data/SegmentationToolPanel.cpp
@@ -40,6 +40,10 @@ SegmentationToolPanel::SegmentationToolPanel(QWidget* parent) : QWidget(parent),
   connect(ui_->recompute_surface_, &QPushButton::clicked, this, &SegmentationToolPanel::recompute_surface);
   ui_->header_label->setAttribute(Qt::WA_TransparentForMouseEvents);
   ui_->open_button->setChecked(false);
+
+  // for 6.6 release we don't have include/exclude
+  //ui_->included_mode_->hide();
+  //ui_->excluded_mode_->hide();
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Data/SegmentationToolPanel.cpp
+++ b/Studio/Data/SegmentationToolPanel.cpp
@@ -42,8 +42,8 @@ SegmentationToolPanel::SegmentationToolPanel(QWidget* parent) : QWidget(parent),
   ui_->open_button->setChecked(false);
 
   // for 6.6 release we don't have include/exclude
-  //ui_->included_mode_->hide();
-  //ui_->excluded_mode_->hide();
+  ui_->included_mode_->hide();
+  ui_->excluded_mode_->hide();
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Visualization/PaintWidget.cpp
+++ b/Studio/Visualization/PaintWidget.cpp
@@ -2,6 +2,7 @@
 #include "PaintWidget.h"
 
 #include <Logging.h>
+#include <Visualization/StudioImageActorPointPlacer.h>
 
 #include <QCursor>
 
@@ -10,7 +11,6 @@
 #include "vtkCommand.h"
 #include "vtkEvent.h"
 #include "vtkImageActor.h"
-#include "vtkImageActorPointPlacer.h"
 #include "vtkObjectFactory.h"
 #include "vtkOrientedGlyphContourRepresentation.h"
 #include "vtkPointPlacer.h"
@@ -255,10 +255,13 @@ bool PaintWidget::use_point_placer(double displayPos[2], int newState) {
 
   if (WidgetState == PaintWidget::Paint || WidgetState == PaintWidget::Erase) {
     if (WidgetState == PaintWidget::Paint) {
+      if (circle_mode_) {
+        // we have to transform the point back to the image space in case there is alignment
+        auto transform = viewer_->get_inverse_image_transform();
+        transform->TransformPoint(worldPos, worldPos);
+      }
+
       viewer_->handle_paint(displayPos, worldPos);
-      ////paint_position( this, worldPos );
-    } else if (WidgetState == PaintWidget::Erase) {
-      ////erase_position( this, worldPos );
     }
 
     EventCallbackCommand->SetAbortFlag(1);

--- a/Studio/Visualization/SliceView.cpp
+++ b/Studio/Visualization/SliceView.cpp
@@ -3,7 +3,7 @@
 #include <vtkCellData.h>
 #include <vtkCutter.h>
 #include <vtkImageActor.h>
-#include <vtkImageActorPointPlacer.h>
+#include <Visualization/StudioImageActorPointPlacer.h>
 #include <vtkImageProperty.h>
 #include <vtkImageSliceMapper.h>
 #include <vtkLookupTable.h>
@@ -62,7 +62,7 @@ SliceView::SliceView(Viewer *viewer) : viewer_(viewer) {
   mask_slice_ = vtkSmartPointer<vtkImageActor>::New();
   slice_mapper_ = vtkSmartPointer<vtkImageSliceMapper>::New();
   mask_mapper_ = vtkSmartPointer<vtkImageSliceMapper>::New();
-  placer_ = vtkSmartPointer<vtkImageActorPointPlacer>::New();
+  placer_ = vtkSmartPointer<StudioImageActorPointPlacer>::New();
   placer_->SetImageActor(image_slice_);
 }
 

--- a/Studio/Visualization/StudioImageActorPointPlacer.cpp
+++ b/Studio/Visualization/StudioImageActorPointPlacer.cpp
@@ -25,8 +25,6 @@ void StudioImageActorPointPlacer::PrintSelf(ostream& os, vtkIndent indent) { thi
 //----------------------------------------------------------------------------
 int StudioImageActorPointPlacer::ComputeWorldPosition(vtkRenderer* renderer, double displayPos[2], double worldPos[3],
                                                       double worldOrient[9]) {
-  //std::cerr << "StudioImageActorPointPlacer::ComputeWorldPosition\n";
-
   vtkImageActor* actor = this->GetImageActor();
   if (!actor) {
     return 0;
@@ -96,8 +94,6 @@ int StudioImageActorPointPlacer::ComputeWorldPosition(vtkRenderer* renderer, dou
 
 //----------------------------------------------------------------------------
 int StudioImageActorPointPlacer::ValidateWorldPosition(double worldPos[3]) {
-  std::cerr << "StudioImageActorPointPlacer::ValidateWorldPosition\n";
-
   vtkImageActor* actor = this->GetImageActor();
   if (!actor) {
     return 0;
@@ -141,8 +137,6 @@ int StudioImageActorPointPlacer::ValidateWorldPosition(double worldPos[3]) {
 
 //----------------------------------------------------------------------------
 int StudioImageActorPointPlacer::UpdateWorldPosition(vtkRenderer* renderer, double worldPos[3], double worldOrient[9]) {
-  std::cerr << "StudioImageActorPointPlacer::UpdateWorldPosition\n";
-
   // For a point already on the plane, we need to ensure it stays within bounds
   if (!this->ValidateWorldPosition(worldPos)) {
     return 0;
@@ -152,7 +146,6 @@ int StudioImageActorPointPlacer::UpdateWorldPosition(vtkRenderer* renderer, doub
   if (worldOrient) {
     vtkImageActor* actor = this->GetImageActor();
     if (actor && actor->GetUserTransform()) {
-      std::cerr << "We have a user transform!\n";
       // Use the normal from the transformed image plane for the Z axis
       vtkNew<vtkCellPicker> picker;
       picker->SetTolerance(0.005);
@@ -207,25 +200,3 @@ int StudioImageActorPointPlacer::UpdateWorldPosition(vtkRenderer* renderer, doub
 
   return 1;
 }
-
-/*
-//----------------------------------------------------------------------------
-int StudioImageActorPointPlacer::UpdateDisplayPosition(vtkRenderer *renderer,
-                         double displayPos[2],
-                         double worldPos[3])
-{
-  // Project the world position to display coordinates
-  double worldPoint[4] = {worldPos[0], worldPos[1], worldPos[2], 1.0};
-  renderer->SetWorldPoint(worldPoint);
-  renderer->WorldToDisplay();
-
-  double displayPoint[3];
-  renderer->GetDisplayPoint(displayPoint);
-
-  // Update the display position
-  displayPos[0] = displayPoint[0];
-  displayPos[1] = displayPoint[1];
-
-  return 1;
-}
-*/

--- a/Studio/Visualization/StudioImageActorPointPlacer.cpp
+++ b/Studio/Visualization/StudioImageActorPointPlacer.cpp
@@ -1,0 +1,231 @@
+#include "StudioImageActorPointPlacer.h"
+
+#include "vtkCamera.h"
+#include "vtkCellPicker.h"
+#include "vtkImageActor.h"
+#include "vtkImageData.h"
+#include "vtkImageMapper3D.h"
+#include "vtkMath.h"
+#include "vtkNew.h"
+#include "vtkObjectFactory.h"
+#include "vtkRenderer.h"
+#include "vtkTransform.h"
+
+vtkStandardNewMacro(StudioImageActorPointPlacer);
+
+//----------------------------------------------------------------------------
+StudioImageActorPointPlacer::StudioImageActorPointPlacer() {}
+
+//----------------------------------------------------------------------------
+StudioImageActorPointPlacer::~StudioImageActorPointPlacer() {}
+
+//----------------------------------------------------------------------------
+void StudioImageActorPointPlacer::PrintSelf(ostream& os, vtkIndent indent) { this->Superclass::PrintSelf(os, indent); }
+
+//----------------------------------------------------------------------------
+int StudioImageActorPointPlacer::ComputeWorldPosition(vtkRenderer* renderer, double displayPos[2], double worldPos[3],
+                                                      double worldOrient[9]) {
+  //std::cerr << "StudioImageActorPointPlacer::ComputeWorldPosition\n";
+
+  vtkImageActor* actor = this->GetImageActor();
+  if (!actor) {
+    return 0;
+  }
+
+  // Use a cell picker for accurate picking on the transformed image
+  vtkNew<vtkCellPicker> picker;
+  picker->SetTolerance(0.005);
+
+  // Pick only on our specific actor
+  picker->InitializePickList();
+  picker->AddPickList(actor);
+  picker->PickFromListOn();
+
+  // Perform the pick
+  if (!picker->Pick(displayPos[0], displayPos[1], 0.0, renderer)) {
+    return 0;
+  }
+
+  // Check if we picked the correct actor
+  vtkImageActor* pickedActor = vtkImageActor::SafeDownCast(picker->GetProp3D());
+  if (pickedActor != actor) {
+    return 0;
+  }
+
+  // Get the picked position - this accounts for the transformation
+  picker->GetPickPosition(worldPos);
+
+  // If orientation is requested, compute it using the transformed plane
+  if (worldOrient) {
+    // Get the normal from the picker - this will be in transformed space
+    double* normal = picker->GetPickNormal();
+
+    // Z axis is the normal to the image plane
+    worldOrient[6] = normal[0];
+    worldOrient[7] = normal[1];
+    worldOrient[8] = normal[2];
+
+    // Compute a suitable X axis that's perpendicular to Z
+    double xAxis[3] = {1.0, 0.0, 0.0};
+    if (fabs(normal[0]) > 0.99) {
+      xAxis[0] = 0.0;
+      xAxis[1] = 1.0;
+    }
+
+    // Make X perpendicular to Z
+    double dot = vtkMath::Dot(xAxis, normal);
+    xAxis[0] -= dot * normal[0];
+    xAxis[1] -= dot * normal[1];
+    xAxis[2] -= dot * normal[2];
+    vtkMath::Normalize(xAxis);
+
+    worldOrient[0] = xAxis[0];
+    worldOrient[1] = xAxis[1];
+    worldOrient[2] = xAxis[2];
+
+    // Y axis is Z cross X
+    double yAxis[3];
+    vtkMath::Cross(normal, xAxis, yAxis);
+    worldOrient[3] = yAxis[0];
+    worldOrient[4] = yAxis[1];
+    worldOrient[5] = yAxis[2];
+  }
+
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+int StudioImageActorPointPlacer::ValidateWorldPosition(double worldPos[3]) {
+  std::cerr << "StudioImageActorPointPlacer::ValidateWorldPosition\n";
+
+  vtkImageActor* actor = this->GetImageActor();
+  if (!actor) {
+    return 0;
+  }
+
+  // Create a cell locator for the actor's mapper input
+  vtkImageMapper3D* mapper = actor->GetMapper();
+  if (!mapper) {
+    return 0;
+  }
+
+  vtkImageData* image = vtkImageData::SafeDownCast(mapper->GetInput());
+  if (!image) {
+    return 0;
+  }
+
+  // Transform the world position back to image space
+  double imagePos[3];
+  if (actor->GetUserTransform()) {
+    vtkNew<vtkTransform> inverseTransform;
+    inverseTransform->DeepCopy(actor->GetUserTransform());
+    inverseTransform->Inverse();
+    inverseTransform->TransformPoint(worldPos, imagePos);
+  } else {
+    imagePos[0] = worldPos[0];
+    imagePos[1] = worldPos[1];
+    imagePos[2] = worldPos[2];
+  }
+
+  // Check if the point is within the image bounds
+  double bounds[6];
+  image->GetBounds(bounds);
+
+  if (imagePos[0] < bounds[0] || imagePos[0] > bounds[1] || imagePos[1] < bounds[2] || imagePos[1] > bounds[3] ||
+      imagePos[2] < bounds[4] || imagePos[2] > bounds[5]) {
+    return 0;
+  }
+
+  return 1;
+}
+
+//----------------------------------------------------------------------------
+int StudioImageActorPointPlacer::UpdateWorldPosition(vtkRenderer* renderer, double worldPos[3], double worldOrient[9]) {
+  std::cerr << "StudioImageActorPointPlacer::UpdateWorldPosition\n";
+
+  // For a point already on the plane, we need to ensure it stays within bounds
+  if (!this->ValidateWorldPosition(worldPos)) {
+    return 0;
+  }
+
+  // Orientation handling
+  if (worldOrient) {
+    vtkImageActor* actor = this->GetImageActor();
+    if (actor && actor->GetUserTransform()) {
+      std::cerr << "We have a user transform!\n";
+      // Use the normal from the transformed image plane for the Z axis
+      vtkNew<vtkCellPicker> picker;
+      picker->SetTolerance(0.005);
+
+      // Pick at the world position
+      double displayPos[3];
+      renderer->SetWorldPoint(worldPos[0], worldPos[1], worldPos[2], 1.0);
+      renderer->WorldToDisplay();
+      renderer->GetDisplayPoint(displayPos);
+
+      // Try to pick on the actor
+      picker->InitializePickList();
+      picker->AddPickList(actor);
+      picker->PickFromListOn();
+
+      if (picker->Pick(displayPos[0], displayPos[1], 0.0, renderer)) {
+        vtkImageActor* pickedActor = vtkImageActor::SafeDownCast(picker->GetProp3D());
+        if (pickedActor == actor) {
+          // Use the picked normal
+          double* normal = picker->GetPickNormal();
+
+          worldOrient[6] = normal[0];
+          worldOrient[7] = normal[1];
+          worldOrient[8] = normal[2];
+
+          // Compute suitable X and Y axes as in ComputeWorldPosition
+          double xAxis[3] = {1.0, 0.0, 0.0};
+          if (fabs(normal[0]) > 0.99) {
+            xAxis[0] = 0.0;
+            xAxis[1] = 1.0;
+          }
+
+          double dot = vtkMath::Dot(xAxis, normal);
+          xAxis[0] -= dot * normal[0];
+          xAxis[1] -= dot * normal[1];
+          xAxis[2] -= dot * normal[2];
+          vtkMath::Normalize(xAxis);
+
+          worldOrient[0] = xAxis[0];
+          worldOrient[1] = xAxis[1];
+          worldOrient[2] = xAxis[2];
+
+          double yAxis[3];
+          vtkMath::Cross(normal, xAxis, yAxis);
+          worldOrient[3] = yAxis[0];
+          worldOrient[4] = yAxis[1];
+          worldOrient[5] = yAxis[2];
+        }
+      }
+    }
+  }
+
+  return 1;
+}
+
+/*
+//----------------------------------------------------------------------------
+int StudioImageActorPointPlacer::UpdateDisplayPosition(vtkRenderer *renderer,
+                         double displayPos[2],
+                         double worldPos[3])
+{
+  // Project the world position to display coordinates
+  double worldPoint[4] = {worldPos[0], worldPos[1], worldPos[2], 1.0};
+  renderer->SetWorldPoint(worldPoint);
+  renderer->WorldToDisplay();
+
+  double displayPoint[3];
+  renderer->GetDisplayPoint(displayPoint);
+
+  // Update the display position
+  displayPos[0] = displayPoint[0];
+  displayPos[1] = displayPoint[1];
+
+  return 1;
+}
+*/

--- a/Studio/Visualization/StudioImageActorPointPlacer.h
+++ b/Studio/Visualization/StudioImageActorPointPlacer.h
@@ -1,0 +1,42 @@
+#ifndef StudioImageActorPointPlacer_h
+#define StudioImageActorPointPlacer_h
+
+#include "vtkImageActorPointPlacer.h"
+
+class StudioImageActorPointPlacer : public vtkImageActorPointPlacer
+{
+public:
+  static StudioImageActorPointPlacer* New();
+  vtkTypeMacro(StudioImageActorPointPlacer, vtkImageActorPointPlacer);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
+
+  // Override ComputeWorldPosition to take transform into account
+  int ComputeWorldPosition(vtkRenderer *renderer,
+                           double displayPos[2],
+                           double worldPos[3],
+                           double worldOrient[9]) override;
+
+  // Override ValidateWorldPosition
+  int ValidateWorldPosition(double worldPos[3]) override;
+  
+  // Override UpdateWorldPosition
+  int UpdateWorldPosition(vtkRenderer *renderer,
+                         double worldPos[3],
+                         double worldOrient[9]) override;
+
+/*
+  // Override UpdateDisplayPosition
+  int UpdateDisplayPosition(vtkRenderer *renderer,
+                           double displayPos[2],
+                           double worldPos[3]) override;
+*/
+protected:
+  StudioImageActorPointPlacer();
+  ~StudioImageActorPointPlacer() override;
+
+private:
+  StudioImageActorPointPlacer(const StudioImageActorPointPlacer&) = delete;
+  void operator=(const StudioImageActorPointPlacer&) = delete;
+};
+
+#endif

--- a/Studio/Visualization/StudioImageActorPointPlacer.h
+++ b/Studio/Visualization/StudioImageActorPointPlacer.h
@@ -1,42 +1,28 @@
-#ifndef StudioImageActorPointPlacer_h
-#define StudioImageActorPointPlacer_h
+#pragma once
 
 #include "vtkImageActorPointPlacer.h"
 
-class StudioImageActorPointPlacer : public vtkImageActorPointPlacer
-{
-public:
+class StudioImageActorPointPlacer : public vtkImageActorPointPlacer {
+ public:
   static StudioImageActorPointPlacer* New();
   vtkTypeMacro(StudioImageActorPointPlacer, vtkImageActorPointPlacer);
   void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Override ComputeWorldPosition to take transform into account
-  int ComputeWorldPosition(vtkRenderer *renderer,
-                           double displayPos[2],
-                           double worldPos[3],
+  int ComputeWorldPosition(vtkRenderer* renderer, double displayPos[2], double worldPos[3],
                            double worldOrient[9]) override;
 
   // Override ValidateWorldPosition
   int ValidateWorldPosition(double worldPos[3]) override;
-  
-  // Override UpdateWorldPosition
-  int UpdateWorldPosition(vtkRenderer *renderer,
-                         double worldPos[3],
-                         double worldOrient[9]) override;
 
-/*
-  // Override UpdateDisplayPosition
-  int UpdateDisplayPosition(vtkRenderer *renderer,
-                           double displayPos[2],
-                           double worldPos[3]) override;
-*/
-protected:
+  // Override UpdateWorldPosition
+  int UpdateWorldPosition(vtkRenderer* renderer, double worldPos[3], double worldOrient[9]) override;
+
+ protected:
   StudioImageActorPointPlacer();
   ~StudioImageActorPointPlacer() override;
 
-private:
+ private:
   StudioImageActorPointPlacer(const StudioImageActorPointPlacer&) = delete;
   void operator=(const StudioImageActorPointPlacer&) = delete;
 };
-
-#endif

--- a/Studio/Visualization/Viewer.cpp
+++ b/Studio/Visualization/Viewer.cpp
@@ -8,7 +8,7 @@
 #include <vtkGlyph3D.h>
 #include <vtkHandleWidget.h>
 #include <vtkImageActor.h>
-#include <vtkImageActorPointPlacer.h>
+#include <Visualization/StudioImageActorPointPlacer.h>
 #include <vtkImageData.h>
 #include <vtkKdTreePointLocator.h>
 #include <vtkLookupTable.h>
@@ -58,7 +58,7 @@ Viewer::Viewer() {
   prop_picker_->SetPickFromList(1);
   point_placer_ = vtkSmartPointer<vtkPolygonalSurfacePointPlacer>::New();
   point_placer_->SetDistanceOffset(0);
-  slice_point_placer_ = vtkSmartPointer<vtkImageActorPointPlacer>::New();
+  slice_point_placer_ = vtkSmartPointer<StudioImageActorPointPlacer>::New();
 
   landmark_widget_ = std::make_shared<LandmarkWidget>(this);
   plane_widget_ = std::make_shared<PlaneWidget>(this);
@@ -756,13 +756,13 @@ void Viewer::display_shape(std::shared_ptr<Shape> shape) {
         auto compare_poly_data = compare_meshes_.meshes()[i]->get_poly_data();
 
         if (compare_settings.get_mean_shape_checked()) {
-          auto transform = visualizer_->get_transform(shape_, compare_settings.get_display_mode(),
+          auto mean_transform = visualizer_->get_transform(shape_, compare_settings.get_display_mode(),
                                                       visualizer_->get_alignment_domain(), i);
 
-          transform->Inverse();
+          mean_transform->Inverse();
           auto transform_filter = vtkSmartPointer<vtkTransformPolyDataFilter>::New();
           transform_filter->SetInputData(compare_poly_data);
-          transform_filter->SetTransform(transform);
+          transform_filter->SetTransform(mean_transform);
           transform_filter->Update();
 
           compare_poly_data = transform_filter->GetOutput();
@@ -1437,6 +1437,15 @@ vtkSmartPointer<vtkTransform> Viewer::get_inverse_landmark_transform(int domain)
 //-----------------------------------------------------------------------------
 vtkSmartPointer<vtkTransform> Viewer::get_image_transform() {
   return visualizer_->get_transform(shape_, visualizer_->get_alignment_domain(), 0);
+}
+
+//-----------------------------------------------------------------------------
+vtkSmartPointer<vtkTransform> Viewer::get_inverse_image_transform() {
+  auto transform = get_image_transform();
+  auto inverse = vtkSmartPointer<vtkTransform>::New();
+  inverse->DeepCopy(transform);
+  inverse->Inverse();
+  return inverse;
 }
 
 //-----------------------------------------------------------------------------

--- a/Studio/Visualization/Viewer.h
+++ b/Studio/Visualization/Viewer.h
@@ -129,6 +129,8 @@ class Viewer {
 
   vtkSmartPointer<vtkTransform> get_image_transform();
 
+  vtkSmartPointer<vtkTransform> get_inverse_image_transform();
+
   SliceView& slice_view();
 
   void update_image_volume(bool force = false);


### PR DESCRIPTION
* #2356 

Hide include/exclude for 6.6 release (#2356)
"included" part of segmentation should become part of the object

Fix bug where segmentation tool does not operate on the correct location.  vtkImageActorPointPlacer does not take into account the UserTransform.  I had to subclass it as StudioImageActorPointPlacer.