### PR TITLE
Update GitHub Actions to Node 20 runtimes (#1909)

### DIFF
--- a/.github/workflows/build-linux-debug.yml
+++ b/.github/workflows/build-linux-debug.yml
@@ -46,7 +46,7 @@ jobs:
       run: df -h
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         lfs: true
 
@@ -65,7 +65,7 @@ jobs:
 
     - name: Restore Dependencies Cache
       id: cache-deps-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: /github/home/install
         key: ${{ runner.os }}-deps-debug-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
@@ -106,7 +106,7 @@ jobs:
 
     - name: Save Dependencies Cache
       if: steps.cache-deps-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: /github/home/install
         key: ${{ runner.os }}-deps-debug-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -44,7 +44,7 @@ jobs:
       run: df -h
       
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         lfs: true
 
@@ -63,7 +63,7 @@ jobs:
 
     - name: Restore Dependencies Cache
       id: cache-deps-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: /github/home/install
         key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
@@ -80,7 +80,7 @@ jobs:
 
     - name: Save Dependencies Cache
       if: steps.cache-deps-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: /github/home/install
         key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
@@ -136,15 +136,23 @@ jobs:
         name: artifact-${{github.sha}}-linux
         path: ${{runner.workspace}}/ShapeWorks/artifacts
 
+    - name: Remove previous dev release
+      if: github.ref == 'refs/heads/master'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: .github/workflows/delete_dev_release.sh dev-linux
+
     - name: Deploy
       id: deploy
       if: github.ref == 'refs/heads/master'
-      uses: marvinpinto/action-automatic-releases@latest
+      uses: softprops/action-gh-release@v2
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "dev-linux"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag_name: "dev-linux"
+        target_commitish: ${{ github.sha }}
         prerelease: true
-        title: "Development Build for Linux"
+        name: "Development Build for Linux"
         files: |
              ${{runner.workspace}}/ShapeWorks/artifacts/*.tar.gz
       

--- a/.github/workflows/build-mac-arm64.yml
+++ b/.github/workflows/build-mac-arm64.yml
@@ -42,7 +42,7 @@ jobs:
         brew install ccache pigz gnu-tar coreutils
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         lfs: true
 
@@ -55,7 +55,7 @@ jobs:
 
     - name: Restore Dependencies Cache
       id: cache-deps-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: /Users/runner/install
         key: ${{ runner.os }}-arm64-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
@@ -67,7 +67,7 @@ jobs:
 
     - name: Save Dependencies Cache
       if: steps.cache-deps-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: /Users/runner/install
         key: ${{ runner.os }}-arm64-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
@@ -129,15 +129,23 @@ jobs:
         name: artifact-${{github.sha}}-mac-arm64
         path: ${{runner.workspace}}/ShapeWorks/artifacts
 
+    - name: Remove previous dev release
+      if: github.ref == 'refs/heads/master'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: .github/workflows/delete_dev_release.sh dev-mac-arm64
+
     - name: Deploy
       id: deploy
       if: github.ref == 'refs/heads/master'
-      uses: marvinpinto/action-automatic-releases@latest
+      uses: softprops/action-gh-release@v2
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "dev-mac-arm64"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag_name: "dev-mac-arm64"
+        target_commitish: ${{ github.sha }}
         prerelease: true
-        title: "Development Build for Mac Arm64"
+        name: "Development Build for Mac Arm64"
         files: |
              ${{runner.workspace}}/ShapeWorks/artifacts/*.zip
              ${{runner.workspace}}/ShapeWorks/artifacts/*.pkg

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -43,7 +43,7 @@ jobs:
         brew install ccache pigz gnu-tar coreutils
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         lfs: true
 
@@ -56,7 +56,7 @@ jobs:
 
     - name: Restore Dependencies Cache
       id: cache-deps-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: /Users/runner/install
         key: ${{ runner.os }}-intel-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
@@ -67,7 +67,7 @@ jobs:
 
     - name: Save Dependencies Cache
       if: steps.cache-deps-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: /Users/runner/install
         key: ${{ runner.os }}-intel-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
@@ -129,15 +129,23 @@ jobs:
         name: artifact-${{github.sha}}-mac
         path: ${{runner.workspace}}/ShapeWorks/artifacts
 
+    - name: Remove previous dev release
+      if: github.ref == 'refs/heads/master'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: .github/workflows/delete_dev_release.sh dev-mac
+
     - name: Deploy
       id: deploy
       if: github.ref == 'refs/heads/master'
-      uses: marvinpinto/action-automatic-releases@latest
+      uses: softprops/action-gh-release@v2
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "dev-mac"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag_name: "dev-mac"
+        target_commitish: ${{ github.sha }}
         prerelease: true
-        title: "Development Build for Mac"
+        name: "Development Build for Mac"
         files: |
              ${{runner.workspace}}/ShapeWorks/artifacts/*.zip
              ${{runner.workspace}}/ShapeWorks/artifacts/*.pkg

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -68,7 +68,7 @@ jobs:
     #       miniconda-version: 'latest'
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         lfs: true
 
@@ -91,7 +91,7 @@ jobs:
 
     - name: Restore Dependencies Cache
       id: cache-deps-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: C:\deps
         key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
@@ -103,7 +103,7 @@ jobs:
 
     - name: Save Dependencies Cache
       if: steps.cache-deps-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: C:\deps
         key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
@@ -233,13 +233,21 @@ jobs:
       shell: bash -l {0}
       run: df -h
         
+    - name: Remove previous dev release
+      if: github.ref == 'refs/heads/master'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: .github/workflows/delete_dev_release.sh dev-windows
+
     - name: Deploy
       if: github.ref == 'refs/heads/master'
-      uses: marvinpinto/action-automatic-releases@latest
+      uses: softprops/action-gh-release@v2
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "dev-windows"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag_name: "dev-windows"
+        target_commitish: ${{ github.sha }}
         prerelease: true
-        title: "Development Build for Windows"
+        name: "Development Build for Windows"
         files: |
              d:/a/ShapeWorks/ShapeWorks/artifacts/*.exe

--- a/.github/workflows/delete_dev_release.sh
+++ b/.github/workflows/delete_dev_release.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Delete the existing rolling "dev-*" prerelease and its git tag so that
+# softprops/action-gh-release recreates the release/tag at the current commit.
+# Without this, an already-existing tag is not moved and the dev release would
+# keep pointing at a stale commit.
+#
+# Usage: delete_dev_release.sh <tag>
+# Requires: GH_TOKEN (GITHUB_TOKEN), GITHUB_REPOSITORY (provided by GitHub Actions)
+#
+# Note: no `set -x` here on purpose -- it would echo the auth header (token).
+
+echo "#############################"
+echo "# Delete previous dev release"
+echo "#############################"
+
+TAG="$1"
+if [[ -z "$TAG" ]]; then
+    echo "Usage: $0 <tag>"
+    exit 1
+fi
+if [[ -z "$GH_TOKEN" ]]; then
+    echo "GH_TOKEN not set; skipping dev release cleanup"
+    exit 0
+fi
+
+API="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+AUTH="Authorization: token ${GH_TOKEN}"
+
+# Find and delete the existing release for this rolling tag (if any).
+release_id=$(curl -sS -H "$AUTH" "${API}/releases/tags/${TAG}" \
+    | grep -m1 '"id":' | grep -o '[0-9]\+' | head -1 || true)
+
+if [[ -n "$release_id" ]]; then
+    echo "Deleting existing release ${release_id} for tag ${TAG}"
+    curl -sS -o /dev/null -w "delete release HTTP %{http_code}\n" \
+        -X DELETE -H "$AUTH" "${API}/releases/${release_id}" || true
+else
+    echo "No existing release found for tag ${TAG}"
+fi
+
+# Delete the tag ref so the tag is recreated at the current commit on deploy.
+echo "Deleting tag ref ${TAG} (if present)"
+curl -sS -o /dev/null -w "delete tag ref HTTP %{http_code}\n" \
+    -X DELETE -H "$AUTH" "${API}/git/refs/tags/${TAG}" || true
+
+echo "Dev release cleanup complete for ${TAG}"
+exit 0


### PR DESCRIPTION
* #1909 

Move all workflow actions off deprecated Node 12/16 runtimes:
- actions/checkout@v3 -> @v4
- actions/cache/{restore,save}@v3 -> @v4 (cache <v4 no longer works)
- marvinpinto/action-automatic-releases@latest (archived, Node 16) -> softprops/action-gh-release@v2

Add delete_dev_release.sh plus a cleanup step before each Deploy so the rolling dev-* release and tag are recreated at the current commit, with target_commitish pinning the new tag to the built commit.