### PR TITLE
Fix fixed domain Procrustes to preserve existing transforms

### DIFF
--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -277,6 +277,11 @@ int Optimize::SetParameters() {
     this->ReadPrefixTransformFile(m_prefix_transform_file);
   }
 
+  // Apply stored Procrustes transforms (e.g. for fixed shapes loaded from project)
+  for (auto& [domain_index, transform] : m_procrustes_transforms) {
+    m_sampler->GetParticleSystem()->SetTransform(domain_index, transform);
+  }
+
   return true;
 }
 
@@ -1809,6 +1814,11 @@ void Optimize::SetFixedDomains(std::vector<int> flags) {
     this->m_fixed_domains_present = true;
   }
   this->m_domain_flags = flags;
+}
+
+//---------------------------------------------------------------------------
+void Optimize::SetProcustesTransforms(std::map<int, vnl_matrix_fixed<double, 4, 4>> transforms) {
+  m_procrustes_transforms = std::move(transforms);
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -5,6 +5,7 @@
 #endif
 
 // std
+#include <map>
 #include <string>
 #include <vector>
 
@@ -236,6 +237,9 @@ class Optimize {
   //! Set Domain Flags (TODO: details)
   void SetFixedDomains(std::vector<int> flags);
 
+  //! Set Procrustes transforms to load for specific domains (applied after initialization)
+  void SetProcustesTransforms(std::map<int, vnl_matrix_fixed<double, 4, 4>> transforms);
+
   //! Shared boundary settings
   void SetSharedBoundaryEnabled(bool enabled);
   void SetSharedBoundaryWeight(double weight);
@@ -415,6 +419,7 @@ class Optimize {
   double m_cotan_sigma_factor = 5.0;
   std::vector<int> m_particle_flags;
   std::vector<int> m_domain_flags;
+  std::map<int, vnl_matrix_fixed<double, 4, 4>> m_procrustes_transforms;  // domain index -> transform
   double m_narrow_band = 0.0;
   bool m_narrow_band_set = false;
   bool m_fixed_domains_present = false;

--- a/Libs/Optimize/ProcrustesRegistration.h
+++ b/Libs/Optimize/ProcrustesRegistration.h
@@ -47,8 +47,10 @@ class ProcrustesRegistration {
   void RunFixedDomainRegistration(int domainStart, int numShapes, int numPoints,
                                   const std::vector<bool>& is_fixed);
 
-  //! Extract prefix-transformed particle positions for a single domain
-  Procrustes3D::ShapeType ExtractShape(int domain_index, int num_points);
+  //! Extract particle positions for a single domain.
+  //! If fully_transformed is true, applies both prefix and Procrustes transforms (world space).
+  //! If false, applies only the prefix transform (for computing new Procrustes transforms).
+  Procrustes3D::ShapeType ExtractShape(int domain_index, int num_points, bool fully_transformed = false);
 
   int m_DomainsPerShape = 1;
   bool m_Scaling = true;


### PR DESCRIPTION
Procrustes was incorrectly modifying fixed shapes' transforms in two ways:
  1. RunFixedDomainRegistration ran GPA on fixed shapes and overwrote their transforms. Now it computes the mean from their already-transformed (world space) positions without modifying them.
  2. Procrustes transforms stored in the project file were never loaded into the ParticleSystem (AddDomain always sets identity). Now they are loaded via SetProcustesTransforms and applied after ParticleSystem initialization.

Also adds fixed_domain_independence test verifying that multiple new shapes produce identical results whether optimized together or individually.