### PR TITLE
Studio: add "Export All Meshes" (#2281)

### DIFF
--- a/Studio/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/Interface/ShapeWorksStudioApp.cpp
@@ -535,6 +535,7 @@ void ShapeWorksStudioApp::disable_all_actions() {
   ui_->action_save_project->setEnabled(false);
   ui_->menu_save_project_as->setEnabled(false);
   ui_->actionExport_PCA_Mesh->setEnabled(false);
+  ui_->action_export_all_meshes->setEnabled(false);
   ui_->actionExport_Eigenvalues->setEnabled(false);
   ui_->actionExport_Eigenvectors->setEnabled(false);
   ui_->actionExport_PCA_Mode_Points->setEnabled(false);
@@ -572,6 +573,7 @@ void ShapeWorksStudioApp::enable_possible_actions() {
   ui_->action_save_project->setEnabled(save_enabled);
   ui_->menu_save_project_as->setEnabled(true);
   ui_->actionExport_PCA_Mesh->setEnabled(analysis_ready);
+  ui_->action_export_all_meshes->setEnabled(analysis_ready);
   ui_->actionExport_Eigenvalues->setEnabled(analysis_ready);
   ui_->actionExport_Eigenvectors->setEnabled(analysis_ready);
   ui_->actionExport_PCA_Mode_Points->setEnabled(analysis_ready);
@@ -1720,6 +1722,55 @@ void ShapeWorksStudioApp::action_export_current_mesh_triggered(int index, bool c
       SW_MESSAGE("Wrote: " + name.toStdString());
     }
   }
+}
+
+//---------------------------------------------------------------------------
+void ShapeWorksStudioApp::on_action_export_all_meshes_triggered() {
+  auto shapes = session_->get_shapes();
+  if (shapes.empty()) {
+    SW_ERROR("No meshes to export");
+    return;
+  }
+
+  QString filename =
+      ExportUtils::get_save_filename(this, tr("Export All Meshes"), ExportUtils::get_mesh_file_filter(), ".vtk");
+  if (filename.isEmpty()) {
+    return;
+  }
+
+  // the chosen filename is used as a prefix; each subject's mesh is written as <base>_<subject>.<ext>
+  // (matching Export All Subjects Particle Scalars)
+  QFileInfo fi(filename);
+  QString base = fi.path() + QDir::separator() + fi.completeBaseName();
+  QString suffix = fi.completeSuffix();
+  auto domain_names = session_->get_project()->get_domain_names();
+  bool multi_domain = domain_names.size() > 1;
+
+  int count = 0;
+  for (auto& shape : shapes) {
+    // the reconstructed meshes are the per-subject shape-model meshes (one per domain)
+    auto mesh_group = shape->get_reconstructed_meshes(true);
+    if (!mesh_group.valid()) {
+      SW_ERROR("Unable to export mesh for " + shape->get_display_name() + ": not ready");
+      return;
+    }
+    auto meshes = mesh_group.meshes();
+    QString subject = QString::fromStdString(shape->get_display_name());
+    for (int domain = 0; domain < static_cast<int>(meshes.size()); domain++) {
+      QString name = base + "_" + subject;
+      if (multi_domain) {
+        name += "_" + QString::fromStdString(domain_names[domain]);
+      }
+      name += "." + suffix;
+
+      if (!StudioUtils::write_mesh(meshes[domain]->get_poly_data(), name)) {
+        return;
+      }
+      SW_MESSAGE("Wrote: " + name.toStdString());
+      count++;
+    }
+  }
+  SW_MESSAGE("Exported " + std::to_string(count) + " meshes");
 }
 
 //---------------------------------------------------------------------------

--- a/Studio/Interface/ShapeWorksStudioApp.h
+++ b/Studio/Interface/ShapeWorksStudioApp.h
@@ -91,6 +91,7 @@ class ShapeWorksStudioApp : public QMainWindow {
   void on_actionExport_PCA_Mode_Points_triggered();
   void on_action_preferences_triggered();
   void action_export_current_mesh_triggered(int index = 0, bool clip_constraints = false);
+  void on_action_export_all_meshes_triggered();
   void on_action_export_current_particles_triggered();
   void on_action_export_mesh_scalars_triggered();
   void on_action_export_pca_scores_triggered();

--- a/Studio/Interface/ShapeWorksStudioApp.ui
+++ b/Studio/Interface/ShapeWorksStudioApp.ui
@@ -750,6 +750,7 @@ QToolBar QToolButton::checked {
      </property>
      <addaction name="action_export_current_mesh"/>
      <addaction name="action_export_current_mesh_clipped"/>
+     <addaction name="action_export_all_meshes"/>
      <addaction name="action_export_current_particles"/>
      <addaction name="action_export_particle_scalars"/>
      <addaction name="action_export_mesh_scalars"/>
@@ -1135,6 +1136,11 @@ QToolBar QToolButton::checked {
   <action name="action_export_current_mesh">
    <property name="text">
     <string>Export Current Mesh...</string>
+   </property>
+  </action>
+  <action name="action_export_all_meshes">
+   <property name="text">
+    <string>Export All Meshes...</string>
    </property>
   </action>
   <action name="action_export_mesh_scalars">


### PR DESCRIPTION
* #2281

Add a File -> Export -> Export All Meshes... action that writes the reconstructed mesh for every subject in the project. The chosen filename is used as a prefix and each mesh is written as <base>_<subject>.<ext> (with an extra _<domain> for multi-domain projects), matching the existing "Export All Subjects Particle Scalars" behavior. Previously only the currently- displayed mesh could be exported; the old "Export PCA Mesh" handler was buggy (domain 0 only, leaked its writer) and unreachable. The action is enabled alongside the other analysis exports.