### PR TITLE
Fix geodesic remesh: correct percent units, enable geodesics on remeshed surface, skip wasted precompute.

### DIFF
--- a/Libs/Optimize/Domain/MeshDomain.cpp
+++ b/Libs/Optimize/Domain/MeshDomain.cpp
@@ -105,8 +105,10 @@ void MeshDomain::SetMesh(std::shared_ptr<Surface> mesh, double geodesic_remesh_p
   } else {
     auto poly_data = surface_->get_polydata();
     Mesh mesh_copy(poly_data);
-    mesh_copy.remeshPercent(geodesic_remesh_percent, 1.0);
-    geodesics_mesh_ = std::make_shared<Surface>(mesh_copy.getVTKMesh());
+    // remeshPercent takes a 0–1 fraction; project value is 0–100
+    mesh_copy.remeshPercent(geodesic_remesh_percent / 100.0, 1.0);
+    // remesh path implies geodesics are enabled — precompute on the small mesh
+    geodesics_mesh_ = std::make_shared<Surface>(mesh_copy.getVTKMesh(), /*geodesics_enabled=*/true);
   }
 }
 

--- a/Libs/Optimize/Domain/MeshDomain.h
+++ b/Libs/Optimize/Domain/MeshDomain.h
@@ -84,6 +84,11 @@ class MeshDomain : public ParticleDomain {
 
   std::shared_ptr<Surface> get_surface() const { return surface_; }
 
+  bool is_geodesics_enabled() const {
+    // ask the geodesics surface, since it (not surface_) is the one used for geodesic queries
+    return geodesics_mesh_ && geodesics_mesh_->is_geodesics_enabled();
+  }
+
  private:
   std::shared_ptr<Surface> surface_;
   std::shared_ptr<Surface> geodesics_mesh_;

--- a/Libs/Optimize/Neighborhood/ParticleNeighborhood.cpp
+++ b/Libs/Optimize/Neighborhood/ParticleNeighborhood.cpp
@@ -53,7 +53,7 @@ std::vector<ParticlePointIndexPair> ParticleNeighborhood::find_neighborhood_poin
   if (domain_->GetDomainType() == DomainType::Mesh) {
     // cast to MeshDomain to ask if geodesics are enabled
     auto mesh_domain = std::dynamic_pointer_cast<MeshDomain>(domain_);
-    use_euclidean = !mesh_domain->get_surface()->is_geodesics_enabled();
+    use_euclidean = !mesh_domain->is_geodesics_enabled();
   } else if (domain_->GetDomainType() == DomainType::Contour) {
     use_euclidean = false;
   }

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1748,9 +1748,11 @@ void Optimize::AddMesh(vtkSmartPointer<vtkPolyData> poly_data) {
     m_sampler->AddMesh(nullptr);
   } else {
     double geodesic_remesh_percent = m_geodesics_enabled ? m_geodesic_remesh_percent : 100;
+    // If we'll precompute geodesics on a remeshed copy, skip the precompute on the full-res surface.
+    bool geodesics_on_main = m_geodesics_enabled && geodesic_remesh_percent >= 100.0;
 
     const auto mesh =
-        std::make_shared<shapeworks::Surface>(poly_data, m_geodesics_enabled, m_geodesic_cache_size_multiplier);
+        std::make_shared<shapeworks::Surface>(poly_data, geodesics_on_main, m_geodesic_cache_size_multiplier);
     m_sampler->AddMesh(mesh, geodesic_remesh_percent);
   }
   this->m_num_shapes++;

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -858,9 +858,12 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
                         for (size_t i = r.begin(); i < r.end(); ++i) {
                           auto& item = work_items[mesh_work_indices[i]];
 
-                          // Construct the main Surface (triangulation, cleaning, normals, cell locator, geodesics)
+                          // When we'll precompute geodesics on a remeshed copy, skip the (expensive)
+                          // geodesic precompute on the full-resolution surface — it's only used for
+                          // cell-locator / snap / normals / geodesic_walk, none of which need it.
+                          bool geodesics_on_main = geodesics_enabled && !remeshing;
                           auto surface = std::make_shared<shapeworks::Surface>(
-                              item.poly_data, geodesics_enabled,
+                              item.poly_data, geodesics_on_main,
                               static_cast<size_t>(geodesic_cache_multiplier));
 
                           // Create the Mesh wrapper and compute surface area
@@ -869,14 +872,16 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
 
                           // Create remeshed Surface for geodesics if needed
                           std::shared_ptr<shapeworks::Surface> geodesics_surface;
-                          if (effective_remesh_percent >= 100.0) {
+                          if (!remeshing) {
                             geodesics_surface = surface;
                           } else {
                             auto poly_copy = surface->get_polydata();
                             Mesh mesh_copy(poly_copy);
-                            mesh_copy.remeshPercent(effective_remesh_percent, 1.0);
-                            geodesics_surface =
-                                std::make_shared<shapeworks::Surface>(mesh_copy.getVTKMesh());
+                            // remeshPercent takes a 0–1 fraction; project value is 0–100
+                            mesh_copy.remeshPercent(effective_remesh_percent / 100.0, 1.0);
+                            geodesics_surface = std::make_shared<shapeworks::Surface>(
+                                mesh_copy.getVTKMesh(), geodesics_enabled,
+                                static_cast<size_t>(geodesic_cache_multiplier));
                           }
 
                           item.surface = surface;

--- a/Libs/Optimize/Sampler.cpp
+++ b/Libs/Optimize/Sampler.cpp
@@ -110,7 +110,7 @@ void Sampler::AllocateDomainsAndNeighborhoods() {
       // cast to MeshDomain
       auto mesh_domain = std::dynamic_pointer_cast<MeshDomain>(domain);
 
-      m_ParticleSystem->GetNeighborhood(i)->set_weighting_enabled(!mesh_domain->get_surface()->is_geodesics_enabled());
+      m_ParticleSystem->GetNeighborhood(i)->set_weighting_enabled(!mesh_domain->is_geodesics_enabled());
     } else if (domain->GetDomainType() == DomainType::Contour) {
       m_ParticleSystem->GetNeighborhood(i)->set_weighting_enabled(false);
     }


### PR DESCRIPTION
* #2556 

Mesh::remeshPercent expects a 0–1 fraction; the two optimize call sites passed the raw project value (e.g. 10) which inflated meshes ~10× instead of reducing to 10%. ACVD then ran for minutes on the bloated mesh, and for some input geometries overshot the target by another 1.65×.

The remeshed Surface was also constructed with the default geodesics_enabled=false, so compute_distance/is_within_distance silently fell back to Euclidean during optimization — masking the slowness as "runs fast" while producing non-geodesic correspondence. Meanwhile the full-resolution main Surface ran precompute_geodesics it never needed.

ParticleNeighborhood and Sampler keyed weighting/euclidean decisions off the main surface's flag; with the precompute moved off the main surface, they now go through a new MeshDomain::is_geodesics_enabled() accessor that asks the canonical geodesics surface.