### PR TITLE
Fix #2157 - Dot vs Comma for decimal, european number format region settings

### DIFF
--- a/Studio/main.cpp
+++ b/Studio/main.cpp
@@ -105,6 +105,7 @@ int main(int argc, char** argv) {
     SW_LOG("ShapeWorks Studio " SHAPEWORKS_VERSION " initializing...");
 
     OverrideQApplication app(argc, argv);
+    QLocale::setDefault(QLocale(QLocale::English, QLocale::UnitedStates));
 
     auto studio_app = QSharedPointer<ShapeWorksStudioApp>::create();
     QResource::registerResource(RSCS_FILE);


### PR DESCRIPTION
* #2157 

We fix this by forcing the locale on startup