### PR TITLE
Verify fixed-domain particle counts match number_of_particles (#2192)

### DIFF
--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -561,6 +561,39 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
   }
 
   if (project_->get_fixed_subjects_present()) {
+    // #2192: fixed-domain particles are pre-optimized and are not re-split during
+    // optimization, so the requested number of particles must match the existing
+    // (original) particle count.  A mismatch otherwise silently produces a broken
+    // model, so reject the inconsistent configuration up front.
+    auto requested = get_number_of_particles();
+    for (const auto& s : subjects) {
+      if (!s->is_fixed()) {
+        continue;
+      }
+      const auto& particle_files = s->get_local_particle_filenames();
+      for (int d = 0; d < domains_per_shape; d++) {
+        if (d >= static_cast<int>(particle_files.size())) {
+          continue;  // missing particle files are reported elsewhere
+        }
+        int expected = 0;
+        if (requested.size() == static_cast<size_t>(domains_per_shape)) {
+          expected = requested[d];
+        } else if (requested.size() == 1) {
+          expected = requested[0];
+        } else {
+          continue;  // parameter/domain count mismatch is reported by the optimizer
+        }
+        int actual = static_cast<int>(read_particles_as_vector(particle_files[d]).size());
+        if (actual != expected) {
+          throw std::invalid_argument(
+              "Fixed domain particle count mismatch: subject '" + s->get_display_name() + "' domain " +
+              std::to_string(d) + " has " + std::to_string(actual) + " particles, but number_of_particles is set to " +
+              std::to_string(expected) +
+              ". When using fixed domains, the number of particles must match the original model.");
+        }
+      }
+    }
+
     int idx = 0;
     std::vector<int> fixed_domains;
 

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -173,6 +173,25 @@ TEST(OptimizeTests, fixed_domain) {
 }
 
 //---------------------------------------------------------------------------
+// #2192: when using fixed domains, the requested number of particles must match
+// the existing (original) particle count.  A mismatch should be reported as an
+// error rather than silently producing a broken model.
+TEST(OptimizeTests, fixed_domain_particle_count_mismatch) {
+  prep_temp("/optimize/fixed_domain", "fixed_domain_particle_count_mismatch");
+
+  Optimize app;
+  ProjectHandle project = std::make_shared<Project>();
+  ASSERT_TRUE(project->load("optimize.swproj"));
+  OptimizeParameters params(project);
+
+  // the fixed shapes have 32 particles; request a different count
+  params.set_number_of_particles({64});
+
+  // set_up_optimize should refuse the inconsistent configuration
+  EXPECT_THROW(params.set_up_optimize(&app), std::invalid_argument);
+}
+
+//---------------------------------------------------------------------------
 TEST(OptimizeTests, fixed_domain_procrustes) {
   prep_temp("/optimize/fixed_domain", "fixed_domain_procrustes");
 


### PR DESCRIPTION
* #2192 

When running with fixed domains, the fixed shapes' particles are pre-optimized and are never re-split. If the user requests a number_of_particles that differs from the original (fixed) model's particle count, optimization silently produces a broken model.

OptimizeParameters::set_up_optimize now checks each fixed subject's particle count against the requested number_of_particles (per domain) and throws a clear std::invalid_argument on mismatch, before any heavy loading.

Adds OptimizeTests.fixed_domain_particle_count_mismatch, which loads the existing fixed_domain project (32 particles), requests 64, and expects the setup to be rejected.