### PR TITLE
Add patch for OpenVDB with Clang17 based on this PR:

### DIFF
--- a/Support/openvdb-9.1.0.patch
+++ b/Support/openvdb-9.1.0.patch
@@ -1,0 +1,31 @@
+diff --git a/openvdb/openvdb/tree/NodeManager.h b/openvdb/openvdb/tree/NodeManager.h
+index 4d0d9b46..12dabaaa 100644
+--- a/openvdb/openvdb/tree/NodeManager.h
++++ b/openvdb/openvdb/tree/NodeManager.h
+@@ -327,7 +327,7 @@ private:
+         void operator()(const NodeRange& range) const
+         {
+             for (typename NodeRange::Iterator it = range.begin(); it; ++it) {
+-                OpT::template eval(mNodeOp, it);
++                OpT::eval(mNodeOp, it);
+             }
+         }
+         const NodeOp mNodeOp;
+@@ -347,7 +347,7 @@ private:
+         void operator()(const NodeRange& range) const
+         {
+             for (typename NodeRange::Iterator it = range.begin(); it; ++it) {
+-                OpT::template eval(mNodeOp, it);
++                OpT::eval(mNodeOp, it);
+             }
+         }
+         const NodeOp& mNodeOp;
+@@ -372,7 +372,7 @@ private:
+         void operator()(const NodeRange& range)
+         {
+             for (typename NodeRange::Iterator it = range.begin(); it; ++it) {
+-                OpT::template eval(*mNodeOp, it);
++                OpT::eval(*mNodeOp, it);
+             }
+         }
+         void join(const NodeReducer& other)

--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -251,6 +251,9 @@ build_openvdb()
   cd openvdb
   git checkout ${OpenVDB_VER}
 
+  # patch for Clang 17
+  patch -p1 < ${SCRIPT_DIR}/Support/openvdb-9.1.0.patch
+  
   if [[ $BUILD_CLEAN = 1 ]]; then rm -rf build; fi
   mkdir -p build && cd build
 


### PR DESCRIPTION
* #2414 

https://github.com/AcademySoftwareFoundation/openvdb/pull/1977/files

I'm doing the patch instead of upgrading because upgrading requires forcing a new version of GCC which will cascade other dependency upgrades.  We may end up doing them, but we need to do this one step at a time and I need the CI/CD working in order to test things.