### PR TITLE
Fix landmark glyph size before optimization (#2276)

### DIFF
--- a/Studio/Data/Session.cpp
+++ b/Studio/Data/Session.cpp
@@ -685,6 +685,31 @@ double Session::update_auto_glyph_size() {
   }
 
   if (num_particles == 0) {
+    // No optimized particles yet (e.g. only initial landmarks have been placed). Size the
+    // glyphs from the displayed shape's bounding box so they render at a sensible size on the
+    // shape, independent of how many landmarks have been placed. Without this the size fell
+    // back to a fixed value of 1, which is invisibly small on large shapes. (#2276)
+    double extent = 0;
+    auto display_mode = get_display_mode();
+    for (auto& shape : shapes_) {
+      auto meshes = shape->get_meshes(display_mode);
+      if (!meshes.valid()) {
+        continue;
+      }
+      auto poly_data = meshes.get_combined_poly_data();
+      if (!poly_data || poly_data->GetNumberOfPoints() == 0) {
+        continue;
+      }
+      double bounds[6];
+      poly_data->GetBounds(bounds);
+      extent = std::max<double>({extent, bounds[1] - bounds[0], bounds[3] - bounds[2], bounds[5] - bounds[4]});
+    }
+    if (extent <= 0) {
+      return auto_glyph_size_;  // no mesh available yet; keep the default
+    }
+    auto_glyph_size_ = extent / 40.0;  // ~2.5% of the shape extent
+    auto_glyph_size_ = std::max<double>(0.1, auto_glyph_size_);
+    auto_glyph_size_ = std::min<double>(10.0, auto_glyph_size_);
     return auto_glyph_size_;
   }
   auto_glyph_size_ = max_range / std::sqrt(static_cast<double>(num_particles)) / 2;

--- a/Studio/Visualization/Visualizer.cpp
+++ b/Studio/Visualization/Visualizer.cpp
@@ -84,6 +84,17 @@ void Visualizer::update_samples() {
 
 //-----------------------------------------------------------------------------
 void Visualizer::update_landmarks() {
+  // The auto glyph size can change as landmarks are placed (it is derived from the shape when
+  // there are no particles yet), so push the current value to the viewers here. Otherwise the
+  // landmark glyphs would be drawn at a stale size until some other action refreshed it. (#2276)
+  if (preferences_.get_glyph_auto_size()) {
+    double size = session_->get_auto_glyph_size();
+    double quality = std::max<double>(preferences_.get_glyph_quality(), 3);
+    Q_FOREACH (ViewerHandle viewer, lightbox_->get_viewers()) {
+      viewer->set_glyph_size_and_quality(size, quality);
+    }
+    current_glyph_size_ = size;
+  }
   Q_FOREACH (ViewerHandle viewer, lightbox_->get_viewers()) {
     viewer->update_landmarks();
   }


### PR DESCRIPTION
* #2276 

Resolves #2276

Two problems made initial landmarks render at (nearly) zero size:

1. Session::update_auto_glyph_size() computed the automatic glyph size only from optimized particles. With just initial landmarks placed it fell back to a fixed size of 1, invisibly small on large shapes. It now sizes glyphs from the displayed shape's bounding box when there are no particles.

2. Placing a landmark recomputed the size but never pushed it to the viewers, so the new size wasn't applied until some other action (e.g. toggling auto-size) refreshed it. Visualizer::update_landmarks() now re-applies the current auto glyph size to the viewers.