### PR TITLE
Add profiling/tracing module and speed improvments to correspondence function of optimizer

### DIFF
--- a/Applications/shapeworks/Commands.cpp
+++ b/Applications/shapeworks/Commands.cpp
@@ -11,6 +11,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include <Profiling.h>
+
 namespace shapeworks {
 
 // boilerplate for a command. Copy this to start a new command
@@ -119,10 +121,12 @@ bool OptimizeCommand::execute(const optparse::Values& options, SharedCommandData
         project->set_filename(StringUtils::getFilename(projectFile));
       }
 
+      TIME_START("set_up_optimize");
       // set up Optimize class based on project parameters
       OptimizeParameters params(project);
       params.set_up_optimize(&app);
       app.SetProject(project);
+      TIME_STOP("set_up_optimize");
 
       bool success = app.Run();
 

--- a/Applications/shapeworks/shapeworks.cpp
+++ b/Applications/shapeworks/shapeworks.cpp
@@ -5,6 +5,7 @@
 #include <exception>
 #include "Executable.h"
 #include "Commands.h"
+#include <Profiling.h>
 
 using namespace shapeworks;
 
@@ -111,9 +112,14 @@ int main(int argc, char *argv[])
   shapeworks.addCommand(ConvertProjectCommand::getCommand());
 
   try {
-    return shapeworks.run(argc, argv);
+    TIME_START("shapeworks");
+    int rc = shapeworks.run(argc, argv);
+    TIME_STOP("shapeworks");
+    TIME_FINALIZE();
+    return rc;
   } catch (const std::exception &e) {
     std::cout << e.what() << std::endl;
+    TIME_FINALIZE();
     return EXIT_FAILURE;
   }
 }

--- a/Libs/Common/CMakeLists.txt
+++ b/Libs/Common/CMakeLists.txt
@@ -4,12 +4,14 @@ set(Common_sources
   ShapeworksUtils.cpp
   Region.cpp
   Logging.cpp
+  Profiling.cpp
   )
 set(Common_headers
   Shapeworks.h
   ShapeworksUtils.h
   Region.h
   Logging.h
+  Profiling.h
   )
 add_library(Common STATIC
   ${Common_sources}

--- a/Libs/Common/Logging.cpp
+++ b/Libs/Common/Logging.cpp
@@ -87,12 +87,16 @@ void Logging::log_stack(const std::string& message) const {
 
 //-----------------------------------------------------------------------------
 void Logging::log_error(const std::string& message, const int line, const char* file) const {
-  spd::error(message);
+  std::string str = message;
+  if (spd::get_level() == spd::level::debug) {
+    str = create_header(line, file) + " Error: " + message;
+  }
+  spd::error(str);
   if (log_open_) {
-    spd::get("file")->error(message);
+    spd::get("file")->error(str);
   }
   if (error_callback_) {
-    error_callback_(message);
+    error_callback_(str);
   }
 }
 

--- a/Libs/Common/Profiling.cpp
+++ b/Libs/Common/Profiling.cpp
@@ -1,0 +1,274 @@
+#include "Profiling.h"
+#include <QCoreApplication>
+#include <QDebug>
+#include <QStandardPaths>
+#include <QDir>
+#include <cstdlib>
+#include <iostream>
+#include <algorithm>
+
+namespace shapeworks {
+
+Timer_Stack_Entry::Timer_Stack_Entry(const QString& name, qint64 start_time_us)
+  : name(name), start_time_us(start_time_us), accumulated_child_time_ms(0.0) {
+}
+
+Profiler::Profiler()
+  : profiling_enabled_(false), tracing_enabled_(false), start_time_us_(0) {
+
+  // Check environment variables
+  const char* profile_env = std::getenv("SW_TIME_PROFILE");
+  if (profile_env) {
+    QString profile_str = QString(profile_env).toLower();
+    profiling_enabled_ = (profile_str == "on" || profile_str == "1" || profile_str == "true");
+  }
+
+  const char* trace_env = std::getenv("SW_TIME_TRACE");
+  if (trace_env) {
+    QString trace_str = QString(trace_env).toLower();
+    tracing_enabled_ = (trace_str == "on" || trace_str == "1" || trace_str == "true");
+  }
+
+  if (profiling_enabled_ || tracing_enabled_) {
+    elapsed_timer_.start();
+    start_time_us_ = std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::high_resolution_clock::now().time_since_epoch()).count();
+  }
+}
+
+Profiler::~Profiler() {
+}
+
+Profiler& Profiler::instance() {
+  static Profiler instance;
+  return instance;
+}
+
+void Profiler::start_timer(const QString& name) {
+  if (!profiling_enabled_ && !tracing_enabled_) {
+    return;
+  }
+
+  QMutexLocker locker(&mutex_);
+  Qt::HANDLE thread_id = QThread::currentThreadId();
+  qint64 current_time_us = elapsed_timer_.nsecsElapsed() / 1000;
+
+  // Add to timer stack
+  auto& stack = timer_stacks_[thread_id];
+  stack.push_back(std::make_unique<Timer_Stack_Entry>(name, current_time_us));
+
+  // Add trace event if tracing enabled
+  if (tracing_enabled_) {
+    Trace_Event event;
+    event.name = name;
+    event.phase = "B";
+    event.timestamp_us = start_time_us_ + current_time_us;
+    event.thread_id = thread_id;
+    event.process_id = QCoreApplication::applicationPid();
+    trace_events_.push_back(event);
+  }
+}
+
+void Profiler::stop_timer(const QString& name) {
+  if (!profiling_enabled_ && !tracing_enabled_) {
+    return;
+  }
+
+  QMutexLocker locker(&mutex_);
+  Qt::HANDLE thread_id = QThread::currentThreadId();
+  qint64 current_time_us = elapsed_timer_.nsecsElapsed() / 1000;
+
+  auto& stack = timer_stacks_[thread_id];
+  if (stack.empty()) {
+    qWarning() << "Timer stack underflow for" << name;
+    return;
+  }
+
+  // Find matching timer in stack (should be at top, but handle mismatched calls)
+  auto it = std::find_if(stack.rbegin(), stack.rend(),
+    [&name](const std::unique_ptr<Timer_Stack_Entry>& entry) {
+      return entry->name == name;
+    });
+
+  if (it == stack.rend()) {
+    qWarning() << "No matching start timer found for" << name;
+    return;
+  }
+
+  auto& entry = **it;
+  double elapsed_ms = (current_time_us - entry.start_time_us) / 1000.0;
+
+  if (profiling_enabled_) {
+    // Update profile entry
+    auto& profile_entry = profile_entries_[name];
+    profile_entry.name = name;
+    profile_entry.thread_id = thread_id;
+    profile_entry.call_count++;
+    profile_entry.inclusive_time_ms += elapsed_ms;
+    profile_entry.exclusive_time_ms += (elapsed_ms - entry.accumulated_child_time_ms);
+
+    // Update parent's subcall count and child time
+    if (stack.size() > 1) {
+      auto parent_it = stack.end() - 2;
+      if (std::distance(stack.begin(), parent_it) >= 0) {
+        (*parent_it)->accumulated_child_time_ms += elapsed_ms;
+        auto& parent_profile = profile_entries_[(*parent_it)->name];
+        parent_profile.subcall_count++;
+      }
+    }
+  }
+
+  // Add trace event if tracing enabled
+  if (tracing_enabled_) {
+    Trace_Event event;
+    event.name = name;
+    event.phase = "E";
+    event.timestamp_us = start_time_us_ + current_time_us;
+    event.thread_id = thread_id;
+    event.process_id = QCoreApplication::applicationPid();
+    trace_events_.push_back(event);
+  }
+
+  // Remove from stack
+  stack.erase(it.base() - 1);
+}
+
+void Profiler::finalize() {
+  if (!profiling_enabled_ && !tracing_enabled_) {
+    return;
+  }
+
+  QMutexLocker locker(&mutex_);
+
+  if (profiling_enabled_) {
+    write_profile_report();
+  }
+
+  if (tracing_enabled_) {
+    write_trace_file();
+  }
+}
+
+void Profiler::write_profile_report() {
+  // Calculate total time
+  double total_time_ms = elapsed_timer_.elapsed();
+
+  // Group entries by thread
+  std::unordered_map<Qt::HANDLE, std::vector<Profile_Entry*>> entries_by_thread;
+  for (auto& pair : profile_entries_) {
+    entries_by_thread[pair.second.thread_id].push_back(&pair.second);
+  }
+
+  QString report;
+  QTextStream stream(&report);
+
+  for (const auto& thread_pair : entries_by_thread) {
+    Qt::HANDLE thread_id = thread_pair.first;
+    auto entries = thread_pair.second;
+
+    // Sort by inclusive time (descending)
+    std::sort(entries.begin(), entries.end(),
+      [](const Profile_Entry* a, const Profile_Entry* b) {
+        return a->inclusive_time_ms > b->inclusive_time_ms;
+      });
+
+    stream << QString("THREAD %1: ").arg(reinterpret_cast<quintptr>(thread_id)) << "\n";
+    stream << "--------------------------------------------------------------------------------------\n";
+    stream << QString("%1 %2 %3 %4 %5 %6 %7\n")
+             .arg("   %Time", 8)
+             .arg("Exclusive", 12)
+             .arg("Inclusive", 12)
+             .arg("#Call", 8)
+             .arg("#Subrs", 8)
+             .arg("Inclusive", 12)
+             .arg("Name", 5);
+    stream << QString("%1 %2 %3 %4 %5 %6\n")
+             .arg("", 8)
+             .arg("msec", 12)
+             .arg("total msec", 12)
+             .arg("", 8)
+             .arg("", 8)
+             .arg("ms/call",12);
+    stream << "--------------------------------------------------------------------------------------\n";
+
+    for (const auto* entry : entries) {
+      double percent = (entry->inclusive_time_ms / total_time_ms) * 100.0;
+      double usec_per_call = entry->call_count > 0 ? (entry->inclusive_time_ms) / entry->call_count : 0.0;
+
+      stream << QString("%1 %2 %3 %4 %5 %6 %7\n")
+               .arg(QString::number(percent, 'f', 1), 8)
+               .arg(QString::number(entry->exclusive_time_ms, 'f', 0), 12)
+               .arg(QString::number(entry->inclusive_time_ms, 'f', 0), 12)
+               .arg(entry->call_count, 8)
+               .arg(entry->subcall_count, 8)
+               .arg(QString::number(usec_per_call, 'f', 0), 12)
+               .arg(entry->name);
+    }
+    stream << "--------------------------------------------------------------------------------------\n\n";
+  }
+
+  // Output to console
+  std::cout << report.toStdString() << std::endl;
+
+  // Write to file
+  QFile file("profile.txt");
+  if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    QTextStream file_stream(&file);
+    file_stream << report;
+    file.close();
+    std::cout << "Profile written to profile.txt" << std::endl;
+  } else {
+    qWarning() << "Failed to write profile.txt";
+  }
+}
+
+void Profiler::write_trace_file() {
+  QJsonObject root;
+  QJsonArray events;
+
+  for (const auto& event : trace_events_) {
+    QJsonObject json_event;
+    json_event["name"] = event.name;
+    json_event["ph"] = event.phase;
+    json_event["ts"] = event.timestamp_us;
+    json_event["tid"] = static_cast<qint64>(reinterpret_cast<quintptr>(event.thread_id));
+    json_event["pid"] = event.process_id;
+    events.append(json_event);
+  }
+
+  root["traceEvents"] = events;
+
+  QJsonDocument doc(root);
+
+  QFile file("trace.json");
+  if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    file.write(doc.toJson());
+    file.close();
+    std::cout << "Trace written to trace.json" << std::endl;
+  } else {
+    qWarning() << "Failed to write trace.json";
+  }
+}
+
+QString Profiler::format_time(double ms) {
+  if (ms >= 1000.0) {
+    return QString::number(ms / 1000.0, 'f', 3) + "s";
+  } else {
+    return QString::number(ms, 'f', 3) + "ms";
+  }
+}
+
+Scoped_Timer::Scoped_Timer(const QString& name)
+  : name_(name), enabled_(Profiler::instance().is_profiling_enabled() || Profiler::instance().is_tracing_enabled()) {
+  if (enabled_) {
+    Profiler::instance().start_timer(name_);
+  }
+}
+
+Scoped_Timer::~Scoped_Timer() {
+  if (enabled_) {
+    Profiler::instance().stop_timer(name_);
+  }
+}
+
+} // namespace shapeworks

--- a/Libs/Common/Profiling.cpp
+++ b/Libs/Common/Profiling.cpp
@@ -201,7 +201,7 @@ void Profiler::write_profile_report() {
 
     for (const auto* entry : entries) {
       double percent = (entry->inclusive_time_ms / total_time_ms) * 100.0;
-      double usec_per_call = entry->call_count > 0 ? (entry->inclusive_time_ms) / entry->call_count : 0.0;
+      double msec_per_call = entry->call_count > 0 ? (entry->inclusive_time_ms) / entry->call_count : 0.0;
 
       stream << QString("%1 %2 %3 %4 %5 %6 %7\n")
                .arg(QString::number(percent, 'f', 1), 8)
@@ -209,7 +209,7 @@ void Profiler::write_profile_report() {
                .arg(QString::number(entry->inclusive_time_ms, 'f', 0), 12)
                .arg(entry->call_count, 8)
                .arg(entry->subcall_count, 8)
-               .arg(QString::number(usec_per_call, 'f', 0), 12)
+               .arg(QString::number(msec_per_call, 'f', 0), 12)
                .arg(entry->name);
     }
     stream << "--------------------------------------------------------------------------------------\n\n";

--- a/Libs/Common/Profiling.h
+++ b/Libs/Common/Profiling.h
@@ -1,16 +1,9 @@
 #pragma once
 
 #include <QElapsedTimer>
-#include <QFile>
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QJsonObject>
 #include <QMutex>
 #include <QString>
-#include <QTextStream>
 #include <QThread>
-#include <chrono>
-#include <memory>
 #include <unordered_map>
 #include <vector>
 

--- a/Libs/Common/Profiling.h
+++ b/Libs/Common/Profiling.h
@@ -1,22 +1,23 @@
 #pragma once
 
-#include <QMutex>
-#include <QString>
 #include <QElapsedTimer>
-#include <QThread>
-#include <QTextStream>
 #include <QFile>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QJsonArray>
+#include <QMutex>
+#include <QString>
+#include <QTextStream>
+#include <QThread>
+#include <chrono>
+#include <memory>
 #include <unordered_map>
 #include <vector>
-#include <memory>
-#include <chrono>
 
 namespace shapeworks {
 
-struct Profile_Entry {
+//---------------------------------------------------------------------------
+struct ProfileEntry {
   QString name;
   double exclusive_time_ms;
   double inclusive_time_ms;
@@ -25,7 +26,8 @@ struct Profile_Entry {
   Qt::HANDLE thread_id;
 };
 
-struct Trace_Event {
+//---------------------------------------------------------------------------
+struct TraceEvent {
   QString name;
   QString phase;  // "B" for begin, "E" for end
   qint64 timestamp_us;
@@ -33,17 +35,19 @@ struct Trace_Event {
   int process_id;
 };
 
-class Timer_Stack_Entry {
-public:
-  Timer_Stack_Entry(const QString& name, qint64 start_time_us);
+//---------------------------------------------------------------------------
+class TimerStackEntry {
+ public:
+  TimerStackEntry(const QString& name, qint64 start_time_us);
 
   QString name;
   qint64 start_time_us;
   double accumulated_child_time_ms;
 };
 
+//---------------------------------------------------------------------------
 class Profiler {
-public:
+ public:
   static Profiler& instance();
 
   void start_timer(const QString& name);
@@ -53,7 +57,7 @@ public:
   bool is_profiling_enabled() const { return profiling_enabled_; }
   bool is_tracing_enabled() const { return tracing_enabled_; }
 
-private:
+ private:
   Profiler();
   ~Profiler();
 
@@ -66,42 +70,28 @@ private:
   qint64 start_time_us_;
 
   QMutex mutex_;
-  std::unordered_map<Qt::HANDLE, std::vector<std::unique_ptr<Timer_Stack_Entry>>> timer_stacks_;
-  std::unordered_map<QString, Profile_Entry> profile_entries_;
-  std::vector<Trace_Event> trace_events_;
+  std::unordered_map<Qt::HANDLE, std::vector<std::unique_ptr<TimerStackEntry>>> timer_stacks_;
+  std::unordered_map<QString, ProfileEntry> profile_entries_;
+  std::vector<TraceEvent> trace_events_;
 
   QElapsedTimer elapsed_timer_;
 };
 
-class Scoped_Timer {
-public:
-  Scoped_Timer(const QString& name);
-  ~Scoped_Timer();
+//---------------------------------------------------------------------------
+class ScopedTimer {
+ public:
+  ScopedTimer(const QString& name);
+  ~ScopedTimer();
 
-private:
+ private:
   QString name_;
   bool enabled_;
 };
 
-} // namespace shapeworks
+}  // namespace shapeworks
 
 // Profiling macros
-#define TIME_START(name) \
-do { \
-      if (shapeworks::Profiler::instance().is_profiling_enabled() || shapeworks::Profiler::instance().is_tracing_enabled()) { \
-        shapeworks::Profiler::instance().start_timer(name); \
-  } \
-} while(0)
-
-#define TIME_STOP(name) \
-    do { \
-      if (shapeworks::Profiler::instance().is_profiling_enabled() || shapeworks::Profiler::instance().is_tracing_enabled()) { \
-        shapeworks::Profiler::instance().stop_timer(name); \
-  } \
-} while(0)
-
-#define TIME_SCOPE(name) \
-shapeworks::Scoped_Timer _scoped_timer_##__LINE__(name)
-
-#define TIME_FINALIZE() \
-    shapeworks::Profiler::instance().finalize()
+#define TIME_START(name) shapeworks::Profiler::instance().start_timer(name);
+#define TIME_STOP(name) shapeworks::Profiler::instance().stop_timer(name);
+#define TIME_SCOPE(name) shapeworks::ScopedTimer _scoped_timer_##__LINE__(name)
+#define TIME_FINALIZE() shapeworks::Profiler::instance().finalize()

--- a/Libs/Common/Profiling.h
+++ b/Libs/Common/Profiling.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <QMutex>
+#include <QString>
+#include <QElapsedTimer>
+#include <QThread>
+#include <QTextStream>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <unordered_map>
+#include <vector>
+#include <memory>
+#include <chrono>
+
+namespace shapeworks {
+
+struct Profile_Entry {
+  QString name;
+  double exclusive_time_ms;
+  double inclusive_time_ms;
+  int call_count;
+  int subcall_count;
+  Qt::HANDLE thread_id;
+};
+
+struct Trace_Event {
+  QString name;
+  QString phase;  // "B" for begin, "E" for end
+  qint64 timestamp_us;
+  Qt::HANDLE thread_id;
+  int process_id;
+};
+
+class Timer_Stack_Entry {
+public:
+  Timer_Stack_Entry(const QString& name, qint64 start_time_us);
+
+  QString name;
+  qint64 start_time_us;
+  double accumulated_child_time_ms;
+};
+
+class Profiler {
+public:
+  static Profiler& instance();
+
+  void start_timer(const QString& name);
+  void stop_timer(const QString& name);
+  void finalize();
+
+  bool is_profiling_enabled() const { return profiling_enabled_; }
+  bool is_tracing_enabled() const { return tracing_enabled_; }
+
+private:
+  Profiler();
+  ~Profiler();
+
+  void write_profile_report();
+  void write_trace_file();
+  QString format_time(double ms);
+
+  bool profiling_enabled_;
+  bool tracing_enabled_;
+  qint64 start_time_us_;
+
+  QMutex mutex_;
+  std::unordered_map<Qt::HANDLE, std::vector<std::unique_ptr<Timer_Stack_Entry>>> timer_stacks_;
+  std::unordered_map<QString, Profile_Entry> profile_entries_;
+  std::vector<Trace_Event> trace_events_;
+
+  QElapsedTimer elapsed_timer_;
+};
+
+class Scoped_Timer {
+public:
+  Scoped_Timer(const QString& name);
+  ~Scoped_Timer();
+
+private:
+  QString name_;
+  bool enabled_;
+};
+
+} // namespace shapeworks
+
+// Profiling macros
+#define TIME_START(name) \
+do { \
+      if (shapeworks::Profiler::instance().is_profiling_enabled() || shapeworks::Profiler::instance().is_tracing_enabled()) { \
+        shapeworks::Profiler::instance().start_timer(name); \
+  } \
+} while(0)
+
+#define TIME_STOP(name) \
+    do { \
+      if (shapeworks::Profiler::instance().is_profiling_enabled() || shapeworks::Profiler::instance().is_tracing_enabled()) { \
+        shapeworks::Profiler::instance().stop_timer(name); \
+  } \
+} while(0)
+
+#define TIME_SCOPE(name) \
+shapeworks::Scoped_Timer _scoped_timer_##__LINE__(name)
+
+#define TIME_FINALIZE() \
+    shapeworks::Profiler::instance().finalize()

--- a/Libs/Optimize/Function/CorrespondenceFunction.cpp
+++ b/Libs/Optimize/Function/CorrespondenceFunction.cpp
@@ -76,21 +76,13 @@ void CorrespondenceFunction::ComputeUpdates(const ParticleSystem* c) {
 
     TIME_START("correspondence::lhs_rhs");
 
-    /*
-    vnl_matrix_type projMat = points_minus_mean * UG;
-    const auto lhs = projMat * invLambda;
-    const auto rhs =
-        invLambda * projMat.transpose();  // invLambda doesn't need to be transposed since its a diagonal matrix
-    */
-
     // Create Eigen maps for the VNL matrices
     Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>> UG_map(UG.data_block(),
                                                                                               UG.rows(), UG.cols());
-
     // Create temporary Eigen matrices for the computations
     Eigen::MatrixXd projMat_eigen = points_minus_mean_map * UG_map;
-
     // Convert invLambda diagonal matrix to Eigen
+
     // Assuming invLambda is a vnl_diag_matrix, you'll need to extract the diagonal
     Eigen::VectorXd invLambda_diag(invLambda.size());
     for (int i = 0; i < invLambda.size(); i++) {
@@ -101,7 +93,6 @@ void CorrespondenceFunction::ComputeUpdates(const ParticleSystem* c) {
     // Perform the computations using Eigen
     const auto lhs = projMat_eigen * invLambda_eigen;
     const auto rhs = invLambda_eigen * projMat_eigen.transpose();
-
     TIME_STOP("correspondence::lhs_rhs");
 
     // resize the inverse covariance matrix if necessary
@@ -109,7 +100,6 @@ void CorrespondenceFunction::ComputeUpdates(const ParticleSystem* c) {
       m_InverseCovMatrix->resize(num_dims, num_dims);
     }
     TIME_START("correspondence::covariance_multiply");
-    //Utils::multiply_into(*m_InverseCovMatrix, lhs, rhs);
     m_InverseCovMatrix->noalias() = lhs * rhs;
     TIME_STOP("correspondence::covariance_multiply");
   }

--- a/Libs/Optimize/Function/CorrespondenceFunction.cpp
+++ b/Libs/Optimize/Function/CorrespondenceFunction.cpp
@@ -48,14 +48,13 @@ void CorrespondenceFunction::ComputeUpdates(const ParticleSystem* c) {
     TIME_START("correspondence::gramMat");
 
     // old
-    //gramMat = points_minus_mean.transpose() * points_minus_mean;
+    // gramMat = points_minus_mean.transpose() * points_minus_mean;
 
-
-    /*
     // Create Eigen maps that point to the VNL data
-    Eigen::Map<Eigen::MatrixXd> points_minus_mean_map(points_minus_mean.data_block(),
-                                                      points_minus_mean.rows(),
-                                                      points_minus_mean.cols());
+    Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
+    points_minus_mean_map(points_minus_mean.data_block(),
+                          points_minus_mean.rows(),
+                          points_minus_mean.cols());
 
     // Perform the computation directly on the mapped data
     Eigen::MatrixXd gramMat_eigen = points_minus_mean_map.transpose() * points_minus_mean_map;
@@ -64,25 +63,6 @@ void CorrespondenceFunction::ComputeUpdates(const ParticleSystem* c) {
     gramMat.set_size(gramMat_eigen.rows(), gramMat_eigen.cols());
     std::memcpy(gramMat.data_block(), gramMat_eigen.data(),
                 gramMat_eigen.size() * sizeof(double));
-    */
-
-    // Create Eigen maps that point to the VNL data
-    Eigen::Map<Eigen::MatrixXd> points_minus_mean_map(points_minus_mean.data_block(),
-                                                      points_minus_mean.rows(),
-                                                      points_minus_mean.cols());
-
-    // Make sure gramMat is the right size first
-    gramMat.set_size(num_samples, num_samples);
-
-    // Create a map to the gramMat data
-    Eigen::Map<Eigen::MatrixXd> gramMat_map(gramMat.data_block(),
-                                            gramMat.rows(),
-                                            gramMat.cols());
-
-    // Perform the computation directly into the mapped gramMat
-    gramMat_map = points_minus_mean_map.transpose() * points_minus_mean_map;
-
-
 
     TIME_STOP("correspondence::gramMat");
 

--- a/Libs/Optimize/Function/CorrespondenceFunction.cpp
+++ b/Libs/Optimize/Function/CorrespondenceFunction.cpp
@@ -4,12 +4,14 @@
 #include <math.h>
 
 #include "Libs/Utils/Utils.h"
+#include "Profiling.h"
 #include "vnl/algo/vnl_svd.h"
 #include "vnl/vnl_diag_matrix.h"
 
 namespace shapeworks {
 
 void CorrespondenceFunction::ComputeUpdates(const ParticleSystem* c) {
+  TIME_SCOPE("CorrespondenceFunction::ComputeUpdates");
   num_dims = m_ShapeData->rows();
   num_samples = m_ShapeData->cols();
 
@@ -45,7 +47,9 @@ void CorrespondenceFunction::ComputeUpdates(const ParticleSystem* c) {
     m_InverseCovMatrix->setZero();
 
   } else {
+    TIME_START("correspondence::gramMat");
     gramMat = points_minus_mean.transpose() * points_minus_mean;
+    TIME_STOP("correspondence::gramMat");
 
     vnl_svd<double> svd(gramMat);
 
@@ -67,7 +71,9 @@ void CorrespondenceFunction::ComputeUpdates(const ParticleSystem* c) {
     if (m_InverseCovMatrix->rows() != num_dims || m_InverseCovMatrix->cols() != num_dims) {
       m_InverseCovMatrix->resize(num_dims, num_dims);
     }
+    TIME_START("correspondence::covariance_multiply");
     Utils::multiply_into(*m_InverseCovMatrix, lhs, rhs);
+    TIME_STOP("correspondence::covariance_multiply");
   }
 
   vnl_matrix_type Q = points_minus_mean * pinvMat;

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -2,10 +2,12 @@
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
-//#include <numeric>
+// #include <numeric>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include "Profiling.h"
 
 #ifdef _WIN32
 #include <direct.h>
@@ -175,6 +177,8 @@ bool Optimize::Run() {
 
 //---------------------------------------------------------------------------
 int Optimize::SetParameters() {
+  TIME_SCOPE("Optimize::SetParameters");
+
   // sanity check
   if (m_domains_per_shape != m_number_of_particles.size()) {
     SW_ERROR("Inconsistency in parameters... m_domains_per_shape != m_number_of_particles.size()");
@@ -494,6 +498,7 @@ void Optimize::AddSinglePoint() {
 
 //---------------------------------------------------------------------------
 void Optimize::Initialize() {
+  TIME_SCOPE("Optimize::Initialize");
   if (m_verbosity_level > 0) {
     SW_LOG("------------------------------");
     SW_LOG("*** Initialize Step ***");
@@ -690,6 +695,8 @@ void Optimize::Initialize() {
 
 //---------------------------------------------------------------------------
 void Optimize::RunOptimize() {
+  TIME_SCOPE("Optimize::RunOptimize");
+
   if (m_verbosity_level > 0) {
     std::cout << "------------------------------\n";
     std::cout << "*** Optimize Step\n";

--- a/Libs/Project/Project.cpp
+++ b/Libs/Project/Project.cpp
@@ -346,6 +346,11 @@ void Project::determine_feature_names() {
             if (poly_data) {
               vtkIdType num_arrays = poly_data->GetPointData()->GetNumberOfArrays();
               for (vtkIdType i = 0; i < num_arrays; i++) {
+                std::string array_name = StringUtils::safeString(poly_data->GetPointData()->GetArrayName(i));
+                // ignore "normals" and "Normals" arrays
+                if (array_name == "normals" || array_name == "Normals") {
+                  continue;
+                }
                 mesh_scalars.push_back(StringUtils::safeString(poly_data->GetPointData()->GetArrayName(i)));
               }
             }

--- a/Libs/Utils/CMakeLists.txt
+++ b/Libs/Utils/CMakeLists.txt
@@ -3,12 +3,14 @@ set(Utils_sources
   Utils.cpp
   StringUtils.cpp
   EigenUtils.cpp
+  PlatformUtils.cpp
   )
 
 set(Utils_headers
   Utils.h
   StringUtils.h
   EigenUtils.h
+  PlatformUtils.h
   )
 
 add_library(Utils STATIC

--- a/Libs/Utils/PlatformUtils.h
+++ b/Libs/Utils/PlatformUtils.h
@@ -1,0 +1,29 @@
+
+namespace shapeworks {
+
+//! Platform utility functions
+class PlatformUtils {
+ public:
+  static bool is_windows() {
+#ifdef _WIN32
+    return true;
+#endif
+    return false;
+  }
+
+  static bool is_linux() {
+#ifdef __linux__
+    return true;
+#endif
+    return false;
+  }
+
+  static bool is_macos() {
+#ifdef __APPLE__
+    return true;
+#endif
+    return false;
+  }
+};
+
+}  // namespace shapeworks

--- a/Studio/Data/Session.cpp
+++ b/Studio/Data/Session.cpp
@@ -1340,9 +1340,7 @@ Eigen::MatrixXd Session::get_all_scalars(std::string target_feature) {
 
     // check that the scalars are the right size
     if (scalars.size() != num_particles) {
-      SW_ERROR("scalars.size() : {}", scalars.size());
-      SW_ERROR("num_particles : {}", num_particles);
-      SW_ERROR("Error: scalars size does not match number of particles");
+      SW_LOG("Size of scalars ({}) does not match number of particles ({})", scalars.size(), num_particles);
       return Eigen::MatrixXd();
     }
 

--- a/Studio/Job/ShapeScalarJob.h
+++ b/Studio/Job/ShapeScalarJob.h
@@ -41,7 +41,7 @@ class ShapeScalarJob : public Job {
  private:
   void prep_data();
 
-  void run_fit();
+  bool run_fit();
   void run_prediction();
 
   static Eigen::VectorXd predict(QSharedPointer<Session> session, QString target_feature,


### PR DESCRIPTION
* Add basic profiling and tracing infrastructure
* Speed improvements for correspondence function of optimizer

This PR adds a very basic profile and trace capability to ShapeWorks.  It is controlled with environment variables SW_TIME_PROFILE=1 and SW_TIME_TRACE=1.  When profiling is on, a file, `profile.txt` is written at the end of execution and displayed on the screen as well.  It looks roughly like this:

```
THREAD 0:
------------------------------------------------------------------------------------------------------
   %Time    Exclusive    Inclusive   #Calls   #Child    Exclusive    Inclusive Name
             total ms     total ms                        ms/call      ms/call
------------------------------------------------------------------------------------------------------
   100.0           96      2785689        1        4           96      2785689 shapeworks
    96.4         1046      2684521        1        1         1046      2684521 Optimize::RunOptimize
    96.3            4      2683476        1     5000            4      2683476 GradientDescentOptimizer
    96.3         5283      2683472     5000    10000            1          537 optimizer_iteration
    91.3           21      2542943     5000     5000            0          509 gradient_before_iteration
    91.3       743136      2542922     5000    25000          149          509 CorrespondenceFunction::ComputeUpdates
    49.0      1363987      1363987     5000        0          273          273 correspondence::covariance_multiply
    10.4       290396       290396     5000        0           58           58 correspondence::gramMat
     4.9       135245       135245     5000        0           27           27 parallel_sampling
     3.5        97351        97351        1        0        97351        97351 Optimize::SetParameters
     3.4        95425        95425     5000        0           19           19 correspondence::lhs_rhs
     1.4        40078        40078     5000        0            8            8 correspondence::svd
     0.4         9899         9899     5000        0            2            2 correspondence::pinvMat
     0.1         2216         2216        1        0         2216         2216 set_up_optimize
     0.1         1504         1504        1        0         1504         1504 Optimize::Initialize
------------------------------------------------------------------------------------------------------
```

All times are in milliseconds.

Exclusive total time  : Time spent in this timer and not any child timers/calls
Inclusive total time : Time spent in this timer and also any child timers/calls
#Calls : Number of times this timer/function is called
#Child : Number of child/sub-calls to other times/functions
Exclusive ms/call : Mean exclusive time per call
Inclusive ms/call : Mean inclusive time per call

The API is quite simple:

```
    TIME_START("correspondence::gramMat");
     ...
    TIME_STOP("correspondence::gramMat");
```

Or:

```
{
TIME_SCOPE("CorrespondenceFunction::ComputeUpdates");
...
}
```

TIME_SCOPE uses RAII to stop the timer at the end of the scope.

Tracing produces a `trace.json` file at the end.  This uses the google trace event format (https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?tab=t.0#heading=h.yr4qxyxotyw) and can be viewed in tools such as Perfetto UI (https://ui.perfetto.dev/)

<img width="3813" height="1048" alt="image" src="https://github.com/user-attachments/assets/45484d71-7d54-4530-94e7-7b930b77bcf4" />


Additionally, profiling of the correspondence function was performed and numerous improvements were made, primarily by converting VNL code to Eigen:

Before:

```
------------------------------------------------------------------------------------------------------
   %Time    Exclusive    Inclusive   #Calls   #Child    Exclusive    Inclusive Name
             total ms     total ms                        ms/call      ms/call
------------------------------------------------------------------------------------------------------
   100.0           96      2785689        1        4           96      2785689 shapeworks
    96.4         1046      2684521        1        1         1046      2684521 Optimize::RunOptimize
    96.3            4      2683476        1     5000            4      2683476 GradientDescentOptimizer
    96.3         5283      2683472     5000    10000            1          537 optimizer_iteration
    91.3           21      2542943     5000     5000            0          509 gradient_before_iteration
    91.3       743136      2542922     5000    25000          149          509 CorrespondenceFunction::ComputeUpdates
    49.0      1363987      1363987     5000        0          273          273 correspondence::covariance_multiply
    10.4       290396       290396     5000        0           58           58 correspondence::gramMat
     4.9       135245       135245     5000        0           27           27 parallel_sampling
     3.5        97351        97351        1        0        97351        97351 Optimize::SetParameters
     3.4        95425        95425     5000        0           19           19 correspondence::lhs_rhs
     1.4        40078        40078     5000        0            8            8 correspondence::svd
     0.4         9899         9899     5000        0            2            2 correspondence::pinvMat
     0.1         2216         2216        1        0         2216         2216 set_up_optimize
     0.1         1504         1504        1        0         1504         1504 Optimize::Initialize
------------------------------------------------------------------------------------------------------
```

After:

```
--------------------------------------------------------------------------------------
   %Time    Exclusive    Inclusive    #Call   #Subrs    Inclusive  Name
                 msec   total msec                        ms/call
--------------------------------------------------------------------------------------
   100.0           95      5115882        1        4      5115882 shapeworks
    98.0         1025      5014928        1        1      5014928 Optimize::RunOptimize
    98.0            4      5013903        1     5000      5013903 GradientDescentOptimizer
    98.0         6766      5013899     5000    10000         1003 optimizer_iteration
    95.2           22      4871999     5000     5000          974 gradient_before_iteration
    95.2      1495283      4871977     5000    10000          974 CorrespondenceFunction::ComputeUpdates
    39.9      2040669      2040669     5000        0          408 correspondence::gramMat
    26.1      1336025      1336025     5000        0          267 correspondence::covariance_multiply
     2.6       135134       135134     5000        0           27 parallel_sampling
     1.9        97173        97173        1        0        97173 Optimize::SetParameters
     0.0         2215         2215        1        0         2215 set_up_optimize
     0.0         1471         1471        1        0         1471 Optimize::Initialize
--------------------------------------------------------------------------------------
```

This reduced the runtime by 46% (1 hour 25 minutes down to 46 minutes).

This was a particular fixed domains runtime with 2048 particles + normals, about 150-ish shapes.  Similar speedups will not be seen at lower particle/shape counts and no improvement occurs for initialization/sampling.

