### PR TITLE
Fix Mac CI linking after SDK bump: rewrite ITK's hardcoded SDK .tbd paths

### DIFF
--- a/.github/workflows/build-mac-arm64.yml
+++ b/.github/workflows/build-mac-arm64.yml
@@ -72,6 +72,12 @@ jobs:
         path: /Users/runner/install
         key: ${{ runner.os }}-arm64-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
 
+    # Rewrite SDK-versioned libiconv.tbd/libm.tbd paths that ITK hardcodes to -l flags, so the
+    # cached dependencies keep linking after a runner Xcode/SDK bump. See issue #2570.
+    - name: Fix hardcoded SDK library paths in dependencies
+      shell: bash -l {0}
+      run: .github/workflows/fix_mac_dependency_paths.sh
+
     - name: cmake
       shell: bash -l {0}
       run: conda activate shapeworks && mkdir build && cd build && cmake -DCMAKE_LIBTOOL=/usr/bin/libtool -DCMAKE_CXX_FLAGS="-g -Wno-enum-constexpr-conversion" -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 -DCMAKE_PREFIX_PATH=$HOME/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPython3_ROOT_DIR:FILEPATH=${CONDA_PREFIX} -DUSE_OPENMP=OFF -DBuild_Studio=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/shapeworks-install -DBUILD_DOCUMENTATION=ON -DUSE_BUNDLED_PYTHON=ON -DGA_MEASUREMENT_ID=$GA_MEASUREMENT_ID -DGA_API_SECRET=$GA_API_SECRET ..

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -72,6 +72,12 @@ jobs:
         path: /Users/runner/install
         key: ${{ runner.os }}-intel-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
 
+    # Rewrite SDK-versioned libiconv.tbd/libm.tbd paths that ITK hardcodes to -l flags, so the
+    # cached dependencies keep linking after a runner Xcode/SDK bump. See issue #2570.
+    - name: Fix hardcoded SDK library paths in dependencies
+      shell: bash -l {0}
+      run: .github/workflows/fix_mac_dependency_paths.sh
+
     - name: cmake
       shell: bash -l {0}
       run: conda activate shapeworks && mkdir build && cd build && cmake -DCMAKE_LIBTOOL=/usr/bin/libtool -DCMAKE_CXX_FLAGS=-g -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 -DCMAKE_PREFIX_PATH=$HOME/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPython3_ROOT_DIR:FILEPATH=${CONDA_PREFIX} -DUSE_OPENMP=OFF -DBuild_Studio=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/shapeworks-install -DBUILD_DOCUMENTATION=OFF -DUSE_BUNDLED_PYTHON=ON -DGA_MEASUREMENT_ID=$GA_MEASUREMENT_ID -DGA_API_SECRET=$GA_API_SECRET ..

--- a/.github/workflows/fix_mac_dependency_paths.sh
+++ b/.github/workflows/fix_mac_dependency_paths.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Workaround for ITK's exported CMake targets hardcoding absolute paths to macOS SDK ".tbd" stub
+# libraries (e.g. libiconv.tbd, libm.tbd) in their INTERFACE_LINK_LIBRARIES. Our dependency install
+# is cached in CI keyed only on the dependency-script hashes, so when the GitHub runner's Xcode/SDK
+# is updated those absolute paths no longer exist and linking fails with, for example:
+#
+#   make: *** No rule to make target
+#     '/Applications/Xcode_16.4.app/.../SDKs/MacOSX15.5.sdk/usr/lib/libiconv.tbd', needed by '...'.
+#
+# These are standard system libraries, so rewrite the SDK-versioned absolute paths to plain
+# -l<name> link flags. The linker then resolves them regardless of the installed SDK version.
+#
+# See: https://github.com/SCIInstitute/ShapeWorks/issues/2570
+
+set -uo pipefail
+
+install_dir="${1:-$HOME/install}"
+
+if [[ ! -d "$install_dir" ]]; then
+  echo "install dir '$install_dir' not found; nothing to patch"
+  exit 0
+fi
+
+# find dependency files that reference an SDK .tbd system library by absolute path
+files=$(grep -rlE 'MacOSX[0-9.]*\.sdk/usr/lib/lib[A-Za-z0-9_+-]*\.tbd' "$install_dir" 2>/dev/null || true)
+
+if [[ -z "$files" ]]; then
+  echo "no hardcoded SDK .tbd library paths found under $install_dir"
+  exit 0
+fi
+
+for f in $files; do
+  sed -i.bak -E 's#/[^";[:space:]]*/MacOSX[0-9.]*\.sdk/usr/lib/lib([A-Za-z0-9_+-]*)\.tbd#-l\1#g' "$f"
+  rm -f "$f.bak"
+  echo "patched hardcoded SDK library paths in: $f"
+done


### PR DESCRIPTION
* #2570 

ITK's exported CMake targets hardcode absolute paths to macOS SDK stub libraries (libiconv.tbd, libm.tbd) in INTERFACE_LINK_LIBRARIES. The dependency install is cached keyed on the dependency-script hashes, so a runner Xcode/SDK bump leaves those absolute paths dangling and every Mac target that links ITK fails with "No rule to make target .../libiconv.tbd".

Add fix_mac_dependency_paths.sh to rewrite SDK-versioned system-library .tbd paths to -l flags, and run it in both Mac workflows after the dependency cache step (per-run, so it does not invalidate the cache).