### PR TITLE
Parallelize mesh loading with TBB and add progress reporting

### DIFF
--- a/Libs/Optimize/Domain/MeshDomain.cpp
+++ b/Libs/Optimize/Domain/MeshDomain.cpp
@@ -98,6 +98,16 @@ void MeshDomain::SetMesh(std::shared_ptr<Surface> mesh, double geodesic_remesh_p
 }
 
 //-------------------------------------------------------------------
+void MeshDomain::SetMesh(std::shared_ptr<Surface> surface, std::shared_ptr<Surface> geodesics_surface,
+                          std::shared_ptr<Mesh> sw_mesh, double surface_area) {
+  m_FixedDomain = false;
+  surface_ = surface;
+  geodesics_mesh_ = geodesics_surface;
+  sw_mesh_ = sw_mesh;
+  surface_area_ = surface_area;
+}
+
+//-------------------------------------------------------------------
 void MeshDomain::InvalidateParticlePosition(int idx) const { this->surface_->invalidate_particle(idx); }
 
 //-------------------------------------------------------------------

--- a/Libs/Optimize/Domain/MeshDomain.h
+++ b/Libs/Optimize/Domain/MeshDomain.h
@@ -73,6 +73,8 @@ class MeshDomain : public ParticleDomain {
   }
 
   void SetMesh(std::shared_ptr<Surface> mesh_, double geodesic_remesh_percent);
+  void SetMesh(std::shared_ptr<Surface> surface, std::shared_ptr<Surface> geodesics_surface,
+               std::shared_ptr<Mesh> sw_mesh, double surface_area);
 
   std::shared_ptr<Mesh> GetSWMesh() const { return sw_mesh_; }
 

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1758,6 +1758,18 @@ void Optimize::AddMesh(vtkSmartPointer<vtkPolyData> poly_data) {
 }
 
 //---------------------------------------------------------------------------
+void Optimize::AddMesh(std::shared_ptr<Surface> surface, std::shared_ptr<Surface> geodesics_surface,
+                       std::shared_ptr<Mesh> sw_mesh, double surface_area) {
+  if (!surface) {
+    m_sampler->AddMesh(nullptr);
+  } else {
+    m_sampler->AddMesh(surface, geodesics_surface, sw_mesh, surface_area);
+  }
+  this->m_num_shapes++;
+  this->m_spacing = 0.5;
+}
+
+//---------------------------------------------------------------------------
 void Optimize::AddContour(vtkSmartPointer<vtkPolyData> poly_data) {
   m_sampler->AddContour(poly_data);
   m_num_shapes++;

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -214,6 +214,8 @@ class Optimize {
   //! Set the shape input images
   void AddImage(ImageType::Pointer image, std::string name = "");
   void AddMesh(vtkSmartPointer<vtkPolyData> poly_data);
+  void AddMesh(std::shared_ptr<Surface> surface, std::shared_ptr<Surface> geodesics_surface,
+               std::shared_ptr<Mesh> sw_mesh, double surface_area);
   void AddContour(vtkSmartPointer<vtkPolyData> poly_data);
 
   //! Set the shape filenames (TODO: details)

--- a/Libs/Optimize/Sampler.cpp
+++ b/Libs/Optimize/Sampler.cpp
@@ -284,6 +284,18 @@ void Sampler::AddMesh(std::shared_ptr<shapeworks::Surface> mesh, double geodesic
   m_DomainList.push_back(domain);
 }
 
+void Sampler::AddMesh(std::shared_ptr<Surface> surface, std::shared_ptr<Surface> geodesics_surface,
+                      std::shared_ptr<Mesh> sw_mesh, double surface_area) {
+  auto domain = std::make_shared<MeshDomain>();
+
+  if (surface) {
+    this->m_Spacing = 1;
+    domain->SetMesh(surface, geodesics_surface, sw_mesh, surface_area);
+    this->m_meshes.push_back(surface->get_polydata());
+  }
+  m_DomainList.push_back(domain);
+}
+
 void Sampler::AddContour(vtkSmartPointer<vtkPolyData> poly_data) {
   auto domain = std::make_shared<ContourDomain>();
 

--- a/Libs/Optimize/Sampler.h
+++ b/Libs/Optimize/Sampler.h
@@ -99,6 +99,8 @@ class Sampler {
   }
 
   void AddMesh(std::shared_ptr<shapeworks::Surface> mesh, double geodesic_remesh_percent = 100);
+  void AddMesh(std::shared_ptr<Surface> surface, std::shared_ptr<Surface> geodesics_surface,
+               std::shared_ptr<Mesh> sw_mesh, double surface_area);
 
   void AddContour(vtkSmartPointer<vtkPolyData> poly_data);
 


### PR DESCRIPTION
* #2503 

Surface construction and geodesic remeshing during optimize setup are now done in parallel using tbb::parallel_for, with SW_PROGRESS updates showing "Loading meshes" or "Loading and remeshing meshes" with a count and progress bar. Pre-built Surface overloads added to MeshDomain, Sampler, and Optimize to support the three-phase approach (collect, parallel compute, sequential register).