### PR TITLE
Add median shape to the Python analysis API (#2320)

### DIFF
--- a/Libs/Analyze/Analyze.cpp
+++ b/Libs/Analyze/Analyze.cpp
@@ -349,6 +349,30 @@ ShapeHandle Analyze::get_mean_shape() {
 }
 
 //---------------------------------------------------------------------------
+Particles Analyze::get_median_shape_points() {
+  SW_DEBUG("get_median_shape_points");
+  if (!compute_stats()) {
+    return Particles();
+  }
+
+  int median = stats_.compute_median_shape(-32);  // -32 = median over all shapes (both groups)
+  auto shapes = get_shapes();
+  if (median < 0 || median >= static_cast<int>(shapes.size())) {
+    SW_ERROR("Unable to compute median shape, stats returned an invalid median index");
+    return Particles();
+  }
+
+  return shapes[median]->get_particles();
+}
+
+//---------------------------------------------------------------------------
+ShapeHandle Analyze::get_median_shape() {
+  SW_DEBUG("get_median_shape");
+  auto shape_points = get_median_shape_points();
+  return create_shape_from_points(shape_points);
+}
+
+//---------------------------------------------------------------------------
 Particles Analyze::get_shape_points(int mode, double value) {
   if (!compute_stats() || stats_.get_eigen_vectors().size() <= 1) {
     return Particles();

--- a/Libs/Analyze/Analyze.h
+++ b/Libs/Analyze/Analyze.h
@@ -45,6 +45,12 @@ class Analyze {
   /// Return the mean shape
   ShapeHandle get_mean_shape();
 
+  /// Return the median shape (the sample with minimum L1 distance to all others) as particle points
+  Particles get_median_shape_points();
+
+  /// Return the median shape as a reconstructed mesh
+  ShapeHandle get_median_shape();
+
   Particles get_group_shape_particles(double ratio);
   ShapeHandle get_group_shape(double ratio);
 

--- a/Libs/Python/PythonAnalyze.cpp
+++ b/Libs/Python/PythonAnalyze.cpp
@@ -3,14 +3,31 @@
 #include "PythonAnalyze.h"
 
 #include <Analyze/Analyze.h>
+#include <Analyze/Particles.h>
 #include <Analyze/Shape.h>
 #include <pybind11/eigen.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 using namespace pybind11::literals;
 using namespace shapeworks;
 
 void define_python_analyze(py::module_ m) {
+  // Particles and Shape must be registered so that Analyze methods returning them (get_shapes,
+  // get_mode_shape, create_shape_from_points, ...) can be used from Python.
+  py::class_<Particles>(m, "Particles")
+      .def("get_combined_global_particles", &Particles::get_combined_global_particles,
+           "combined world particles across all domains as a flat vector")
+      .def("get_combined_local_particles", &Particles::get_combined_local_particles,
+           "combined local particles across all domains as a flat vector")
+      .def("get_number_of_domains", &Particles::get_number_of_domains)
+      .def("get_total_number_of_particles", &Particles::get_total_number_of_particles);
+
+  py::class_<Shape, std::shared_ptr<Shape>>(m, "Shape")
+      .def("get_id", &Shape::get_id)
+      .def("get_display_name", &Shape::get_display_name)
+      .def("get_particles", &Shape::get_particles, "returns the particles for this shape");
+
   py::class_<Analyze>(m, "Analyze")
       .def(py::init<ProjectHandle>())
       .def("get_mean_shape",

--- a/Libs/Python/PythonAnalyze.cpp
+++ b/Libs/Python/PythonAnalyze.cpp
@@ -29,6 +29,19 @@ void define_python_analyze(py::module_ m) {
              auto particles = analyze.get_mean_shape_points();
              return particles.get_combined_global_particles();
            })
+      .def("get_median_shape_points",
+           [](Analyze& analyze) -> decltype(auto) {
+             auto particles = analyze.get_median_shape_points();
+             return particles.get_combined_global_particles();
+           })
+      .def("get_median_shape",
+           [](Analyze& analyze) {
+             auto mesh_group = analyze.get_median_shape()->get_reconstructed_meshes(true);
+             if (!mesh_group.valid()) {
+               throw std::runtime_error("Invalid mesh group");
+             }
+             return Mesh(mesh_group.meshes()[0]->get_poly_data());
+           })
       .def("get_shape_points", &Analyze::get_shape_points)
       .def("get_mode_shape", &Analyze::get_mode_shape)
       .def("groups_active", &Analyze::groups_active)

--- a/Testing/PythonTests/PythonTests.cpp
+++ b/Testing/PythonTests/PythonTests.cpp
@@ -90,6 +90,10 @@ TEST(pythonTests, medianShapeTest) {
   run_test("median.py");
 }
 
+TEST(pythonTests, getShapesTest) {
+  run_test("get_shapes.py");
+}
+
 TEST(pythonTests, meshInfoTest) {
   run_test("meshinfo.py");
 }

--- a/Testing/PythonTests/PythonTests.cpp
+++ b/Testing/PythonTests/PythonTests.cpp
@@ -86,6 +86,10 @@ TEST(pythonTests, dicomSeriesTest) {
   run_test("dicomseries.py");
 }
 
+TEST(pythonTests, medianShapeTest) {
+  run_test("median.py");
+}
+
 TEST(pythonTests, meshInfoTest) {
   run_test("meshinfo.py");
 }

--- a/Testing/PythonTests/get_shapes.py
+++ b/Testing/PythonTests/get_shapes.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import numpy as np
+from shapeworks import *
+
+success = True
+
+def getShapesTest():
+  # the project's particle paths are relative, so load from its directory
+  os.chdir(os.environ["DATA"] + "/shapeworksTests/analyze")
+  project = Project()
+  project.load("ellipsoid.swproj")
+  analyze = Analyze(project)
+
+  shapes = analyze.get_shapes()
+  if len(shapes) != analyze.get_num_subjects():
+    return False
+
+  for shape in shapes:
+    pts = np.asarray(shape.get_particles().get_combined_global_particles()).ravel()
+    if len(pts) == 0 or not np.all(np.isfinite(pts)):
+      return False
+    # id / name accessors should work
+    shape.get_id()
+    shape.get_display_name()
+
+  return True
+
+success &= utils.test(getShapesTest)
+
+sys.exit(not success)

--- a/Testing/PythonTests/median.py
+++ b/Testing/PythonTests/median.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import numpy as np
+from shapeworks import *
+
+success = True
+
+def medianShapeTest():
+  # the project's particle paths are relative, so load from its directory (as the CLI analyze test does)
+  os.chdir(os.environ["DATA"] + "/shapeworksTests/analyze")
+  project = Project()
+  project.load("ellipsoid.swproj")
+  analyze = Analyze(project)
+
+  mean = np.asarray(analyze.get_mean_shape_points()).ravel()
+  median = np.asarray(analyze.get_median_shape_points()).ravel()
+
+  # the median shape is an actual sample: same size as the mean, finite, and (for this data) distinct from it
+  if len(median) == 0 or len(median) != len(mean) or not np.all(np.isfinite(median)):
+    return False
+  if np.allclose(mean, median):
+    return False
+
+  # the reconstructed median mesh should be valid
+  mesh = analyze.get_median_shape()
+  return mesh.numPoints() > 0
+
+success &= utils.test(medianShapeTest)
+
+sys.exit(not success)


### PR DESCRIPTION
* #2320

Add Analyze::get_median_shape_points() and Analyze::get_median_shape(), exposed to the Python API as sw.Analyze.get_median_shape_points() and get_median_shape(). The median shape is the sample with the minimum sum of L1 distances to all others (via ParticleShapeStatistics::compute_median_shape), mirroring the existing get_mean_shape_points()/get_mean_shape() pair. Covered by a new median.py Python test.