### PR TITLE
Fix cutting-plane glyph size before optimization (#2595)

### DIFF
--- a/Studio/Data/Session.cpp
+++ b/Studio/Data/Session.cpp
@@ -855,6 +855,7 @@ void Session::new_plane_point(PickResult result) {
     plane.points().push_back(pos);
     planes.push_back(plane);
   }
+  update_auto_glyph_size();
   Q_EMIT planes_changed();
 }
 

--- a/Studio/Visualization/Visualizer.cpp
+++ b/Studio/Visualization/Visualizer.cpp
@@ -83,18 +83,25 @@ void Visualizer::update_samples() {
 }
 
 //-----------------------------------------------------------------------------
-void Visualizer::update_landmarks() {
-  // The auto glyph size can change as landmarks are placed (it is derived from the shape when
-  // there are no particles yet), so push the current value to the viewers here. Otherwise the
-  // landmark glyphs would be drawn at a stale size until some other action refreshed it. (#2276)
-  if (preferences_.get_glyph_auto_size()) {
-    double size = session_->get_auto_glyph_size();
-    double quality = std::max<double>(preferences_.get_glyph_quality(), 3);
-    Q_FOREACH (ViewerHandle viewer, lightbox_->get_viewers()) {
-      viewer->set_glyph_size_and_quality(size, quality);
-    }
-    current_glyph_size_ = size;
+void Visualizer::sync_auto_glyph_size() {
+  // The auto glyph size can change as landmarks/plane points are placed (it is derived from the
+  // shape when there are no particles yet), so push the current value to the viewers. Otherwise
+  // the landmark and cutting-plane glyphs would be drawn at a stale size until some other action
+  // refreshed it. (#2276, #2595)
+  if (!preferences_.get_glyph_auto_size()) {
+    return;
   }
+  double size = session_->get_auto_glyph_size();
+  double quality = std::max<double>(preferences_.get_glyph_quality(), 3);
+  Q_FOREACH (ViewerHandle viewer, lightbox_->get_viewers()) {
+    viewer->set_glyph_size_and_quality(size, quality);
+  }
+  current_glyph_size_ = size;
+}
+
+//-----------------------------------------------------------------------------
+void Visualizer::update_landmarks() {
+  sync_auto_glyph_size();
   Q_FOREACH (ViewerHandle viewer, lightbox_->get_viewers()) {
     viewer->update_landmarks();
   }
@@ -103,6 +110,7 @@ void Visualizer::update_landmarks() {
 
 //-----------------------------------------------------------------------------
 void Visualizer::update_planes() {
+  sync_auto_glyph_size();
   Q_FOREACH (ViewerHandle viewer, lightbox_->get_viewers()) {
     viewer->update_planes();
   }

--- a/Studio/Visualization/Visualizer.h
+++ b/Studio/Visualization/Visualizer.h
@@ -166,6 +166,9 @@ class Visualizer : public QObject {
  private:
   Preferences& preferences_;
 
+  //! Push the current auto glyph size to the viewers (no-op unless auto-size is on).
+  void sync_auto_glyph_size();
+
   void compute_measurements();
 
   void setup_single_selected_point_lut();


### PR DESCRIPTION
* #2595

Before any particles exist, cutting-plane points rendered at a near-zero size and were invisible until some other action refreshed the glyphs. The auto glyph size fix for landmarks (#2276) already sizes glyphs from the shape bounding box, but the new size was never pushed to the viewers when planes changed.

Extracts the viewer glyph-size sync into Visualizer::sync_auto_glyph_size() and calls it from update_planes() as well as update_landmarks(), and has Session::new_plane_point() recompute the size like new_landmark() does.

Fixes #2595