### PR TITLE
Resolve #2487 - Auto subset size in grooming should pick a smart auto

### DIFF
--- a/Libs/Groom/Groom.cpp
+++ b/Libs/Groom/Groom.cpp
@@ -560,7 +560,7 @@ bool Groom::run_alignment() {
   bool any_alignment = false;
 
   int reference_index = -1;
-  int subset_size = -1;
+  int subset_size = base_params.get_alignment_subset_size();
 
   // per-domain alignment
   for (size_t domain = 0; domain < num_domains; domain++) {

--- a/Libs/Mesh/MeshUtils.cpp
+++ b/Libs/Mesh/MeshUtils.cpp
@@ -182,6 +182,10 @@ PhysicalRegion MeshUtils::boundingBox(const std::vector<Mesh>& meshes, bool cent
 }
 
 int MeshUtils::findReferenceMesh(std::vector<Mesh>& meshes, int random_subset_size) {
+  // auto (-1) defaults to a subset of 30 to avoid O(n^2) pairwise ICP on large datasets
+  if (random_subset_size < 0) {
+    random_subset_size = 30;
+  }
   bool use_random_subset = random_subset_size > 0 && random_subset_size < meshes.size();
   int num_meshes = use_random_subset ? random_subset_size : meshes.size();
 


### PR DESCRIPTION
* #2487 

Auto  now defaults to a subset of 30 to avoid O(n^2) pairwise ICP on large datasets