### PR TITLE
Add feature to export clipped meshes (constraints clipped) for #2436

### DIFF
--- a/Libs/Analyze/Shape.cpp
+++ b/Libs/Analyze/Shape.cpp
@@ -916,6 +916,16 @@ Constraints& Shape::get_constraints(int domain_id) {
 }
 
 //---------------------------------------------------------------------------
+bool Shape::has_constraints() {
+  for (int i = 0; i < constraints_.size(); i++) {
+    if (constraints_[i].hasConstraints()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+//---------------------------------------------------------------------------
 bool Shape::has_planes() {
   for (int i = 0; i < constraints_.size(); i++) {
     for (auto& plane : constraints_[i].getPlaneConstraints()) {

--- a/Libs/Analyze/Shape.h
+++ b/Libs/Analyze/Shape.h
@@ -185,6 +185,8 @@ class Shape {
 
   Constraints& get_constraints(int domain_id);
 
+  bool has_constraints();
+
   bool has_planes();
 
   std::vector<std::shared_ptr<Surface>> get_groomed_mesh_wrappers();

--- a/Studio/Data/ExportUtils.cpp
+++ b/Studio/Data/ExportUtils.cpp
@@ -7,12 +7,14 @@
 #include <Shape.h>
 #include <StringUtils.h>
 #include <Utils/StudioUtils.h>
+#include <Visualization/Visualizer.h>
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 
 #include <QDir>
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QObject>
 #include <QProgressDialog>
 
 namespace shapeworks {
@@ -223,6 +225,11 @@ bool ExportUtils::write_pca_scores(ShapeWorksStudioApp* app, ParticleShapeStatis
 
   output.close();
   return true;
+}
+
+//----------------------------------------------------------------------------
+QString ExportUtils::get_mesh_file_filter() {
+  return QObject::tr("VTK files (*.vtk);;PLY files (*.ply);;VTP files (*.vtp);;OBJ files (*.obj);;STL files (*.stl)");
 }
 
 }  // namespace shapeworks

--- a/Studio/Data/ExportUtils.h
+++ b/Studio/Data/ExportUtils.h
@@ -23,6 +23,9 @@ class ExportUtils {
   static bool write_particle_scalars(ShapeWorksStudioApp* app, std::shared_ptr<Shape> shape, QString filename);
 
   static bool write_pca_scores(ShapeWorksStudioApp* app, ParticleShapeStatistics* stats, QString filename);
+
+  static QString get_mesh_file_filter();
+
 };
 
 }  // namespace shapeworks

--- a/Studio/Interface/ShapeWorksStudioApp.h
+++ b/Studio/Interface/ShapeWorksStudioApp.h
@@ -27,7 +27,7 @@
 class Ui_ShapeWorksStudioApp;
 
 namespace monailabel {
-  class MonaiLabelTool;
+class MonaiLabelTool;
 }
 
 namespace shapeworks {
@@ -89,7 +89,7 @@ class ShapeWorksStudioApp : public QMainWindow {
   void on_actionExport_Eigenvectors_triggered();
   void on_actionExport_PCA_Mode_Points_triggered();
   void on_action_preferences_triggered();
-  void action_export_current_mesh_triggered(int index = 0);
+  void action_export_current_mesh_triggered(int index = 0, bool clip_constraints = false);
   void on_action_export_current_particles_triggered();
   void on_action_export_mesh_scalars_triggered();
   void on_action_export_pca_scores_triggered();
@@ -162,6 +162,8 @@ class ShapeWorksStudioApp : public QMainWindow {
   Preferences& prefs() { return preferences_; }
   QSharedPointer<Session> session() { return session_; }
 
+  QSharedPointer<Visualizer> get_visualizer() { return visualizer_; }
+
  protected:
   void dragEnterEvent(QDragEnterEvent* event) override;
   void dragLeaveEvent(QDragLeaveEvent* event) override;
@@ -179,8 +181,6 @@ class ShapeWorksStudioApp : public QMainWindow {
   bool should_reconstruct_view_show();
 
   static bool write_particle_file(std::string filename, Eigen::VectorXd particles);
-
-  static QString get_mesh_file_filter();
 
   static const std::string SETTING_ZOOM_C;
 

--- a/Studio/Interface/ShapeWorksStudioApp.ui
+++ b/Studio/Interface/ShapeWorksStudioApp.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1243</width>
+    <width>1310</width>
     <height>705</height>
    </rect>
   </property>
@@ -714,7 +714,7 @@ QToolBar QToolButton::checked {
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1243</width>
+     <width>1310</width>
      <height>33</height>
     </rect>
    </property>
@@ -727,6 +727,7 @@ QToolBar QToolButton::checked {
       <string>Export...</string>
      </property>
      <addaction name="action_export_current_mesh"/>
+     <addaction name="action_export_current_mesh_clipped"/>
      <addaction name="action_export_current_particles"/>
      <addaction name="action_export_particle_scalars"/>
      <addaction name="action_export_mesh_scalars"/>
@@ -1171,16 +1172,16 @@ QToolBar QToolButton::checked {
    </property>
   </action>
   <action name="action_monai_mode">
-    <property name="checkable">
-     <bool>true</bool>
-    </property>
-    <property name="icon">
-     <iconset resource="../Resources/ShapeWorksStudio.qrc">
-      <normaloff>:/Studio/Images/MONAI-Label.png</normaloff>:/Studio/Images/MONAI-Label.png</iconset>
-    </property>
-    <property name="text">
-     <string>MONAI</string>
-    </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../Resources/ShapeWorksStudio.qrc">
+     <normaloff>:/Studio/Images/MONAI-Label.png</normaloff>:/Studio/Images/MONAI-Label.png</iconset>
+   </property>
+   <property name="text">
+    <string>MONAI</string>
+   </property>
   </action>
   <action name="action_export_pca_montage">
    <property name="text">
@@ -1218,6 +1219,11 @@ QToolBar QToolButton::checked {
    </property>
    <property name="menuRole">
     <enum>QAction::ApplicationSpecificRole</enum>
+   </property>
+  </action>
+  <action name="action_export_current_mesh_clipped">
+   <property name="text">
+    <string>Export Current Mesh Clipped...</string>
    </property>
   </action>
  </widget>

--- a/Studio/Visualization/Lightbox.h
+++ b/Studio/Visualization/Lightbox.h
@@ -94,6 +94,8 @@ class Lightbox : public QObject {
 
   vtkRenderWindow* get_render_window();
 
+  int get_start_shape();
+
  public Q_SLOTS:
   void handle_timer_callback();
 
@@ -108,8 +110,6 @@ class Lightbox : public QObject {
   void display_shapes();
 
   void insert_shape_into_viewer(std::shared_ptr<Shape> shape, int position);
-
-  int get_start_shape();
 
   vtkSmartPointer<vtkRenderer> renderer_;
 

--- a/Studio/Visualization/Visualizer.h
+++ b/Studio/Visualization/Visualizer.h
@@ -80,8 +80,8 @@ class Visualizer : public QObject {
   vtkSmartPointer<vtkPolyData> get_current_particle_poly_data();
 
   void handle_new_mesh();
-  vtkSmartPointer<vtkPolyData> get_current_mesh(int index);
-  std::vector<vtkSmartPointer<vtkPolyData>> get_current_meshes_transformed(int index);
+  vtkSmartPointer<vtkPolyData> get_current_mesh(int index, bool clip_constraints);
+  std::vector<vtkSmartPointer<vtkPolyData>> get_current_meshes_transformed(int index, bool clip_constraints = false);
 
   //! Get the currently selected feature map
   const std::string& get_feature_map() const;


### PR DESCRIPTION
* #2436 


<img width="1179" height="668" alt="image" src="https://github.com/user-attachments/assets/73ecdefd-ff76-41b3-a209-3df94ab63fa6" />

Exported

<img width="680" height="576" alt="image" src="https://github.com/user-attachments/assets/f32d8945-298c-4798-b282-1317a2ff5ac0" />
