### PR TITLE
Batch: bump tornado, pymdown-extensions, idna, urllib3

### DIFF
--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -899,7 +899,7 @@ uri-template==1.3.0
     # via
     #   -r requirements.in
     #   jsonschema
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements.in
     #   requests

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -839,7 +839,7 @@ toml==0.10.2
     # via
     #   -r requirements.in
     #   swcc
-tornado==6.5.5
+tornado==6.5.7
     # via
     #   -r requirements.in
     #   bokeh

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -178,7 +178,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via jupyterlab
-idna==3.10
+idna==3.15
     # via
     #   -r requirements.in
     #   anyio

--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -673,7 +673,7 @@ pygments==2.20.0
     #   mkdocs-material
     #   nbconvert
     #   rich
-pymdown-extensions==10.16.1
+pymdown-extensions==10.21.3
     # via
     #   -r requirements.in
     #   mkdocs-material


### PR DESCRIPTION
Combined test of four open dependabot PRs to run CI once instead of four times:

- #2560 tornado 6.5.5 → 6.5.7
- #2555 pymdown-extensions 10.16.1 → 10.21.3
- #2554 idna 3.10 → 3.15
- #2553 urllib3 2.6.3 → 2.7.0