### PR TITLE
Auto-set distance field and default setField type (#1939)

### DIFF
--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -947,10 +947,14 @@ PYBIND11_MODULE(shapeworks_py, m) {
           "distance",
           [](Mesh& mesh, const Mesh& target, const Mesh::DistanceMethod method) -> decltype(auto) {
             auto distances_and_ids = mesh.distance(target, method);
-            return py::make_tuple(arrToPy(distances_and_ids[0], MOVE_ARRAY), arrToPy(distances_and_ids[1], MOVE_ARRAY));
+            // Also store the distances as a "distance" point field so the result can be written directly
+            // as a heat map (e.g. mesh.distance(other); mesh.write(...)). See issue #1939.
+            mesh.setField("distance", distances_and_ids[0], Mesh::FieldType::Point);
+            return py::make_tuple(arrToPy(distances_and_ids[0], COPY_ARRAY), arrToPy(distances_and_ids[1], MOVE_ARRAY));
           },
-          "computes closest distance from vertices of this mesh to target mesh, returning indices of faces or vertices "
-          "in target mesh that contain closest points",
+          "computes closest distance from vertices of this mesh to target mesh, returning the distances and the "
+          "indices of faces or vertices in the target mesh that contain the closest points; the distances are also "
+          "stored on this mesh as a 'distance' point field",
           "target"_a, "method"_a = Mesh::DistanceMethod::PointToCell)
 
       .def(
@@ -1080,7 +1084,8 @@ PYBIND11_MODULE(shapeworks_py, m) {
             auto vtkarr = pyToArr(array);
             return mesh.setField(name, vtkarr, type);
           },
-          "sets the given field for points with array", "name"_a, "array"_a, "type"_a)
+          "sets the given field for points with array (type defaults to Point)", "name"_a, "array"_a,
+          "type"_a = Mesh::FieldType::Point)
 
       .def(
           "getField",

--- a/Testing/PythonTests/distance.py
+++ b/Testing/PythonTests/distance.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import numpy as np
 from shapeworks import *
 
 success = True
@@ -35,5 +36,27 @@ def distanceTest2():
   return femur1 == fwd and femur2 == rev
 
 success &= utils.test(distanceTest2)
+
+# issue #1939: distance() should store the result as a "distance" point field automatically,
+# without a separate setField call
+def distanceAutoFieldTest():
+  femur1 = Mesh(os.environ["DATA"] + "/m03_L_femur.ply")
+  femur2 = Mesh(os.environ["DATA"] + "/m04_L_femur.ply")
+  distances, ids = femur1.distance(femur2)
+  field = femur1.getField("distance", Mesh.Point)
+  return np.allclose(np.asarray(field).ravel(), np.asarray(distances).ravel())
+
+success &= utils.test(distanceAutoFieldTest)
+
+# issue #1939: setField's type argument should default to Point
+def setFieldDefaultTypeTest():
+  femur1 = Mesh(os.environ["DATA"] + "/m03_L_femur.ply")
+  femur2 = Mesh(os.environ["DATA"] + "/m04_L_femur.ply")
+  distances, ids = femur1.distance(femur2)
+  femur1.setField("my_distance", distances)  # no explicit type -> defaults to Point
+  field = femur1.getField("my_distance", Mesh.Point)
+  return np.allclose(np.asarray(field).ravel(), np.asarray(distances).ravel())
+
+success &= utils.test(setFieldDefaultTypeTest)
 
 sys.exit(not success)


### PR DESCRIPTION
* #1939 

Mesh.distance() now also stores its result as a "distance" point field on the mesh, so the heat map can be written directly (mesh.distance(other); mesh.write(...)) without a separate setField call. Mesh.setField()'s type argument now defaults to Point. Both are Python-API conveniences; the distance() return value is unchanged, so existing code keeps working. Covered by two new distance.py tests.