### PR TITLE
Handle contour polylines with >2-point line cells (#2377)

### DIFF
--- a/Libs/Optimize/Domain/ContourDomain.cpp
+++ b/Libs/Optimize/Domain/ContourDomain.cpp
@@ -1,5 +1,6 @@
 #include "ContourDomain.h"
 
+#include <vtkCellArray.h>
 #include <vtkDijkstraGraphGeodesicPath.h>
 #include <vtkDoubleArray.h>
 #include <numeric>
@@ -11,6 +12,39 @@ namespace shapeworks {
 
 const double epsilon = 1e-6;
 
+//---------------------------------------------------------------------------
+// VTK line cells may be polylines: a single cell with more than two points.
+// The rest of the contour code assumes two-point line cells, so split any
+// polyline cell into a series of two-point segments. (#2377)
+static vtkSmartPointer<vtkPolyData> split_polylines_into_segments(vtkSmartPointer<vtkPolyData> poly_data) {
+  bool needs_split = false;
+  for (vtkIdType i = 0; i < poly_data->GetNumberOfCells(); i++) {
+    if (poly_data->GetCell(i)->GetNumberOfPoints() != 2) {
+      needs_split = true;
+      break;
+    }
+  }
+  if (!needs_split) {
+    return poly_data;
+  }
+
+  auto segments = vtkSmartPointer<vtkCellArray>::New();
+  auto cell = vtkSmartPointer<vtkGenericCell>::New();
+  for (vtkIdType i = 0; i < poly_data->GetNumberOfCells(); i++) {
+    poly_data->GetCell(i, cell);
+    auto ids = cell->GetPointIds();
+    for (vtkIdType j = 0; j + 1 < ids->GetNumberOfIds(); j++) {
+      segments->InsertNextCell(2);
+      segments->InsertCellPoint(ids->GetId(j));
+      segments->InsertCellPoint(ids->GetId(j + 1));
+    }
+  }
+  poly_data->SetLines(segments);
+  poly_data->BuildCells();
+  poly_data->BuildLinks();
+  return poly_data;
+}
+
 void ContourDomain::SetPolyLine(vtkSmartPointer<vtkPolyData> poly_data) {
   this->m_FixedDomain = false;
 
@@ -19,6 +53,8 @@ void ContourDomain::SetPolyLine(vtkSmartPointer<vtkPolyData> poly_data) {
   this->poly_data_->DeepCopy(poly_data);
   this->poly_data_->BuildCells();
   this->poly_data_->BuildLinks();
+
+  split_polylines_into_segments(this->poly_data_);
 
   auto cell = vtkSmartPointer<vtkGenericCell>::New();
   for (int i = 0; i < this->poly_data_->GetNumberOfCells(); i++) {

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -7,6 +7,7 @@
 #include <Utils/StringUtils.h>
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
+#include <vtkCellType.h>
 
 #include <atomic>
 #include <boost/algorithm/string.hpp>
@@ -850,7 +851,10 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
           throw std::invalid_argument("Error, mesh had zero cells: " + filename);
         }
         // TODO This is a HACK for detecting contours
-        item.is_contour_hack = (pd->GetCell(0)->GetNumberOfPoints() == 2);
+        // Line cells may be plain lines (two points) or polylines (more than two points),
+        // so detect a contour by cell type rather than point count. (#2377)
+        int cell_type = pd->GetCellType(0);
+        item.is_contour_hack = (cell_type == VTK_LINE || cell_type == VTK_POLY_LINE);
         item.poly_data = pd;
       } else if (domain_type == DomainType::Contour) {
         Mesh mesh = MeshUtils::threadSafeReadMesh(filename.c_str());

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -513,6 +513,29 @@ TEST(OptimizeTests, contour_domain_test) {
 }
 
 //---------------------------------------------------------------------------
+// #2377: a contour stored as a VTK polyline (a single line cell with more than two points)
+// was misdetected as a mesh and crashed optimization. Verify it is treated as a contour
+// and optimizes successfully.
+TEST(OptimizeTests, contour_polyline_test) {
+  prep_temp("/optimize/contour_polyline", "contour_polyline");
+
+  Optimize app;
+  ProjectHandle project = std::make_shared<Project>();
+  ASSERT_TRUE(project->load("optimize.swproj"));
+  OptimizeParameters params(project);
+  ASSERT_TRUE(params.set_up_optimize(&app));
+  ASSERT_TRUE(app.Run());
+
+  // each polyline domain should be treated as a contour and receive the requested particles
+  auto ps = app.GetSampler()->GetParticleSystem();
+  ASSERT_EQ(ps->GetNumberOfDomains(), 3);
+  for (size_t d = 0; d < ps->GetNumberOfDomains(); d++) {
+    EXPECT_EQ(ps->GetDomain(d)->GetDomainType(), DomainType::Contour);
+    EXPECT_EQ(ps->GetPositions(d)->GetSize(), 16);
+  }
+}
+
+//---------------------------------------------------------------------------
 TEST(OptimizeTests, procrustes_disabled_test) {
   prep_temp("/optimize/procrustes", "procrustes_disabled_test");
 

--- a/Testing/data/optimize/contour_polyline/c0.vtk
+++ b/Testing/data/optimize/contour_polyline/c0.vtk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1ed75b8f4951efd80332145a5726f61c5150a735f13f4037d4fe07ef99b58aa
+size 2063

--- a/Testing/data/optimize/contour_polyline/c1.vtk
+++ b/Testing/data/optimize/contour_polyline/c1.vtk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db811261fbd45e9edc7e451a81f2e475d6521f42d3c0d25d29e755d7e7ef4485
+size 2063

--- a/Testing/data/optimize/contour_polyline/c2.vtk
+++ b/Testing/data/optimize/contour_polyline/c2.vtk
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12e6ad9145ac13ec35a3feb5b1c4e4c54b52ebd62f78d0e434d0a9475a21d356
+size 2063

--- a/Testing/data/optimize/contour_polyline/optimize.swproj
+++ b/Testing/data/optimize/contour_polyline/optimize.swproj
@@ -1,0 +1,53 @@
+{
+  "data": [
+    {
+      "name": "c0",
+      "shape_1": "c0.vtk",
+      "groomed_1": "c0.vtk",
+      "local_particles_1": "contour_polyline_particles/c0_local.particles",
+      "world_particles_1": "contour_polyline_particles/c0_world.particles",
+      "alignment_1": "1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000",
+      "procrustes_1": "1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000"
+    },
+    {
+      "name": "c1",
+      "shape_1": "c1.vtk",
+      "groomed_1": "c1.vtk",
+      "local_particles_1": "contour_polyline_particles/c1_local.particles",
+      "world_particles_1": "contour_polyline_particles/c1_world.particles",
+      "alignment_1": "1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000",
+      "procrustes_1": "1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000"
+    },
+    {
+      "name": "c2",
+      "shape_1": "c2.vtk",
+      "groomed_1": "c2.vtk",
+      "local_particles_1": "contour_polyline_particles/c2_local.particles",
+      "world_particles_1": "contour_polyline_particles/c2_world.particles",
+      "alignment_1": "1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000",
+      "procrustes_1": "1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000 0.000000 0.000000 0.000000 0.000000 1.000000"
+    }
+  ],
+  "optimize": {
+    "checkpointing_interval": "0",
+    "ending_regularization": "0.100000",
+    "initial_relative_weighting": "0.010000",
+    "iterations_per_split": "100",
+    "keep_checkpoints": "0",
+    "number_of_particles": "16",
+    "optimization_iterations": "100",
+    "procrustes_interval": "0",
+    "procrustes_scaling": "false",
+    "relative_weighting": "1.000000",
+    "save_init_splits": "0",
+    "starting_regularization": "100.000000",
+    "use_normals": "0",
+    "verbosity": "0",
+    "multiscale": "false",
+    "narrow_band": "4.000000",
+    "optimize_output_prefix": "<project>_particles",
+    "procrustes": "false",
+    "use_geodesic_distance": "false",
+    "use_landmarks": "false"
+  }
+}


### PR DESCRIPTION
* #2377 

Resolves #2377

VTK can store a contour as a single polyline cell with more than two points. ShapeWorks assumed line cells always have exactly two points, so such a contour was misdetected as a mesh (the contour-detection check required GetCell(0) to have two points) and crashed in optimization.

- OptimizeParameters: detect a contour by cell type (VTK_LINE or VTK_POLY_LINE) instead of point count, so polylines are routed to the contour path.
- ContourDomain::SetPolyLine: split any polyline cell into two-point segments before building the contour, so the rest of the contour code (which assumes two-point line cells) works.

Adds OptimizeTests.contour_polyline_test with a fixture of polyline contours; without the fix the polyline is processed as a mesh and the optimization crashes.