### PR TITLE
Python PCA API

### DIFF
--- a/Libs/Particles/ParticleShapeStatistics.cpp
+++ b/Libs/Particles/ParticleShapeStatistics.cpp
@@ -476,7 +476,10 @@ int ParticleShapeStatistics::read_point_files(const std::string& s) {
 }
 
 //---------------------------------------------------------------------------
-ParticleShapeStatistics::ParticleShapeStatistics(std::shared_ptr<Project> project) {
+ParticleShapeStatistics::ParticleShapeStatistics(std::shared_ptr<Project> project) { load_from_project(project); }
+
+//---------------------------------------------------------------------------
+void ParticleShapeStatistics::load_from_project(std::shared_ptr<Project> project) {
   std::vector<Eigen::VectorXd> points;
   std::vector<int> groups;
   for (auto& s : project->get_subjects()) {
@@ -564,6 +567,13 @@ int ParticleShapeStatistics::do_pca(ParticleSystemEvaluation ParticleSystemEvalu
   }
 
   return do_pca(particlePoints, domainsPerShape);
+}
+
+//---------------------------------------------------------------------------
+int ParticleShapeStatistics::do_pca(std::shared_ptr<Project> project) {
+  load_from_project(project);
+  compute_modes();
+  return 0;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Particles/ParticleShapeStatistics.cpp
+++ b/Libs/Particles/ParticleShapeStatistics.cpp
@@ -497,7 +497,7 @@ ParticleShapeStatistics::ParticleShapeStatistics(std::shared_ptr<Project> projec
 
 //---------------------------------------------------------------------------
 int ParticleShapeStatistics::do_pca(std::vector<std::vector<Point>> global_pts, int domainsPerShape) {
-  this->domains_per_shape_ = domainsPerShape;
+  domains_per_shape_ = domainsPerShape;
 
   // Assumes all the same size.
   num_samples_ = global_pts.size() / domains_per_shape_;
@@ -507,11 +507,6 @@ int ParticleShapeStatistics::do_pca(std::vector<std::vector<Point>> global_pts, 
   shapes_.resize(num_dimensions_, num_samples_);
   mean_.resize(num_dimensions_);
   mean_.fill(0);
-
-  std::cout << "VDimension = " << values_per_particle_ << "-------------\n";
-  std::cout << "m_numSamples = " << num_samples_ << "-------------\n";
-  std::cout << "m_domainsPerShape = " << domains_per_shape_ << "-------------\n";
-  std::cout << "global_pts.size() = " << global_pts.size() << "-------------\n";
 
   // Compile the "meta shapes"
   for (unsigned int i = 0; i < num_samples_; i++) {
@@ -636,6 +631,13 @@ int ParticleShapeStatistics::principal_component_projections() {
   }
 
   return 0;
+}
+
+//---------------------------------------------------------------------------
+Eigen::VectorXd ParticleShapeStatistics::project_new_sample(const Eigen::VectorXd& new_sample) {
+  // Subtract mean and project onto principal components
+  Eigen::VectorXd centered_sample = new_sample - mean_;
+  return eigenvectors_.transpose() * centered_sample;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Particles/ParticleShapeStatistics.h
+++ b/Libs/Particles/ParticleShapeStatistics.h
@@ -57,6 +57,9 @@ class ParticleShapeStatistics {
   //!  principal componenent axes for each of the samples.  ComputeModes must be called first.
   int principal_component_projections();
 
+  //! Projects a new sample into the PCA space defined by the original samples.
+  Eigen::VectorXd project_new_sample(const Eigen::VectorXd& new_sample);
+
   //! Returns the sample size
   int get_num_samples() const { return num_samples_; }
   int get_group1_num_samples() const { return num_samples_group1_; }

--- a/Libs/Particles/ParticleShapeStatistics.h
+++ b/Libs/Particles/ParticleShapeStatistics.h
@@ -19,12 +19,14 @@ class Project;
 class ParticleShapeStatistics {
  public:
   ParticleShapeStatistics(){};
-  ParticleShapeStatistics(std::shared_ptr<Project> project);
+  explicit ParticleShapeStatistics(std::shared_ptr<Project> project);
   ~ParticleShapeStatistics(){};
 
   int do_pca(std::vector<std::vector<Point>> global_pts, int domainsPerShape = 1);
 
   int do_pca(ParticleSystemEvaluation particleSystem, int domainsPerShape = 1);
+
+  int do_pca(std::shared_ptr<Project> project);
 
   //! Loads a set of point files and pre-computes some statistics.
   int import_points(std::vector<Eigen::VectorXd> points, std::vector<int> group_ids);
@@ -137,6 +139,8 @@ class ParticleShapeStatistics {
   bool get_particle_to_surface_mode() const { return particle_to_surface_mode_; }
   //! Set the meshes for each sample (used for some evaluation metrics)
   void set_meshes(const std::vector<Mesh>& meshes) { meshes_ = meshes; }
+
+  void load_from_project(std::shared_ptr<Project> project);
 
  private:
   unsigned int num_samples_group1_;

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1281,8 +1281,13 @@ PYBIND11_MODULE(shapeworks_py, m) {
 
       .def(py::init<>())
 
+      // int do_pca(ParticleSystemEvaluation particleSystem, int domainsPerShape = 1);
       .def("PCA", py::overload_cast<ParticleSystemEvaluation, int>(&ParticleShapeStatistics::do_pca),
            "calculates the eigen values and eigen vectors of the data", "particleSystem"_a, "domainsPerShape"_a = 1)
+
+      // int do_pca(std::shared_ptr<Project> project);
+      .def("PCA", py::overload_cast<std::shared_ptr<Project>>(&ParticleShapeStatistics::do_pca),
+           "calculates the eigen values and eigen vectors of the data from a project", "project"_a)
 
       .def("principalComponentProjections", &ParticleShapeStatistics::principal_component_projections,
            "projects the original data on the calculated principal components")

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -559,8 +559,7 @@ PYBIND11_MODULE(shapeworks_py, m) {
           [](Image& image, std::vector<double>& pt) -> decltype(auto) {
             return image.evaluate(Point({pt[0], pt[1], pt[2]}));
           },
-          "evaluate the image at any given point in space", "pt"_a)
-      ;
+          "evaluate the image at any given point in space", "pt"_a);
 
   // PhysicalRegion
   py::class_<PhysicalRegion>(m, "PhysicalRegion")
@@ -1309,9 +1308,10 @@ PYBIND11_MODULE(shapeworks_py, m) {
       .def("percentVarByMode", &ParticleShapeStatistics::get_percent_variance_by_mode,
            "return the variance accounted for by the principal components")
 
-      .def("projectNewSample", &ParticleShapeStatistics::project_new_sample,
-           "project a new sample into the PCA space", "newSample"_a)
-      ;
+      .def("projectNewSample", &ParticleShapeStatistics::project_new_sample, "project a new sample into the PCA space",
+           "newSample"_a)
+
+      .def("getMean", &ParticleShapeStatistics::get_mean, "returns the mean shape particles");
 
   define_python_analyze(m);
   define_python_groom(m);

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -1302,7 +1302,11 @@ PYBIND11_MODULE(shapeworks_py, m) {
        components are constructed")
 
       .def("percentVarByMode", &ParticleShapeStatistics::get_percent_variance_by_mode,
-           "return the variance accounted for by the principal components");
+           "return the variance accounted for by the principal components")
+
+      .def("projectNewSample", &ParticleShapeStatistics::project_new_sample,
+           "project a new sample into the PCA space", "newSample"_a)
+      ;
 
   define_python_analyze(m);
   define_python_groom(m);


### PR DESCRIPTION
* #2425

This PR adds additional functionality to support using ShapeWorks PCA from Python.

Example script:

```python
import shapeworks as sw
import glob
import os
import sys
import numpy as np


def read_data():
    # create ParticleSystem
    script_dir = os.path.dirname(os.path.abspath(__file__))
    particleFilesDir = script_dir + "/data/la_particles/"
    particleFilesList = glob.glob(particleFilesDir + "*world.particles")
    print(particleFilesList)
    ps = sw.ParticleSystem(particleFilesList)
    return ps


# now load data/la_particles/CARMA0046_groomed_world.particles using numpy
new_sample = np.loadtxt(os.path.dirname(os.path.abspath(__file__)) +
                        "/data/la_particles/CARMA0046_groomed_world.particles")
# flatten new_sample to 1D array
new_sample = new_sample.flatten()

# To use raw particle files
# ps = read_data()
# pca = sw.ParticleShapeStatistics()
# pca.PCA(ps)

# To use ShapeWorks Projects
project = sw.Project()
os.chdir("data")
project.load("la.xlsx")
pca = sw.ParticleShapeStatistics()
pca.PCA(project)

# print the mean shape particles
mean_shape = pca.getMean()
print("Mean shape: ", mean_shape)

eigenvalues = pca.eigenValues()
print("Eigenvalues: ", eigenvalues)

eigenvectors = pca.eigenVectors()
print("Eigenvectors: ", eigenvectors)

scores = pca.projectNewSample(new_sample)
print("Scores: ", scores)
```