### PR TITLE
Bump python dependencies (consolidate dependabot PRs)

### DIFF
--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -355,7 +355,7 @@ jupyter-events==0.12.0
     #   jupyter-server
 jupyter-lsp==2.3.0
     # via jupyterlab
-jupyter-server==2.17.0
+jupyter-server==2.18.0
     # via
     #   -r requirements.in
     #   jupyter-lsp
@@ -367,7 +367,7 @@ jupyter-server-terminals==0.5.3
     # via
     #   -r requirements.in
     #   jupyter-server
-jupyterlab==4.4.8
+jupyterlab==4.5.7
     # via notebook
 jupyterlab-pygments==0.3.0
     # via
@@ -393,7 +393,7 @@ lark==1.2.2
     # via rfc3987-syntax
 light-the-torch==0.8.0
     # via -r requirements.in
-lxml==6.0.1
+lxml==6.1.0
     # via -r requirements.in
 markdown==3.9
     # via
@@ -455,7 +455,7 @@ mergedeep==1.3.4
     #   mkdocs-get-deps
 mike==2.1.3
     # via -r requirements.in
-mistune==3.1.4
+mistune==3.2.1
     # via
     #   -r requirements.in
     #   nbconvert
@@ -498,7 +498,7 @@ nbclient==0.10.2
     # via
     #   -r requirements.in
     #   nbconvert
-nbconvert==7.17.0
+nbconvert==7.17.1
     # via
     #   -r requirements.in
     #   jupyter-server

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -373,7 +373,7 @@ jupyterlab-pygments==0.3.0
     # via
     #   -r requirements.in
     #   nbconvert
-jupyterlab-server==2.27.3
+jupyterlab-server==2.28.0
     # via
     #   jupyterlab
     #   notebook


### PR DESCRIPTION
Consolidates dependabot PRs #2541, #2542, #2544, #2545, #2548:
- jupyter-server 2.17.0 -> 2.18.0
- jupyterlab 4.4.8 -> 4.5.7
- lxml 6.0.1 -> 6.1.0
- mistune 3.1.4 -> 3.2.1
- nbconvert 7.17.0 -> 7.17.1