### PR TITLE
Improve Optimize panel layout with dividers, aligned inputs, and reorganized parameter groups

### DIFF
--- a/Studio/Optimize/OptimizeTool.cpp
+++ b/Studio/Optimize/OptimizeTool.cpp
@@ -66,12 +66,11 @@ OptimizeTool::OptimizeTool(Preferences& prefs, Telemetry& telemetry) : preferenc
   ui_->shared_boundary_weight->setToolTip("Weight of shared boundary optimization");
   ui_->sampling_scale->setToolTip("Enable sampling gradient scaling");
   ui_->sampling_auto_scale->setToolTip("Automatically scale sampling gradient based on surface area");
-  ui_->sampling_scale_value->setToolTip("Manual scale value for sampling gradient (when auto-scale is disabled)");
+  ui_->sampling_scale_value->setToolTip("Scale multiplier for sampling gradient (applied on top of auto-scale when enabled)");
   ui_->use_disentangled_ssm->setToolTip("Use disentangled Optimization technique to build spatiotemporal SSM.");
 
   // hidden for 6.5 release
-  ui_->disentangled_label->hide();
-  ui_->disentangled_widget->hide();
+  ui_->use_disentangled_ssm->hide();
 
   QIntValidator* above_zero = new QIntValidator(1, std::numeric_limits<int>::max(), this);
   QIntValidator* zero_and_up = new QIntValidator(0, std::numeric_limits<int>::max(), this);
@@ -270,18 +269,13 @@ void OptimizeTool::load_params() {
   setup_domain_boxes();
   auto params = OptimizeParameters(session_->get_project());
 
-  ui_->number_of_particles->setText(QString::number(params.get_number_of_particles()[0]));
-
-  auto domain_names = session_->get_project()->get_domain_names();
-  for (int i = 0; i < domain_names.size(); i++) {
-    if (i < particle_boxes_.size()) {
-      int particles = 128;
-      if (i < params.get_number_of_particles().size()) {
-        particles = params.get_number_of_particles()[i];
-      }
-
-      particle_boxes_[i]->setText(QString::number(particles));
+  auto num_particles = params.get_number_of_particles();
+  for (int i = 0; i < particle_boxes_.size(); i++) {
+    int particles = 128;
+    if (i < num_particles.size()) {
+      particles = num_particles[i];
     }
+    particle_boxes_[i]->setText(QString::number(particles));
   }
 
   ui_->initial_relative_weighting->setText(QString::number(params.get_initial_relative_weighting()));
@@ -322,16 +316,11 @@ void OptimizeTool::store_params() {
   auto params = OptimizeParameters(session_->get_project());
 
   std::vector<int> num_particles;
-  num_particles.push_back(ui_->number_of_particles->text().toInt());
-
-  auto domain_names = session_->get_project()->get_domain_names();
-  if (domain_names.size() > 1) {
-    num_particles.clear();
-    for (int i = 0; i < domain_names.size(); i++) {
-      if (i < particle_boxes_.size()) {
-        num_particles.push_back(particle_boxes_[i]->text().toInt());
-      }
-    }
+  for (int i = 0; i < particle_boxes_.size(); i++) {
+    num_particles.push_back(particle_boxes_[i]->text().toInt());
+  }
+  if (num_particles.empty()) {
+    num_particles.push_back(ui_->number_of_particles->text().toInt());
   }
 
   params.set_number_of_particles(num_particles);
@@ -405,9 +394,8 @@ void OptimizeTool::update_ui_elements() {
 
   bool shared_boundary_available = session_->get_project()->get_domain_names().size() > 1;
   ui_->shared_boundary->setVisible(shared_boundary_available);
-  ui_->shared_boundary_label->setVisible(shared_boundary_available);
-  ui_->shared_boundary_weight->setVisible(shared_boundary_available);
   ui_->shared_boundary_weight_label->setVisible(shared_boundary_available);
+  ui_->shared_boundary_weight->setVisible(shared_boundary_available);
 
   ui_->sampling_auto_scale->setEnabled(ui_->sampling_scale->isChecked());
   ui_->sampling_scale_value->setEnabled(ui_->sampling_scale->isChecked());
@@ -465,35 +453,49 @@ void OptimizeTool::update_run_button() {
 
 //---------------------------------------------------------------------------
 void OptimizeTool::setup_domain_boxes() {
-  qDeleteAll(ui_->domain_widget->findChildren<QWidget*>(QString(), Qt::FindDirectChildrenOnly));
+  // Clean up any previously added domain widgets from the parent grid
+  for (auto* w : domain_grid_widgets_) {
+    w->setParent(nullptr);
+    delete w;
+  }
+  domain_grid_widgets_.clear();
   particle_boxes_.clear();
 
   QLineEdit* last_box = ui_->number_of_particles;
 
+  // Hide the stacked widget and add inputs directly to the parent grid
+  // so they share the same columns as the parameter rows below
+  ui_->particle_stack->setVisible(false);
+  QGridLayout* grid = qobject_cast<QGridLayout*>(ui_->group_box->layout());
+  QIntValidator* above_zero = new QIntValidator(1, std::numeric_limits<int>::max(), this);
+
   if (session_->get_project()->get_number_of_domains_per_subject() < 2) {
-    ui_->particle_stack->setCurrentIndex(0);
-    ui_->domain_widget->setMaximumSize(1, 1);
+    QLineEdit* box = new QLineEdit(this);
+    last_box = box;
+    box->setAlignment(Qt::AlignHCenter);
+    box->setValidator(above_zero);
+    box->setText(ui_->number_of_particles->text());
+    connect(box, &QLineEdit::textChanged, this, &OptimizeTool::update_run_button);
+    particle_boxes_.push_back(box);
+    grid->addWidget(box, 0, 2);
+    domain_grid_widgets_.push_back(box);
   } else {
-    ui_->domain_widget->setMaximumSize(9999, 9999);
     auto domain_names = session_->get_project()->get_domain_names();
-    QGridLayout* layout = new QGridLayout;
-    QIntValidator* above_zero = new QIntValidator(1, std::numeric_limits<int>::max(), this);
     for (int i = 0; i < domain_names.size(); i++) {
       auto label = new QLabel(QString::fromStdString(domain_names[i]), this);
-      layout->addWidget(label, i, 0);
+      label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+      grid->addWidget(label, i, 1);
+      domain_grid_widgets_.push_back(label);
+
       QLineEdit* box = new QLineEdit(this);
       last_box = box;
       box->setAlignment(Qt::AlignHCenter);
       box->setValidator(above_zero);
       connect(box, &QLineEdit::textChanged, this, &OptimizeTool::update_run_button);
-
       particle_boxes_.push_back(box);
-      layout->addWidget(box, i, 1);
+      grid->addWidget(box, i, 2);
+      domain_grid_widgets_.push_back(box);
     }
-
-    delete ui_->domain_widget->layout();
-    ui_->domain_widget->setLayout(layout);
-    ui_->particle_stack->setCurrentIndex(1);
   }
 
   QWidget::setTabOrder(last_box, ui_->initial_relative_weighting);
@@ -502,22 +504,25 @@ void OptimizeTool::setup_domain_boxes() {
   QWidget::setTabOrder(ui_->starting_regularization, ui_->ending_regularization);
   QWidget::setTabOrder(ui_->ending_regularization, ui_->iterations_per_split);
   QWidget::setTabOrder(ui_->iterations_per_split, ui_->optimization_iterations);
-  QWidget::setTabOrder(ui_->optimization_iterations, ui_->use_geodesic_distance);
+  QWidget::setTabOrder(ui_->optimization_iterations, ui_->narrow_band);
+  QWidget::setTabOrder(ui_->narrow_band, ui_->use_geodesic_distance);
   QWidget::setTabOrder(ui_->use_geodesic_distance, ui_->geodesic_remesh_percent);
   QWidget::setTabOrder(ui_->geodesic_remesh_percent, ui_->use_normals);
   QWidget::setTabOrder(ui_->use_normals, ui_->normals_strength);
   QWidget::setTabOrder(ui_->normals_strength, ui_->use_geodesics_from_landmarks);
   QWidget::setTabOrder(ui_->use_geodesics_from_landmarks, ui_->geodesics_to_landmarks_weight);
-  QWidget::setTabOrder(ui_->geodesics_to_landmarks_weight, ui_->procrustes);
-  QWidget::setTabOrder(ui_->procrustes, ui_->procrustes_scaling);
-  QWidget::setTabOrder(ui_->procrustes_scaling, ui_->procrustes_rotation_translation);
-  QWidget::setTabOrder(ui_->procrustes_rotation_translation, ui_->procrustes_interval);
-  QWidget::setTabOrder(ui_->procrustes_interval, ui_->multiscale);
+  QWidget::setTabOrder(ui_->geodesics_to_landmarks_weight, ui_->multiscale);
   QWidget::setTabOrder(ui_->multiscale, ui_->multiscale_particles);
-  QWidget::setTabOrder(ui_->multiscale_particles, ui_->use_landmarks);
-  QWidget::setTabOrder(ui_->use_landmarks, ui_->narrow_band);
-  QWidget::setTabOrder(ui_->narrow_band, ui_->run_optimize_button);
+  QWidget::setTabOrder(ui_->multiscale_particles, ui_->shared_boundary);
   QWidget::setTabOrder(ui_->shared_boundary, ui_->shared_boundary_weight);
+  QWidget::setTabOrder(ui_->shared_boundary_weight, ui_->use_landmarks);
+  QWidget::setTabOrder(ui_->use_landmarks, ui_->procrustes);
+  QWidget::setTabOrder(ui_->procrustes, ui_->procrustes_interval);
+  QWidget::setTabOrder(ui_->procrustes_interval, ui_->procrustes_scaling);
+  QWidget::setTabOrder(ui_->procrustes_scaling, ui_->procrustes_rotation_translation);
+  QWidget::setTabOrder(ui_->procrustes_rotation_translation, ui_->sampling_scale);
+  QWidget::setTabOrder(ui_->sampling_scale, ui_->sampling_scale_value);
+  QWidget::setTabOrder(ui_->sampling_scale_value, ui_->sampling_auto_scale);
   QWidget::setTabOrder(ui_->shared_boundary_weight, ui_->use_disentangled_ssm);
   QWidget::setTabOrder(ui_->use_disentangled_ssm, ui_->run_optimize_button);
   QWidget::setTabOrder(ui_->run_optimize_button, ui_->restoreDefaults);

--- a/Studio/Optimize/OptimizeTool.h
+++ b/Studio/Optimize/OptimizeTool.h
@@ -79,6 +79,7 @@ private:
   void handle_load_progress(int count);
 
   std::vector<QLineEdit*> particle_boxes_;
+  std::vector<QWidget*> domain_grid_widgets_;
 
   Preferences& preferences_;
   Telemetry& telemetry_;

--- a/Studio/Optimize/OptimizeTool.ui
+++ b/Studio/Optimize/OptimizeTool.ui
@@ -234,434 +234,7 @@ QWidget#optimize_panel {
                <property name="bottomMargin">
                 <number>0</number>
                </property>
-               <item row="19" column="0">
-                <widget class="QLabel" name="label_15">
-                 <property name="text">
-                  <string>Use Initial Landmarks</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="25" column="2">
-                <widget class="QWidget" name="widget_9" native="true">
-                 <layout class="QGridLayout" name="gridLayout_14">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="shared_boundary">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_19">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_20">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="21" column="2">
-                <widget class="QWidget" name="sampling_scale_widget" native="true">
-                 <layout class="QGridLayout" name="gridLayout_sampling_scale">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="sampling_scale">
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_sampling_scale_1">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_sampling_scale_2">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="22" column="2">
-                <widget class="QWidget" name="sampling_auto_scale_widget" native="true">
-                 <layout class="QGridLayout" name="gridLayout_sampling_auto_scale">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="sampling_auto_scale">
-                    <property name="text">
-                     <string/>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_sampling_auto_scale_1">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_sampling_auto_scale_2">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="5" column="2">
-                <widget class="QLineEdit" name="iterations_per_split">
-                 <property name="text">
-                  <string>1000</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="0">
-                <widget class="QLabel" name="label_19">
-                 <property name="text">
-                  <string>Optimization Iterations</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="0">
-                <widget class="QLabel" name="label_20">
-                 <property name="text">
-                  <string>Normals</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="20" column="2">
-                <widget class="QLineEdit" name="narrow_band">
-                 <property name="text">
-                  <string>000</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="13" column="0">
-                <widget class="QLabel" name="label_22">
-                 <property name="text">
-                  <string>Procrustes</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="26" column="0">
-                <widget class="QLabel" name="shared_boundary_weight_label">
-                 <property name="text">
-                  <string>Shared Boundary Weight</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="3">
-                <spacer name="horizontalSpacer_9">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="4" column="0">
-                <widget class="QLabel" name="label_9">
-                 <property name="text">
-                  <string>Ending Regularization</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="2">
-                <widget class="QLineEdit" name="normals_strength">
-                 <property name="text">
-                  <string>10</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="2">
-                <widget class="QWidget" name="widget_3" native="true">
-                 <layout class="QGridLayout" name="gridLayout_4">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="procrustes_scaling">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_5">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_6">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="4" column="2">
-                <widget class="QLineEdit" name="ending_regularization">
-                 <property name="text">
-                  <string>1.0</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="16" column="2">
-                <widget class="QLineEdit" name="procrustes_interval">
-                 <property name="text">
-                  <string>10</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="16" column="0">
-                <widget class="QLabel" name="label_11">
-                 <property name="text">
-                  <string>Procrustes Interval</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QLabel" name="label_4">
-                 <property name="text">
-                  <string>Relative Weighting</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="12" column="0">
-                <widget class="QLabel" name="label_26">
-                 <property name="text">
-                  <string>Landmark Distance Weight</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="22" column="0">
-                <widget class="QLabel" name="sampling_auto_scale_label">
-                 <property name="text">
-                  <string>Sampling Auto Scale</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="0">
-                <widget class="QLabel" name="label_25">
-                 <property name="text">
-                  <string>Geodesic Distance from Landmarks</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="10" column="0">
-                <widget class="QLabel" name="label_21">
-                 <property name="text">
-                  <string>Normals Strength</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="2">
-                <widget class="QWidget" name="widget_5" native="true">
-                 <layout class="QGridLayout" name="gridLayout_8">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="use_geodesic_distance">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_11">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_12">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="1" column="2">
-                <widget class="QLineEdit" name="initial_relative_weighting">
-                 <property name="text">
-                  <string>0.05</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="26" column="2">
-                <widget class="QLineEdit" name="shared_boundary_weight">
-                 <property name="text">
-                  <string>0.1</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
+               <!-- Row 0: Number of Particles -->
                <item row="0" column="0">
                 <widget class="QLabel" name="label_3">
                  <property name="text">
@@ -669,514 +242,7 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-               <item row="1" column="1">
-                <spacer name="horizontalSpacer_10">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="13" column="2">
-                <widget class="QWidget" name="widget_2" native="true">
-                 <layout class="QGridLayout" name="gridLayout_3">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="procrustes">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_3">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_4">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="17" column="2">
-                <widget class="QWidget" name="widget_4" native="true">
-                 <layout class="QGridLayout" name="gridLayout_5">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="multiscale">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_7">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_8">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="12" column="2">
-                <widget class="QLineEdit" name="geodesics_to_landmarks_weight">
-                 <property name="text">
-                  <string>1</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="2">
-                <widget class="QLineEdit" name="geodesic_remesh_percent">
-                 <property name="text">
-                  <string>100</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="11" column="2">
-                <widget class="QWidget" name="widget_8" native="true">
-                 <layout class="QGridLayout" name="gridLayout_13">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="use_geodesics_from_landmarks">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_17">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_18">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="18" column="0">
-                <widget class="QLabel" name="label_14">
-                 <property name="text">
-                  <string>Multiscale Start</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="0">
-                <widget class="QLabel" name="label_10">
-                 <property name="text">
-                  <string>Starting Regularization</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="9" column="2">
-                <widget class="QWidget" name="widget" native="true">
-                 <layout class="QGridLayout" name="gridLayout_2">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="use_normals">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_2">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="2" column="2">
-                <widget class="QLineEdit" name="relative_weighting">
-                 <property name="text">
-                  <string>1.0</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="15" column="0">
-                <widget class="QLabel" name="label_16">
-                 <property name="text">
-                  <string>Procrustes Rotation/Translation</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="5" column="0">
-                <widget class="QLabel" name="label_8">
-                 <property name="text">
-                  <string>Iterations per Split</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="7" column="0">
-                <widget class="QLabel" name="label_23">
-                 <property name="text">
-                  <string>Geodesic Distance</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="18" column="2">
-                <widget class="QLineEdit" name="multiscale_particles">
-                 <property name="text">
-                  <string>32</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="15" column="2">
-                <widget class="QWidget" name="widget_7" native="true">
-                 <layout class="QGridLayout" name="gridLayout_10">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="procrustes_rotation_translation">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_15">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_16">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="30" column="0">
-                <widget class="QLabel" name="disentangled_label">
-                 <property name="text">
-                  <string>Disentangled Spatiotemporal SSM</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="14" column="0">
-                <widget class="QLabel" name="label_12">
-                 <property name="text">
-                  <string>Procrustes Scaling</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="3" column="2">
-                <widget class="QLineEdit" name="starting_regularization">
-                 <property name="text">
-                  <string>10</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="label_5">
-                 <property name="text">
-                  <string>Initial Relative Weighting</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="6" column="2">
-                <widget class="QLineEdit" name="optimization_iterations">
-                 <property name="text">
-                  <string>1000</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item row="30" column="2">
-                <widget class="QWidget" name="disentangled_widget" native="true">
-                 <layout class="QGridLayout" name="gridLayout_18">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="use_disentangled_ssm">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_13">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_14">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="25" column="0">
-                <widget class="QLabel" name="shared_boundary_label">
-                 <property name="text">
-                  <string>Shared Boundary</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="20" column="0">
-                <widget class="QLabel" name="label_24">
-                 <property name="text">
-                  <string>Narrow Band</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="8" column="0">
-                <widget class="QLabel" name="label_27">
-                 <property name="text">
-                  <string>Geodesic Remesh Percent</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="19" column="2">
-                <widget class="QWidget" name="widget_6" native="true">
-                 <layout class="QGridLayout" name="gridLayout_9">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="1">
-                   <widget class="QCheckBox" name="use_landmarks">
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <spacer name="horizontalSpacer_13a">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_14a">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-               <item row="0" column="2">
+               <item row="0" column="1" colspan="3">
                 <widget class="QStackedWidget" name="particle_stack">
                  <property name="currentIndex">
                   <number>0</number>
@@ -1228,34 +294,469 @@ QWidget#optimize_panel {
                  </widget>
                 </widget>
                </item>
-               <item row="17" column="0">
-                <widget class="QLabel" name="label_13">
+               <!-- Row 10: Initial Relative Weighting -->
+               <item row="10" column="0">
+                <widget class="QLabel" name="label_5">
+                 <property name="text">
+                  <string>Initial Relative Weighting</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="10" column="1">
+                <spacer name="horizontalSpacer_10">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item row="10" column="2">
+                <widget class="QLineEdit" name="initial_relative_weighting">
+                 <property name="text">
+                  <string>0.05</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 11: Relative Weighting -->
+               <item row="11" column="0">
+                <widget class="QLabel" name="label_4">
+                 <property name="text">
+                  <string>Relative Weighting</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="11" column="2">
+                <widget class="QLineEdit" name="relative_weighting">
+                 <property name="text">
+                  <string>1.0</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 12: Starting Regularization -->
+               <item row="12" column="0">
+                <widget class="QLabel" name="label_10">
+                 <property name="text">
+                  <string>Starting Regularization</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="12" column="2">
+                <widget class="QLineEdit" name="starting_regularization">
+                 <property name="text">
+                  <string>10</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 13: Ending Regularization -->
+               <item row="13" column="0">
+                <widget class="QLabel" name="label_9">
+                 <property name="text">
+                  <string>Ending Regularization</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="13" column="2">
+                <widget class="QLineEdit" name="ending_regularization">
+                 <property name="text">
+                  <string>1.0</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 14: Iterations per Split -->
+               <item row="14" column="0">
+                <widget class="QLabel" name="label_8">
+                 <property name="text">
+                  <string>Iterations per Split</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="14" column="2">
+                <widget class="QLineEdit" name="iterations_per_split">
+                 <property name="text">
+                  <string>1000</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 15: Optimization Iterations -->
+               <item row="15" column="0">
+                <widget class="QLabel" name="label_19">
+                 <property name="text">
+                  <string>Optimization Iterations</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="15" column="2">
+                <widget class="QLineEdit" name="optimization_iterations">
+                 <property name="text">
+                  <string>1000</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 16: Narrow Band -->
+               <item row="16" column="0">
+                <widget class="QLabel" name="label_24">
+                 <property name="text">
+                  <string>Narrow Band</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="16" column="2">
+                <widget class="QLineEdit" name="narrow_band">
+                 <property name="text">
+                  <string>000</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Divider: after numeric params -->
+               <item row="17" column="0" colspan="4">
+                <widget class="Line" name="line_opt_1">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 18: Geodesic Distance (combined checkbox + remesh percent) -->
+               <item row="18" column="0">
+                <widget class="QCheckBox" name="use_geodesic_distance">
+                 <property name="text">
+                  <string>Geodesic Distance</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="18" column="1">
+                <widget class="QLabel" name="geodesic_remesh_label">
+                 <property name="text">
+                  <string>Remesh %:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+              <item row="18" column="2">
+                <widget class="QLineEdit" name="geodesic_remesh_percent">
+                 <property name="text">
+                  <string>100</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 19: Normals (combined checkbox + strength) -->
+               <item row="19" column="0">
+                <widget class="QCheckBox" name="use_normals">
+                 <property name="text">
+                  <string>Normals</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="19" column="1">
+                <widget class="QLabel" name="normals_strength_label">
+                 <property name="text">
+                  <string>Strength:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+              <item row="19" column="2">
+                <widget class="QLineEdit" name="normals_strength">
+                 <property name="text">
+                  <string>10</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 20: Geodesic from Landmarks (combined checkbox + weight) -->
+               <item row="20" column="0">
+                <widget class="QCheckBox" name="use_geodesics_from_landmarks">
+                 <property name="text">
+                  <string>Geodesic from Landmarks</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="20" column="1">
+                <widget class="QLabel" name="geodesic_landmarks_weight_label">
+                 <property name="text">
+                  <string>Weight:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+              <item row="20" column="2">
+                <widget class="QLineEdit" name="geodesics_to_landmarks_weight">
+                 <property name="text">
+                  <string>1</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 21: Multiscale Mode (combined checkbox + start particles) -->
+               <item row="21" column="0">
+                <widget class="QCheckBox" name="multiscale">
                  <property name="text">
                   <string>Multiscale Mode</string>
                  </property>
                 </widget>
                </item>
-               <item row="21" column="0">
-                <widget class="QLabel" name="sampling_scale_label">
+               <item row="21" column="1">
+                <widget class="QLabel" name="multiscale_start_label">
+                 <property name="text">
+                  <string>Start:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+              <item row="21" column="2">
+                <widget class="QLineEdit" name="multiscale_particles">
+                 <property name="text">
+                  <string>32</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 22: Shared Boundary (combined checkbox + weight) -->
+               <item row="22" column="0">
+                <widget class="QCheckBox" name="shared_boundary">
+                 <property name="text">
+                  <string>Shared Boundary</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="22" column="1">
+                <widget class="QLabel" name="shared_boundary_weight_label">
+                 <property name="text">
+                  <string>Weight:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+              <item row="22" column="2">
+                <widget class="QLineEdit" name="shared_boundary_weight">
+                 <property name="text">
+                  <string>0.1</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 23: Use Initial Landmarks (checkbox only) -->
+               <item row="23" column="0">
+                <widget class="QCheckBox" name="use_landmarks">
+                 <property name="text">
+                  <string>Use Initial Landmarks</string>
+                 </property>
+                </widget>
+               </item>
+               <!-- Divider: after Geodesic/Options group -->
+               <item row="24" column="0" colspan="4">
+                <widget class="Line" name="line_opt_2">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 25: Procrustes (combined checkbox + interval) -->
+               <item row="25" column="0">
+                <widget class="QCheckBox" name="procrustes">
+                 <property name="text">
+                  <string>Procrustes</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="25" column="1">
+                <widget class="QLabel" name="procrustes_interval_label">
+                 <property name="text">
+                  <string>Interval:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+              <item row="25" column="2">
+                <widget class="QLineEdit" name="procrustes_interval">
+                 <property name="text">
+                  <string>10</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 26: Procrustes sub-options (Scaling + Rot/Trans) -->
+               <item row="26" column="0" colspan="3">
+                <widget class="QWidget" name="procrustes_sub_widget" native="true">
+                 <layout class="QHBoxLayout" name="procrustes_sub_layout">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <spacer name="procrustes_sub_spacer">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="procrustes_scaling">
+                    <property name="text">
+                     <string>Scaling</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="procrustes_rotation_translation">
+                    <property name="text">
+                     <string>Rotation/Translation</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <!-- Divider: after Procrustes group -->
+               <item row="27" column="0" colspan="4">
+                <widget class="Line" name="line_opt_3">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 28: Sampling Scale (combined checkbox + multiplier) -->
+               <item row="28" column="0">
+                <widget class="QCheckBox" name="sampling_scale">
                  <property name="text">
                   <string>Sampling Scale</string>
                  </property>
-                </widget>
-               </item>
-               <item row="23" column="0">
-                <widget class="QLabel" name="sampling_scale_value_label">
-                 <property name="text">
-                  <string>Sampling Scale Value</string>
+                 <property name="checked">
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>
-               <item row="23" column="2">
+               <item row="28" column="1">
+                <widget class="QLabel" name="sampling_scale_label">
+                 <property name="text">
+                  <string>Multiplier:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+              <item row="28" column="2">
                 <widget class="QLineEdit" name="sampling_scale_value">
                  <property name="text">
                   <string>1.0</string>
                  </property>
                  <property name="alignment">
                   <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <!-- Row 29: Auto Scale (sub-checkbox) -->
+               <item row="29" column="0" colspan="3">
+                <widget class="QWidget" name="sampling_auto_scale_sub_widget" native="true">
+                 <layout class="QHBoxLayout" name="sampling_auto_scale_sub_layout">
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <spacer name="sampling_auto_scale_spacer">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="sampling_auto_scale">
+                    <property name="text">
+                     <string>Auto Scale</string>
+                    </property>
+                    <property name="checked">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <!-- Row 30: Disentangled SSM (checkbox only, hidden) -->
+               <item row="30" column="0">
+                <widget class="QCheckBox" name="use_disentangled_ssm">
+                 <property name="text">
+                  <string>Disentangled SSM</string>
                  </property>
                 </widget>
                </item>
@@ -1352,15 +853,24 @@ QWidget#optimize_panel {
   <tabstop>iterations_per_split</tabstop>
   <tabstop>optimization_iterations</tabstop>
   <tabstop>use_geodesic_distance</tabstop>
+  <tabstop>geodesic_remesh_percent</tabstop>
   <tabstop>use_normals</tabstop>
   <tabstop>normals_strength</tabstop>
+  <tabstop>use_geodesics_from_landmarks</tabstop>
+  <tabstop>geodesics_to_landmarks_weight</tabstop>
   <tabstop>procrustes</tabstop>
-  <tabstop>procrustes_scaling</tabstop>
   <tabstop>procrustes_interval</tabstop>
+  <tabstop>procrustes_scaling</tabstop>
+  <tabstop>procrustes_rotation_translation</tabstop>
   <tabstop>multiscale</tabstop>
   <tabstop>multiscale_particles</tabstop>
   <tabstop>use_landmarks</tabstop>
   <tabstop>narrow_band</tabstop>
+  <tabstop>sampling_scale</tabstop>
+  <tabstop>sampling_scale_value</tabstop>
+  <tabstop>sampling_auto_scale</tabstop>
+  <tabstop>shared_boundary</tabstop>
+  <tabstop>shared_boundary_weight</tabstop>
   <tabstop>use_disentangled_ssm</tabstop>
  </tabstops>
  <resources>


### PR DESCRIPTION
* #2505 

Before:

<img width="892" height="1882" alt="image" src="https://github.com/user-attachments/assets/30f39505-ed55-40ec-aa06-650bf0193380" />

After:

<img width="397" height="680" alt="image" src="https://github.com/user-attachments/assets/3051b319-bbf8-489c-bfef-590e9a4eeb7e" />


Also improved multidomain layout:

<img width="396" height="775" alt="image" src="https://github.com/user-attachments/assets/9c4b51ad-0397-48bb-854a-90fe91074d04" />
