### PR TITLE
Fix #2365 - Python dependency version problem

### DIFF
--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -176,7 +176,7 @@ tqdm==4.66.3
 traitlets==5.9.0
 traittypes==0.2.1
 trimesh==3.12.6
-typing_extensions==4.5.0
+typing_extensions==4.12.2
 tzdata==2023.3
 uri-template==1.3.0
 urllib3==1.26.19


### PR DESCRIPTION
* #2365 

Needed typing_extensions==4.12.2