### PR TITLE
Bump grouped pip dependencies

### DIFF
--- a/python_requirements.txt
+++ b/python_requirements.txt
@@ -50,7 +50,7 @@ beautifulsoup4==4.13.5
     # via
     #   -r requirements.in
     #   nbconvert
-bleach[css]==6.2.0
+bleach[css]==6.4.0
     # via
     #   -r requirements.in
     #   nbconvert
@@ -178,7 +178,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via jupyterlab
-idna==3.10
+idna==3.15
     # via
     #   -r requirements.in
     #   anyio
@@ -355,7 +355,7 @@ jupyter-events==0.12.0
     #   jupyter-server
 jupyter-lsp==2.3.0
     # via jupyterlab
-jupyter-server==2.18.0
+jupyter-server==2.20.0
     # via
     #   -r requirements.in
     #   jupyter-lsp
@@ -673,7 +673,7 @@ pygments==2.20.0
     #   mkdocs-material
     #   nbconvert
     #   rich
-pymdown-extensions==10.16.1
+pymdown-extensions==10.21.3
     # via
     #   -r requirements.in
     #   mkdocs-material
@@ -839,7 +839,7 @@ toml==0.10.2
     # via
     #   -r requirements.in
     #   swcc
-tornado==6.5.5
+tornado==6.5.7
     # via
     #   -r requirements.in
     #   bokeh
@@ -899,7 +899,7 @@ uri-template==1.3.0
     # via
     #   -r requirements.in
     #   jsonschema
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements.in
     #   requests


### PR DESCRIPTION
Combines dependabot updates:
- bleach[css] 6.2.0 -> 6.4.0 (#2564)
- jupyter-server 2.18.0 -> 2.20.0 (#2563)
- tornado 6.5.5 -> 6.5.7 (#2560)
- pymdown-extensions 10.16.1 -> 10.21.3 (#2555)
- idna 3.10 -> 3.15 (#2554)
- urllib3 2.6.3 -> 2.7.0 (#2553)