### PR TITLE
Apply cutting plane table center/normal edits (#2567)

### DIFF
--- a/Libs/Optimize/Constraints/PlaneConstraint.cpp
+++ b/Libs/Optimize/Constraints/PlaneConstraint.cpp
@@ -3,6 +3,8 @@
 #include <vtkPlane.h>
 #include <vtkTriangle.h>
 
+#include <Eigen/Geometry>
+#include <cmath>
 #include <iostream>
 
 namespace shapeworks {
@@ -39,6 +41,81 @@ void PlaneConstraint::updatePlaneFromPoints() {
     planePoint_ = (points_[0] + points_[1] + points_[2]) / 3.0;
     vtkTriangle::ComputeNormal(points_[0].data(), points_[1].data(), points_[2].data(), planeNormal_.data());
   }
+}
+
+//-----------------------------------------------------------------------------
+void PlaneConstraint::updatePointsFromPlane() {
+  double norm = planeNormal_.norm();
+  if (norm < 1e-12) {
+    // degenerate normal, leave the points unchanged
+    return;
+  }
+  Eigen::Vector3d normal = planeNormal_ / norm;
+
+  // preserve the current triangle size if we have three points, otherwise use a default radius
+  double radius = 1.0;
+  if (points_.size() == 3) {
+    Eigen::Vector3d centroid = (points_[0] + points_[1] + points_[2]) / 3.0;
+    radius = ((points_[0] - centroid).norm() + (points_[1] - centroid).norm() + (points_[2] - centroid).norm()) / 3.0;
+  }
+  if (radius < 1e-6) {
+    radius = 1.0;
+  }
+
+  // build an orthonormal basis (u, v) spanning the plane such that u x v = normal
+  Eigen::Vector3d arbitrary = (std::abs(normal[0]) < 0.9) ? Eigen::Vector3d(1, 0, 0) : Eigen::Vector3d(0, 1, 0);
+  Eigen::Vector3d u = normal.cross(arbitrary).normalized();
+  Eigen::Vector3d v = normal.cross(u);  // unit length since normal and u are orthonormal
+
+  // equilateral triangle centered at planePoint_ so that its centroid is planePoint_ and its
+  // computed normal (see updatePlaneFromPoints) matches planeNormal_
+  const double kSqrt3Over2 = 0.8660254037844386;  // sqrt(3)/2
+  points_.resize(3);
+  points_[0] = planePoint_ + radius * u;
+  points_[1] = planePoint_ + radius * (-0.5 * u + kSqrt3Over2 * v);
+  points_[2] = planePoint_ + radius * (-0.5 * u - kSqrt3Over2 * v);
+}
+
+//-----------------------------------------------------------------------------
+void PlaneConstraint::setPlaneCenter(const Eigen::Vector3d &center) {
+  // translate the defining points so their centroid becomes the new center (preserves shape/normal)
+  if (points_.size() == 3) {
+    Eigen::Vector3d centroid = (points_[0] + points_[1] + points_[2]) / 3.0;
+    Eigen::Vector3d delta = center - centroid;
+    for (auto &point : points_) {
+      point += delta;
+    }
+  }
+  planePoint_ = center;
+}
+
+//-----------------------------------------------------------------------------
+void PlaneConstraint::setPlaneNormalDirection(const Eigen::Vector3d &normal) {
+  double norm = normal.norm();
+  if (norm < 1e-12) {
+    // degenerate target normal, leave the plane unchanged
+    return;
+  }
+  Eigen::Vector3d new_normal = normal / norm;
+
+  if (points_.size() == 3) {
+    updatePlaneFromPoints();  // make sure planePoint_/planeNormal_ reflect the current points
+    Eigen::Vector3d old_normal = planeNormal_;
+    if (old_normal.norm() > 1e-12) {
+      // rotate the points about the center so the triangle's normal becomes new_normal (preserves shape)
+      Eigen::Quaterniond rotation = Eigen::Quaterniond::FromTwoVectors(old_normal.normalized(), new_normal);
+      Eigen::Vector3d center = planePoint_;
+      for (auto &point : points_) {
+        point = center + rotation * (point - center);
+      }
+      planeNormal_ = new_normal;
+      return;
+    }
+  }
+
+  // no valid points to rotate (degenerate or missing): rebuild them from the center and new normal
+  planeNormal_ = new_normal;
+  updatePointsFromPlane();
 }
 
 //-----------------------------------------------------------------------------

--- a/Libs/Optimize/Constraints/PlaneConstraint.h
+++ b/Libs/Optimize/Constraints/PlaneConstraint.h
@@ -14,7 +14,8 @@ namespace shapeworks {
  * \class PlaneConstraint
  * \ingroup Group-Constraints
  *
- *  Encapsulate functionality related to cutting-plane constraints. Inherits from Constraint. See Constraint.h for more information
+ *  Encapsulate functionality related to cutting-plane constraints. Inherits from Constraint. See Constraint.h for more
+ * information
  *
  */
 
@@ -46,6 +47,20 @@ class PlaneConstraint : public Constraint {
   double constraintEval(const Eigen::Vector3d &pt) const override;
 
   void updatePlaneFromPoints();
+
+  //! Rebuild the three defining points from the current plane point and normal.
+  //! This is the inverse of updatePlaneFromPoints() and is used when the center/normal
+  //! are edited directly (e.g. in the Studio cutting-plane table).
+  void updatePointsFromPlane();
+
+  //! Move the plane to a new center by translating the defining points. Preserves the triangle's
+  //! shape and normal. Used when the center is edited directly (e.g. in the Studio cutting-plane table).
+  void setPlaneCenter(const Eigen::Vector3d &center);
+
+  //! Reorient the plane to a new normal by rotating the defining points about the current center.
+  //! Preserves the triangle's shape and center. The input need not be a unit vector. Used when the
+  //! normal is edited directly (e.g. in the Studio cutting-plane table).
+  void setPlaneNormalDirection(const Eigen::Vector3d &normal);
 
   //! Return this plane as a vtkPlane
   vtkSmartPointer<vtkPlane> getVTKPlane();

--- a/Studio/Data/DataTool.cpp
+++ b/Studio/Data/DataTool.cpp
@@ -12,9 +12,14 @@
 #include <vtkPointData.h>
 #include <vtkTransformPolyDataFilter.h>
 
+#include <Eigen/Core>
+#include <QAbstractItemDelegate>
+#include <QAbstractItemView>
 #include <QDebug>
 #include <QMenu>
 #include <QMessageBox>
+#include <QStyledItemDelegate>
+#include <QTableWidgetItem>
 #include <QThread>
 
 #include "SegmentationToolPanel.h"
@@ -25,7 +30,58 @@ static QString click_message = "⌘+click";
 static QString click_message = "ctrl+click";
 #endif
 
+namespace {
+// Item delegate that keeps a count of open editors so the owning table isn't rebuilt out from
+// under an in-progress edit. Reference counting (rather than a single bool) is required to handle
+// Tab navigation, where the next cell's editor is created before the previous one is destroyed.
+class EditTrackingDelegate : public QStyledItemDelegate {
+ public:
+  EditTrackingDelegate(int* open_count, QObject* parent) : QStyledItemDelegate(parent), open_count_(open_count) {}
+
+  QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& option, const QModelIndex& index) const override {
+    ++(*open_count_);
+    return QStyledItemDelegate::createEditor(parent, option, index);
+  }
+
+  void destroyEditor(QWidget* editor, const QModelIndex& index) const override {
+    if (*open_count_ > 0) {
+      --(*open_count_);
+    }
+    QStyledItemDelegate::destroyEditor(editor, index);
+  }
+
+ private:
+  int* open_count_;
+};
+}  // namespace
+
 namespace shapeworks {
+
+//---------------------------------------------------------------------------
+// Parse a "x,y,z" string into a 3D vector. Returns false if the string is not three finite numbers.
+static bool parse_vector3(const QString& text, Eigen::Vector3d& out) {
+  const QStringList parts = text.split(",");
+  if (parts.size() != 3) {
+    return false;
+  }
+  bool ok[3] = {false, false, false};
+  const double x = parts[0].trimmed().toDouble(&ok[0]);
+  const double y = parts[1].trimmed().toDouble(&ok[1]);
+  const double z = parts[2].trimmed().toDouble(&ok[2]);
+  if (!ok[0] || !ok[1] || !ok[2]) {
+    return false;
+  }
+  out = Eigen::Vector3d(x, y, z);
+  // reject nan/inf (QString::toDouble accepts "nan"/"inf" as valid)
+  return out.allFinite();
+}
+
+//---------------------------------------------------------------------------
+// Format a 3D vector as "x,y,z" with enough precision to round-trip a double edit without silently
+// truncating the coordinates the user did not touch.
+static QString format_vector3(const Eigen::Vector3d& v) {
+  return QString::number(v[0], 'g', 12) + "," + QString::number(v[1], 'g', 12) + "," + QString::number(v[2], 'g', 12);
+}
 
 //---------------------------------------------------------------------------
 DataTool::DataTool(Preferences& prefs) : preferences_(prefs) {
@@ -53,6 +109,16 @@ DataTool::DataTool(Preferences& prefs) : preferences_(prefs) {
 
   connect(ui_->delete_plane_, &QPushButton::clicked, this, &DataTool::delete_planes_clicked);
   connect(ui_->delete_ffc_, &QPushButton::clicked, this, &DataTool::delete_ffc_clicked);
+
+  // when a plane's center/normal is edited in the table
+  connect(ui_->plane_table_, &QTableWidget::itemChanged, this, &DataTool::plane_table_data_edited);
+  // track open editors so the table isn't rebuilt while the user is editing a cell
+  auto* plane_delegate = new EditTrackingDelegate(&plane_table_editors_open_, ui_->plane_table_);
+  ui_->plane_table_->setItemDelegate(plane_delegate);
+  // flush any deferred plane table rebuild once the user finishes editing a cell (queued so any
+  // editor transition, e.g. Tab to the next cell, has settled before we decide whether to rebuild)
+  connect(plane_delegate, &QAbstractItemDelegate::closeEditor, this, &DataTool::plane_table_editing_finished,
+          Qt::QueuedConnection);
 
   connect(ui_->notes, &QTextEdit::textChanged, this, [this] { session_->set_modified(true); });
 
@@ -285,6 +351,15 @@ void DataTool::delete_ffc_clicked() {
 
 //---------------------------------------------------------------------------
 void DataTool::update_plane_table() {
+  // don't rebuild the table while the user is editing a cell; doing so would destroy the in-progress
+  // editor (losing focus mid-type). Defer the rebuild until editing finishes (see
+  // plane_table_editing_finished).
+  if (plane_table_editors_open_ > 0) {
+    plane_table_update_pending_ = true;
+    return;
+  }
+  plane_table_update_pending_ = false;
+
   auto shapes = session_->get_shapes();
   auto domain_names = session_->get_project()->get_domain_names();
 
@@ -306,6 +381,8 @@ void DataTool::update_plane_table() {
   table_headers << "Normal";
 
   QTableWidget* table = ui_->plane_table_;
+  // block itemChanged signals while we populate the table so plane_table_data_edited() doesn't fire
+  table->blockSignals(true);
   table->clear();
   table->setRowCount(plane_count);
   table->setColumnCount(table_headers.size());
@@ -322,38 +399,46 @@ void DataTool::update_plane_table() {
         int plane_id = 0;
         for (auto& plane : planes) {
           plane.updatePlaneFromPoints();
-          // shape
+          bool valid = plane.points().size() == 3;
+          // shape (not editable)
           auto* new_item = new QTableWidgetItem(QString::fromStdString(shape->get_display_name()));
           new_item->setData(Qt::UserRole, i);  // shape id
+          new_item->setFlags(new_item->flags() & ~Qt::ItemIsEditable);
           table->setItem(row, 0, new_item);
-          // domain
+          // domain (not editable)
           new_item = new QTableWidgetItem(QString::fromStdString(domain_names[domain_id]));
           new_item->setData(Qt::UserRole, domain_id);
+          new_item->setFlags(new_item->flags() & ~Qt::ItemIsEditable);
           table->setItem(row, 1, new_item);
 
           auto center = plane.getPlanePoint();
           auto normal = plane.getPlaneNormal();
-          auto center_string =
-              QString::number(center[0]) + "," + QString::number(center[1]) + "," + QString::number(center[2]);
-          auto normal_string =
-              QString::number(normal[0]) + "," + QString::number(normal[1]) + "," + QString::number(normal[2]);
-          if (plane.points().size() != 3) {
+          auto center_string = format_vector3(center);
+          auto normal_string = format_vector3(normal);
+          if (!valid) {
             normal_string = "N/A";
             center_string = "N/A";
           }
-          // center
+          // center (editable only when the plane is well-defined)
           new_item = new QTableWidgetItem(center_string);
           new_item->setData(Qt::UserRole, plane_id++);
+          if (!valid) {
+            new_item->setFlags(new_item->flags() & ~Qt::ItemIsEditable);
+          }
           table->setItem(row, 2, new_item);
 
-          // normal
+          // normal (editable only when the plane is well-defined)
           new_item = new QTableWidgetItem(normal_string);
+          if (!valid) {
+            new_item->setFlags(new_item->flags() & ~Qt::ItemIsEditable);
+          }
           table->setItem(row, 3, new_item);
           row++;
         }
       }
     }
   }
+  table->blockSignals(false);
 
   if (table->rowCount() < 1) {
     table->setMaximumHeight(ui_->table_label->height() * 2);
@@ -363,6 +448,75 @@ void DataTool::update_plane_table() {
   table->resizeColumnsToContents();
   table->horizontalHeader()->setStretchLastSection(false);
   table->setSelectionBehavior(QAbstractItemView::SelectRows);
+}
+
+//---------------------------------------------------------------------------
+void DataTool::plane_table_data_edited(QTableWidgetItem* item) {
+  if (!item || !session_) {
+    return;
+  }
+
+  // only the center (column 2) and normal (column 3) hold editable plane data
+  const int row = item->row();
+  const int col = item->column();
+  if (col != 2 && col != 3) {
+    return;
+  }
+
+  auto* table = ui_->plane_table_;
+  if (row < 0 || row >= table->rowCount() || !table->item(row, 0) || !table->item(row, 1) || !table->item(row, 2)) {
+    return;
+  }
+
+  const int shape_id = table->item(row, 0)->data(Qt::UserRole).toInt();
+  const int domain_id = table->item(row, 1)->data(Qt::UserRole).toInt();
+  const int plane_id = table->item(row, 2)->data(Qt::UserRole).toInt();
+
+  auto shapes = session_->get_shapes();
+  if (shape_id < 0 || shape_id >= shapes.size()) {
+    return;
+  }
+  auto& planes = shapes[shape_id]->get_constraints(domain_id).getPlaneConstraints();
+  if (plane_id < 0 || plane_id >= planes.size()) {
+    return;
+  }
+  auto& plane = planes[plane_id];
+  if (plane.points().size() != 3) {
+    return;
+  }
+
+  Eigen::Vector3d value;
+  if (!parse_vector3(item->text(), value)) {
+    // quietly revert (status message only, no error dialog) once the user finishes editing
+    SW_LOG("Ignoring plane value '{}'; expected three comma-separated numbers", item->text());
+    update_plane_table();  // deferred while editing; reverts the display to the stored values
+    return;
+  }
+  if (col == 3 && value.norm() < 1e-12) {
+    SW_LOG("Ignoring plane normal of zero length");
+    update_plane_table();  // deferred; reverts
+    return;
+  }
+
+  // apply the edited component, moving the defining points so the change takes effect while
+  // preserving the triangle's shape (the normal is normalized inside setPlaneNormalDirection)
+  if (col == 2) {
+    plane.setPlaneCenter(value);
+  } else {
+    plane.setPlaneNormalDirection(value);
+  }
+
+  session_->set_modified(true);
+  session_->trigger_planes_changed();
+}
+
+//---------------------------------------------------------------------------
+void DataTool::plane_table_editing_finished() {
+  // a rebuild was requested while the user was editing; now that editing has finished, apply it.
+  // (this connection is queued, so any editor transition has settled and the open count is accurate)
+  if (plane_table_update_pending_ && plane_table_editors_open_ == 0) {
+    update_plane_table();
+  }
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Data/DataTool.h
+++ b/Studio/Data/DataTool.h
@@ -12,6 +12,7 @@
 
 class Ui_DataTool;
 class QComboBox;
+class QTableWidgetItem;
 
 namespace shapeworks {
 
@@ -72,6 +73,8 @@ class DataTool : public QWidget {
   void table_selection_changed();
   void subject_notes_changed();
   void table_data_edited();
+  void plane_table_data_edited(QTableWidgetItem* item);
+  void plane_table_editing_finished();
 
  Q_SIGNALS:
   void import_button_clicked();
@@ -89,5 +92,13 @@ class DataTool : public QWidget {
   std::shared_ptr<LandmarkTableModel> landmark_table_model_;
 
   bool block_table_update_{false};
+
+  //! number of open editors in the plane table (tracked via a custom item delegate). While > 0 the
+  //! table must not be rebuilt, or the in-progress editor would be destroyed (losing focus mid-type).
+  int plane_table_editors_open_{0};
+
+  //! set when a plane table rebuild is requested while the user is editing a cell, so the rebuild
+  //! can be deferred until editing finishes (avoids destroying the in-progress editor)
+  bool plane_table_update_pending_{false};
 };
 }  // namespace shapeworks

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 
 #include "../Testing.h"
+#include "Libs/Optimize/Constraints/PlaneConstraint.h"
 #include "Libs/Optimize/Domain/Surface.h"
 #include "Optimize.h"
 #include "OptimizeParameterFile.h"
@@ -22,15 +23,15 @@ static void prep_temp(std::string data, std::string name) {
 }
 
 //---------------------------------------------------------------------------
-static bool check_constraint_violations(Optimize &app, double slack) {
+static bool check_constraint_violations(Optimize& app, double slack) {
   // Check that points don't violate the constraints
   size_t domains_per_shape = app.GetSampler()->GetParticleSystem()->GetDomainsPerShape();
   size_t num_doms = app.GetSampler()->GetParticleSystem()->GetNumberOfDomains();
 
-  std::vector<std::vector<itk::FixedArray<double, 3> > > lists;
+  std::vector<std::vector<itk::FixedArray<double, 3>>> lists;
 
   for (size_t domain = 0; domain < num_doms; domain++) {
-    std::vector<itk::FixedArray<double, 3> > list;
+    std::vector<itk::FixedArray<double, 3>> list;
     for (auto k = 0; k < app.GetSampler()->GetParticleSystem()->GetPositions(domain)->GetSize(); k++) {
       list.push_back(app.GetSampler()->GetParticleSystem()->GetPositions(domain)->Get(k));
     }
@@ -220,8 +221,7 @@ TEST(OptimizeTests, fixed_domain_procrustes) {
 TEST(OptimizeTests, fixed_domain_independence) {
   // Helper lambda: run optimization with specified fixed/excluded/new configuration
   // Returns local particles for each domain, indexed by domain index in the project
-  auto run_optimize = [](const std::string& temp_name,
-                         const std::vector<bool>& is_fixed,
+  auto run_optimize = [](const std::string& temp_name, const std::vector<bool>& is_fixed,
                          const std::vector<bool>& is_excluded) -> std::vector<std::vector<itk::Point<double>>> {
     prep_temp("/optimize/fixed_domain", temp_name);
 
@@ -246,24 +246,18 @@ TEST(OptimizeTests, fixed_domain_independence) {
 
   // Project has 4 shapes: sphere10, sphere20, sphere30, sphere40
   // Run A: sphere10,20 fixed; sphere30,40 both new
-  auto points_together = run_optimize(
-      "fixed_domain_indep_together",
-      {true, true, false, false},   // is_fixed
-      {false, false, false, false}  // is_excluded
+  auto points_together = run_optimize("fixed_domain_indep_together", {true, true, false, false},  // is_fixed
+                                      {false, false, false, false}                                // is_excluded
   );
 
   // Run B: sphere10,20 fixed; sphere30 new; sphere40 excluded
-  auto points_30_alone = run_optimize(
-      "fixed_domain_indep_30",
-      {true, true, false, false},  // is_fixed
-      {false, false, false, true}  // is_excluded: sphere40 excluded
+  auto points_30_alone = run_optimize("fixed_domain_indep_30", {true, true, false, false},  // is_fixed
+                                      {false, false, false, true}  // is_excluded: sphere40 excluded
   );
 
   // Run C: sphere10,20 fixed; sphere40 new; sphere30 excluded
-  auto points_40_alone = run_optimize(
-      "fixed_domain_indep_40",
-      {true, true, false, false},  // is_fixed
-      {false, false, true, false}  // is_excluded: sphere30 excluded
+  auto points_40_alone = run_optimize("fixed_domain_indep_40", {true, true, false, false},  // is_fixed
+                                      {false, false, true, false}  // is_excluded: sphere30 excluded
   );
 
   // In run A (together), domains are: 0=sphere10, 1=sphere20, 2=sphere30, 3=sphere40
@@ -675,6 +669,81 @@ TEST(OptimizeTests, cutting_plane_test) {
             << shapeworks::ShapeWorksUtils::elapsed(start, end, false) << "sec \n";
 
   ASSERT_TRUE(good);
+}
+
+//---------------------------------------------------------------------------
+// Editing a cutting plane's center/normal (e.g. in the Studio table) rebuilds its defining points
+// via updatePointsFromPlane().  Verify that the edited center/normal survive a round-trip back through
+// updatePlaneFromPoints() (the derivation used everywhere else).
+TEST(OptimizeTests, plane_constraint_update_points_from_plane) {
+  PlaneConstraint plane;
+
+  // start from three points defining an arbitrary plane
+  plane.points() = {Eigen::Vector3d(1, 0, 0), Eigen::Vector3d(0, 1, 0), Eigen::Vector3d(0, 0, 1)};
+  plane.updatePlaneFromPoints();
+
+  // edit the center and normal, then rebuild the defining points
+  const Eigen::Vector3d new_center(3.0, -2.0, 5.0);
+  const Eigen::Vector3d new_normal = Eigen::Vector3d(1.0, 2.0, -2.0).normalized();
+  plane.setPlanePoint(new_center);
+  plane.setPlaneNormal(new_normal);
+  plane.updatePointsFromPlane();
+
+  ASSERT_EQ(plane.points().size(), 3);
+
+  // re-derive center/normal from the rebuilt points and confirm they match the edited values
+  plane.updatePlaneFromPoints();
+  ASSERT_TRUE(plane.getPlanePoint().isApprox(new_center, 1e-6));
+  // normal direction must be preserved (not flipped)
+  ASSERT_NEAR(plane.getPlaneNormal().normalized().dot(new_normal), 1.0, 1e-6);
+}
+
+//---------------------------------------------------------------------------
+// Editing the center/normal in the Studio table should move the plane while preserving the shape of
+// the three user-placed defining points (setPlaneCenter translates, setPlaneNormalDirection rotates).
+TEST(OptimizeTests, plane_constraint_edit_preserves_point_shape) {
+  // a deliberately non-equilateral triangle
+  const std::vector<Eigen::Vector3d> original = {Eigen::Vector3d(0, 0, 0), Eigen::Vector3d(4, 0, 0),
+                                                 Eigen::Vector3d(0, 1, 0)};
+
+  // the three squared edge lengths characterize the triangle's shape/size
+  auto edge_lengths = [](const std::vector<Eigen::Vector3d>& p) {
+    return Eigen::Vector3d((p[1] - p[0]).norm(), (p[2] - p[1]).norm(), (p[0] - p[2]).norm());
+  };
+  const Eigen::Vector3d original_edges = edge_lengths(original);
+
+  // --- center edit: translate ---
+  {
+    PlaneConstraint plane;
+    plane.points() = original;
+    plane.updatePlaneFromPoints();
+    const Eigen::Vector3d old_normal = plane.getPlaneNormal();
+
+    const Eigen::Vector3d new_center(10.0, -5.0, 7.0);
+    plane.setPlaneCenter(new_center);
+    plane.updatePlaneFromPoints();
+
+    ASSERT_TRUE(plane.getPlanePoint().isApprox(new_center, 1e-6));             // center applied
+    ASSERT_TRUE(edge_lengths(plane.points()).isApprox(original_edges, 1e-6));  // shape preserved
+    ASSERT_NEAR(plane.getPlaneNormal().dot(old_normal), 1.0, 1e-6);            // normal unchanged
+  }
+
+  // --- normal edit: rotate ---
+  {
+    PlaneConstraint plane;
+    plane.points() = original;
+    plane.updatePlaneFromPoints();
+    const Eigen::Vector3d old_center = plane.getPlanePoint();
+
+    const Eigen::Vector3d new_normal = Eigen::Vector3d(1.0, 1.0, 1.0).normalized();
+    // pass a non-unit vector to confirm it is normalized internally
+    plane.setPlaneNormalDirection(2.0 * new_normal);
+    plane.updatePlaneFromPoints();
+
+    ASSERT_NEAR(plane.getPlaneNormal().normalized().dot(new_normal), 1.0, 1e-6);  // normal applied
+    ASSERT_TRUE(plane.getPlanePoint().isApprox(old_center, 1e-6));                // center preserved
+    ASSERT_TRUE(edge_lengths(plane.points()).isApprox(original_edges, 1e-6));     // shape preserved
+  }
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
* #2567 

Apply cutting plane table center/normal edits.

Edits to a cutting plane's center/normal in the Studio table previously had no effect. Now they update the plane and 3D view; Shape and Domain columns are read-only.