### PR TITLE
Add minimum_size option to Image::isolate() (#2324)

### DIFF
--- a/Applications/shapeworks/ImageCommands.cpp
+++ b/Applications/shapeworks/ImageCommands.cpp
@@ -1362,8 +1362,10 @@ bool ImageToMesh::execute(const optparse::Values &options, SharedCommandData &sh
 void Isolate::buildParser()
 {
   const std::string prog = "isolate";
-  const std::string desc = "finds the largest object in a binary segmentation and removes all other objects";
+  const std::string desc = "finds the largest object in a binary segmentation and removes all other objects (or, with --minsize, keeps every object at least that many voxels)";
   parser.prog(prog).description(desc);
+
+  parser.add_option("--minsize").action("store").type("int").set_default(0).help("Keep every connected component with at least this many voxels; 0 keeps only the largest object [default: %default].");
 
   Command::buildParser();
 }
@@ -1376,7 +1378,9 @@ bool Isolate::execute(const optparse::Values &options, SharedCommandData &shared
     return false;
   }
 
-  sharedData.image.isolate();
+  int minsize = static_cast<int>(options.get("minsize"));
+
+  sharedData.image.isolate(minsize);
   return true;
 }
 

--- a/Libs/Image/Image.cpp
+++ b/Libs/Image/Image.cpp
@@ -22,6 +22,7 @@
 #include <itkIntensityWindowingImageFilter.h>
 #include <itkMultiplyImageFilter.h>
 #include <itkNearestNeighborInterpolateImageFunction.h>
+#include <itkNumericTraits.h>
 #include <itkOrientImageFilter.h>
 #include <itkRegionOfInterestImageFilter.h>
 #include <itkReinitializeLevelSetImageFilter.h>
@@ -30,7 +31,6 @@
 #include <itkScalableAffineTransform.h>
 #include <itkSigmoidImageFilter.h>
 #include <itkTestingComparisonImageFilter.h>
-#include <itkThresholdImageFilter.h>
 #include <itkVTKImageExport.h>
 #include <itkVTKImageToImageFilter.h>
 #include <vtkCleanPolyData.h>
@@ -870,9 +870,10 @@ Image& Image::setCoordsys(ImageType::DirectionType coordsys) {
   return *this;
 }
 
-Image& Image::isolate() {
+Image& Image::isolate(int64_t minimum_size) {
   TIME_SCOPE("Image::isolate");
-  typedef itk::Image<unsigned char, 3> IsolateType;
+  // Use a wide label type so noisy segmentations with many components don't overflow.
+  typedef itk::Image<unsigned int, 3> IsolateType;
   typedef itk::CastImageFilter<ImageType, IsolateType> ToIntType;
   ToIntType::Pointer filter = ToIntType::New();
   filter->SetInput(this->itk_image_);
@@ -887,13 +888,21 @@ Image& Image::isolate() {
   auto relabel = itk::RelabelComponentImageFilter<IsolateType, IsolateType>::New();
   relabel->SetInput(cc->GetOutput());
   relabel->SortByObjectSizeOn();
+  if (minimum_size > 0) {
+    // Discard components smaller than minimum_size (they are relabeled to background).
+    relabel->SetMinimumObjectSize(minimum_size);
+  }
   relabel->Update();
 
-  auto thresh = itk::ThresholdImageFilter<IsolateType>::New();
+  // Components are sorted largest-first (label 1 = largest). With the default minimum_size of 0
+  // keep only the largest object; otherwise keep every component that survived the size filter.
+  const unsigned int upper = (minimum_size > 0) ? itk::NumericTraits<unsigned int>::max() : 1u;
+  auto thresh = itk::BinaryThresholdImageFilter<IsolateType, IsolateType>::New();
   thresh->SetInput(relabel->GetOutput());
+  thresh->SetLowerThreshold(1);
+  thresh->SetUpperThreshold(upper);
+  thresh->SetInsideValue(1);
   thresh->SetOutsideValue(0);
-  thresh->ThresholdBelow(0);
-  thresh->ThresholdAbove(1);
   thresh->Update();
 
   auto cast = itk::CastImageFilter<IsolateType, ImageType>::New();

--- a/Libs/Image/Image.h
+++ b/Libs/Image/Image.h
@@ -9,6 +9,7 @@
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>
 
+#include <cstdint>
 #include <limits>
 
 #include "Region.h"
@@ -207,8 +208,9 @@ class Image {
   /// sets the coordinate system in which this image lives in physical space
   Image& setCoordsys(ImageType::DirectionType coordsys);
 
-  /// isolate the largest object in a binary segmentation
-  Image& isolate();
+  /// isolate objects in a binary segmentation. By default (minimum_size == 0) only the single largest
+  /// object is kept; if minimum_size > 0, every connected component with at least that many voxels is kept.
+  Image& isolate(int64_t minimum_size = 0);
 
   // query functions //
 

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -558,7 +558,10 @@ PYBIND11_MODULE(shapeworks_py, m) {
           "toMesh", [](Image& image, Image::PixelType isovalue) { return image.toMesh(isovalue); },
           "converts image to mesh at specified isovalue", "isovalue"_a)
 
-      .def("isolate", &Image::isolate, "isolate largest object")
+      .def("isolate", &Image::isolate,
+           "isolate the largest object (minimum_size=0), or keep every connected component with at least "
+           "minimum_size voxels",
+           "minimum_size"_a = 0)
 
       .def(
           "evaluate",

--- a/Testing/ImageTests/ImageTests.cpp
+++ b/Testing/ImageTests/ImageTests.cpp
@@ -1129,6 +1129,27 @@ TEST(ImageTests, isolateTest1) {
   ASSERT_TRUE(image == ground_truth);
 }
 
+TEST(ImageTests, isolateMinimumSizeTest) {
+  const std::string input = std::string(TEST_DATA_DIR) + "/isolate_input.nrrd";
+  Image ground_truth(std::string(TEST_DATA_DIR) + "/isolate_output.nrrd");
+
+  // minimum_size == 0 preserves the default behavior: keep only the largest object
+  Image default_behavior(input);
+  default_behavior.isolate(0);
+  ASSERT_TRUE(default_behavior == ground_truth);
+
+  // a positive minimum_size keeps every component at least that large, so the smaller objects the
+  // default discards are retained -- the result must therefore differ from the largest-only output
+  Image keep_all(input);
+  keep_all.isolate(1);
+  ASSERT_FALSE(keep_all == ground_truth);
+
+  // a minimum_size larger than every component removes everything, leaving an empty (all-zero) image
+  Image empty(input);
+  empty.isolate(std::numeric_limits<int64_t>::max());
+  ASSERT_EQ(empty.max(), 0.0f);
+}
+
 TEST(ImageTests, evaluateTest) {
   Image image(std::string(TEST_DATA_DIR) + "/computedt2.nrrd");
   Point pt1({37.0, 46.0, 50.0});    // outside close


### PR DESCRIPTION
* #2324 

isolate() now takes an optional minimum_size (default 0). With 0 it keeps only the largest object, exactly as before; with a positive value it keeps every connected component of at least that many voxels, which is useful for cleaning up noisy segmentations. Widen the intermediate label type from unsigned char to unsigned int so segmentations with many components don't overflow. Exposed through the Python binding (minimum_size=0) and the CLI (--minsize), and covered by a new ImageTests case.