### PR TITLE
CI/CD Deps update

### DIFF
--- a/.github/workflows/build-linux-debug.yml
+++ b/.github/workflows/build-linux-debug.yml
@@ -16,6 +16,9 @@ env:
   BUILD_TYPE: Debug
   SW_CLOUD_LOGIN: ${{ secrets.CLOUD_LOGIN }}
   CACHE_HOST: ${{ secrets.SSH_HOST }}
+  CCACHE_DIR: /github/home/.ccache
+  CCACHE_MAXSIZE: "500M"
+  CCACHE_COMPRESS: "true"
 #  LD_LIBRARY_PATH: /opt/conda/envs/shapeworks/lib
 
 concurrency:
@@ -121,9 +124,30 @@ jobs:
     - name: Check space6
       run: df -h
 
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /github/home/.ccache
+        key: ${{ runner.os }}-ccache-debug-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-debug-
+
     - name: make
       shell: bash -l {0}
       run: conda activate shapeworks && cd build && make -j2
+
+    - name: ccache stats
+      if: always()
+      shell: bash -l {0}
+      run: ccache -s || true
+
+    - name: Save ccache
+      if: always()
+      continue-on-error: true
+      uses: actions/cache/save@v4
+      with:
+        path: /github/home/.ccache
+        key: ${{ runner.os }}-ccache-debug-${{ github.sha }}
 
     - name: Check space7
       run: df -h

--- a/.github/workflows/build-linux-debug.yml
+++ b/.github/workflows/build-linux-debug.yml
@@ -68,7 +68,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: /github/home/install
-        key: ${{ runner.os }}-deps-debug-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-deps-debug-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
 
     - name: Check space3.5
       run: df -h
@@ -109,7 +109,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: /github/home/install
-        key: ${{ runner.os }}-deps-debug-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-deps-debug-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
 
     - name: Check space5
       run: df -h

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: /github/home/install
-        key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
 
     - name: try import vtk
       shell: bash -l {0}
@@ -83,7 +83,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: /github/home/install
-        key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/Dockerfile', '.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
 
     - name: Check space4
       run: df -h

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -18,6 +18,9 @@ env:
   CACHE_HOST: ${{ secrets.SSH_HOST }}
   GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
   GA_API_SECRET: ${{ secrets.GA_API_SECRET }}
+  CCACHE_DIR: /github/home/.ccache
+  CCACHE_MAXSIZE: "500M"
+  CCACHE_COMPRESS: "true"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -95,9 +98,30 @@ jobs:
     - name: Check space5
       run: df -h
 
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /github/home/.ccache
+        key: ${{ runner.os }}-ccache-release-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-release-
+
     - name: make
       shell: bash -l {0}
       run: conda activate shapeworks && cd build && make -j4
+
+    - name: ccache stats
+      if: always()
+      shell: bash -l {0}
+      run: ccache -s || true
+
+    - name: Save ccache
+      if: always()
+      continue-on-error: true
+      uses: actions/cache/save@v4
+      with:
+        path: /github/home/.ccache
+        key: ${{ runner.os }}-ccache-release-${{ github.sha }}
 
     - name: Install bundled Python packages
       shell: bash -l {0}

--- a/.github/workflows/build-mac-arm64.yml
+++ b/.github/workflows/build-mac-arm64.yml
@@ -58,7 +58,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: /Users/runner/install
-        key: ${{ runner.os }}-arm64-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-arm64-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
 
     - name: Build Dependencies
       if: steps.cache-deps-restore.outputs.cache-hit != 'true'
@@ -70,7 +70,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: /Users/runner/install
-        key: ${{ runner.os }}-arm64-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-arm64-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
 
     # Rewrite SDK-versioned libiconv.tbd/libm.tbd paths that ITK hardcodes to -l flags, so the
     # cached dependencies keep linking after a runner Xcode/SDK bump. See issue #2570.

--- a/.github/workflows/build-mac-arm64.yml
+++ b/.github/workflows/build-mac-arm64.yml
@@ -19,6 +19,9 @@ env:
   CACHE_HOST: ${{ secrets.SSH_HOST }}
   GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
   GA_API_SECRET: ${{ secrets.GA_API_SECRET }}
+  CCACHE_DIR: /Users/runner/.ccache
+  CCACHE_MAXSIZE: "500M"
+  CCACHE_COMPRESS: "true"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -82,9 +85,30 @@ jobs:
       shell: bash -l {0}
       run: conda activate shapeworks && mkdir build && cd build && cmake -DCMAKE_LIBTOOL=/usr/bin/libtool -DCMAKE_CXX_FLAGS="-g -Wno-enum-constexpr-conversion" -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 -DCMAKE_PREFIX_PATH=$HOME/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPython3_ROOT_DIR:FILEPATH=${CONDA_PREFIX} -DUSE_OPENMP=OFF -DBuild_Studio=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/shapeworks-install -DBUILD_DOCUMENTATION=ON -DUSE_BUNDLED_PYTHON=ON -DGA_MEASUREMENT_ID=$GA_MEASUREMENT_ID -DGA_API_SECRET=$GA_API_SECRET ..
 
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /Users/runner/.ccache
+        key: ${{ runner.os }}-ccache-arm64-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-arm64-
+
     - name: make
       shell: bash -l {0}
       run: conda activate shapeworks && cd build && make -j4
+
+    - name: ccache stats
+      if: always()
+      shell: bash -l {0}
+      run: ccache -s || true
+
+    - name: Save ccache
+      if: always()
+      continue-on-error: true
+      uses: actions/cache/save@v4
+      with:
+        path: /Users/runner/.ccache
+        key: ${{ runner.os }}-ccache-arm64-${{ github.sha }}
 
     - name: Install bundled Python packages
       shell: bash -l {0}

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -19,6 +19,9 @@ env:
   CACHE_HOST: ${{ secrets.SSH_HOST }}
   GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
   GA_API_SECRET: ${{ secrets.GA_API_SECRET }}
+  CCACHE_DIR: /Users/runner/.ccache
+  CCACHE_MAXSIZE: "500M"
+  CCACHE_COMPRESS: "true"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -82,9 +85,30 @@ jobs:
       shell: bash -l {0}
       run: conda activate shapeworks && mkdir build && cd build && cmake -DCMAKE_LIBTOOL=/usr/bin/libtool -DCMAKE_CXX_FLAGS=-g -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 -DCMAKE_PREFIX_PATH=$HOME/install -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPython3_ROOT_DIR:FILEPATH=${CONDA_PREFIX} -DUSE_OPENMP=OFF -DBuild_Studio=ON -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/shapeworks-install -DBUILD_DOCUMENTATION=OFF -DUSE_BUNDLED_PYTHON=ON -DGA_MEASUREMENT_ID=$GA_MEASUREMENT_ID -DGA_API_SECRET=$GA_API_SECRET ..
 
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /Users/runner/.ccache
+        key: ${{ runner.os }}-ccache-intel-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-intel-
+
     - name: make
       shell: bash -l {0}
       run: conda activate shapeworks && cd build && make -j4
+
+    - name: ccache stats
+      if: always()
+      shell: bash -l {0}
+      run: ccache -s || true
+
+    - name: Save ccache
+      if: always()
+      continue-on-error: true
+      uses: actions/cache/save@v4
+      with:
+        path: /Users/runner/.ccache
+        key: ${{ runner.os }}-ccache-intel-${{ github.sha }}
 
     - name: Install bundled Python packages
       shell: bash -l {0}

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -59,7 +59,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: /Users/runner/install
-        key: ${{ runner.os }}-intel-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-intel-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
 
     - name: Build Dependencies
       shell: bash -l {0}
@@ -70,7 +70,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: /Users/runner/install
-        key: ${{ runner.os }}-intel-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-intel-deps-osx${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
 
     # Rewrite SDK-versioned libiconv.tbd/libm.tbd paths that ITK hardcodes to -l flags, so the
     # cached dependencies keep linking after a runner Xcode/SDK bump. See issue #2570.

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -94,7 +94,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: C:\deps
-        key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
 
     - name: Build Dependencies
       if: steps.cache-deps-restore.outputs.cache-hit != 'true'
@@ -106,7 +106,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: C:\deps
-        key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'python_requirements.txt', 'build_dependencies.sh') }}
+        key: ${{ runner.os }}-deps-${{ hashFiles('.github/workflows/gha_deps.sh', 'install_shapeworks.sh', 'build_dependencies.sh') }}
       
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory


### PR DESCRIPTION
* #2589

Drop python_requirements.txt from dependency cache key
Persist ccache across runs for Linux and macOS builds
