### PR TITLE
Warn when optimizing a project with no optimize parameters (#1677)

### DIFF
--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -143,6 +143,9 @@ OptimizeParameters::OptimizeParameters(ProjectHandle project) {
 void OptimizeParameters::save_to_project() { project_->set_parameters(Parameters::OPTIMIZE_PARAMS, params_); }
 
 //---------------------------------------------------------------------------
+bool OptimizeParameters::has_optimize_parameters() { return !params_.get_map().empty(); }
+
+//---------------------------------------------------------------------------
 std::vector<int> OptimizeParameters::get_number_of_particles() { return params_.get(Keys::number_of_particles, {128}); }
 
 //---------------------------------------------------------------------------
@@ -444,6 +447,9 @@ void OptimizeParameters::set_fixed_subjects_choice(std::string choice) {
 
 //---------------------------------------------------------------------------
 bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
+  if (!has_optimize_parameters()) {
+    SW_WARN("No optimize parameters were provided; using default values.");
+  }
   optimize->SetVerbosity(get_verbosity());
   int domains_per_shape = project_->get_number_of_domains_per_subject();
   bool normals_enabled = get_use_normals()[0];

--- a/Libs/Optimize/OptimizeParameters.h
+++ b/Libs/Optimize/OptimizeParameters.h
@@ -21,6 +21,9 @@ class OptimizeParameters {
   explicit OptimizeParameters(ProjectHandle project);
   void save_to_project();
 
+  //! Return whether the project supplied any optimize parameters (otherwise defaults are used).
+  bool has_optimize_parameters();
+
   std::string get_optimize_output_prefix();
   void set_optimize_output_prefix(std::string prefix);
 

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -105,6 +105,23 @@ TEST(OptimizeTests, sample) {
 }
 
 //---------------------------------------------------------------------------
+TEST(OptimizeTests, missing_optimize_parameters_test) {
+  prep_temp("/optimize/sphere", "missing_optimize_parameters");
+
+  ProjectHandle project = std::make_shared<Project>();
+  ASSERT_TRUE(project->load("optimize.swproj"));
+
+  // the project defines optimize parameters
+  OptimizeParameters params_with(project);
+  EXPECT_TRUE(params_with.has_optimize_parameters());
+
+  // clearing them means defaults will be used
+  project->clear_parameters(Parameters::OPTIMIZE_PARAMS);
+  OptimizeParameters params_without(project);
+  EXPECT_FALSE(params_without.has_optimize_parameters());
+}
+
+//---------------------------------------------------------------------------
 TEST(OptimizeTests, open_mesh_test) {
   prep_temp("/optimize/hemisphere", "open_mesh_test");
 


### PR DESCRIPTION
* #1677

A project with no optimize parameters silently uses built-in defaults (128 particles, etc.). Adds OptimizeParameters::has_optimize_parameters() and has set_up_optimize() warn when none were provided; it only fires for a genuinely empty project since Studio and programmatic setters populate parameters first.

Adds OptimizeTests.missing_optimize_parameters_test.