### PR TITLE
Add Image.getDICOMSeriesUIDs to query DICOM series (#2317)

### DIFF
--- a/Libs/Image/Image.cpp
+++ b/Libs/Image/Image.cpp
@@ -328,6 +328,20 @@ Image::ImageType::Pointer Image::readDICOMImage(const std::string& pathname) {
   return reader->GetOutput();
 }
 
+std::vector<std::string> Image::getDICOMSeriesUIDs(const std::string& pathname) {
+  if (pathname.empty()) {
+    throw std::invalid_argument("Empty pathname");
+  }
+
+  auto names_generator = itk::GDCMSeriesFileNames::New();
+  names_generator->SetUseSeriesDetails(true);
+  names_generator->AddSeriesRestriction("0008|0021");  // group DICOM files by series date
+  names_generator->SetGlobalWarningDisplay(false);
+  names_generator->SetDirectory(pathname);
+
+  return names_generator->GetSeriesUIDs();
+}
+
 Image& Image::write(const std::string& filename, bool compressed) {
   TIME_SCOPE("Image::write");
   if (!this->itk_image_) {

--- a/Libs/Image/Image.h
+++ b/Libs/Image/Image.h
@@ -315,6 +315,9 @@ class Image {
     return {"nrrd", "nii", "nii.gz", "mhd", "tiff", "jpeg", "jpg", "png", "dcm", "ima"};
   }
 
+  //! Return the DICOM series UIDs found in the given directory
+  static std::vector<std::string> getDICOMSeriesUIDs(const std::string& pathname);
+
   //! Return if the file type is supported
   static bool isSupportedType(const std::string& filename) {
     for (const auto& type : Image::getSupportedTypes()) {

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -117,6 +117,9 @@ PYBIND11_MODULE(shapeworks_py, m) {
       .def(py::init<const std::string&>())
       .def(py::init<const Image&>())
 
+      .def_static("getDICOMSeriesUIDs", &Image::getDICOMSeriesUIDs,
+                  "return the list of DICOM series UIDs found in the given directory", "pathname"_a)
+
       // constructor that wraps numpy float32 array
       .def(py::init
            // The reasons we don't simply specify py::array_t<float>

--- a/Testing/ImageTests/ImageTests.cpp
+++ b/Testing/ImageTests/ImageTests.cpp
@@ -13,6 +13,12 @@ TEST(ImageTests, dicomReadTest) {
   ASSERT_TRUE(image == ground_truth);
 }
 
+TEST(ImageTests, dicomSeriesUIDsTest) {
+  auto uids = Image::getDICOMSeriesUIDs(std::string(TEST_DATA_DIR) + "/dcm_files");
+  ASSERT_FALSE(uids.empty());
+  ASSERT_FALSE(uids[0].empty());
+}
+
 TEST(ImageTests, readTest) {
   try {
     Image image(std::string(TEST_DATA_DIR) + "foo.nrrd");

--- a/Testing/PythonTests/PythonTests.cpp
+++ b/Testing/PythonTests/PythonTests.cpp
@@ -82,6 +82,10 @@ TEST(pythonTests, imageInfoTest) {
   run_test("imageinfo.py");
 }
 
+TEST(pythonTests, dicomSeriesTest) {
+  run_test("dicomseries.py");
+}
+
 TEST(pythonTests, meshInfoTest) {
   run_test("meshinfo.py");
 }

--- a/Testing/PythonTests/dicomseries.py
+++ b/Testing/PythonTests/dicomseries.py
@@ -1,0 +1,13 @@
+import os
+import sys
+from shapeworks import *
+
+success = True
+
+def dicomSeriesUIDsTest():
+  uids = Image.getDICOMSeriesUIDs(os.environ["DATA"] + "/dcm_files")
+  return len(uids) > 0 and len(uids[0]) > 0
+
+success &= utils.test(dicomSeriesUIDsTest)
+
+sys.exit(not success)


### PR DESCRIPTION
* #2317

Add a static Image::getDICOMSeriesUIDs(directory) that returns the DICOM series UIDs found in a directory (via GDCMSeriesFileNames), exposed to the Python API as Image.getDICOMSeriesUIDs(). Covered by a C++ ImageTests case and a new dicomseries.py Python test using the existing dcm_files data.