### PR TITLE
Fix #2383 - Warning message pops up if analytics is on PCA tab when optimization complete

### DIFF
--- a/Libs/Particles/ParticleShapeStatistics.h
+++ b/Libs/Particles/ParticleShapeStatistics.h
@@ -139,7 +139,7 @@ class ParticleShapeStatistics {
   unsigned int num_samples_group1_;
   unsigned int num_samples_group2_;
   unsigned int num_samples_;
-  unsigned int domains_per_shape_;
+  unsigned int domains_per_shape_ = 0;
   unsigned int num_dimensions_;
   std::vector<int> group_ids_;
 

--- a/Studio/Analysis/AnalysisTool.cpp
+++ b/Studio/Analysis/AnalysisTool.cpp
@@ -1171,9 +1171,6 @@ void AnalysisTool::update_slider() {
 
 //---------------------------------------------------------------------------
 void AnalysisTool::reset_stats() {
-  stats_ready_ = false;
-  evals_ready_ = false;
-
   ui_->tabWidget->setCurrentWidget(ui_->mean_tab);
   ui_->allSamplesRadio->setChecked(true);
   ui_->singleSamplesRadio->setChecked(false);
@@ -1200,6 +1197,8 @@ void AnalysisTool::reset_stats() {
   particle_area_panel_->reset();
   shape_scalar_panel_->reset();
   stats_ = ParticleShapeStatistics();
+  evals_ready_ = false;
+  stats_ready_ = false;
 
   ui_->pca_scalar_combo->clear();
   if (session_) {


### PR DESCRIPTION
Fix #2383 - Warning message pops up if analytics is on PCA tab when optimization complete

* #2383
