### PR TITLE
Fix optimizer hack to detect contour types (#2457)

### DIFF
--- a/Libs/Groom/Groom.cpp
+++ b/Libs/Groom/Groom.cpp
@@ -410,11 +410,8 @@ bool Groom::run_mesh_pipeline(Mesh& mesh, GroomParameters params, const std::str
 
   if (params.get_remesh()) {
     auto poly_data = mesh.getVTKMesh();
-    if (poly_data->GetNumberOfCells() == 0 || poly_data->GetCell(0)->GetNumberOfPoints() == 2) {
+    if (poly_data->GetNumberOfCells() == 0 || MeshUtils::is_contour(poly_data)) {
       SW_DEBUG("Number of cells: {}", poly_data->GetNumberOfCells());
-      if (poly_data->GetNumberOfCells() > 0) {
-        SW_DEBUG("Number of points in first cell: {}", poly_data->GetCell(0)->GetNumberOfPoints());
-      }
       throw std::runtime_error("malformed mesh, mesh should be triangular");
     }
     int total_vertices = mesh.getVTKMesh()->GetNumberOfPoints();
@@ -1108,19 +1105,15 @@ Mesh Groom::check_and_fix_mesh(Mesh& mesh, const std::string& step, const std::s
   if (poly_data->GetNumberOfCells() == 0) {
     throw std::runtime_error(fmt::format("Error in mesh, step: {}, file: {}, mesh has zero cells", step, filename));
   }
-  if (poly_data->GetCell(0)->GetNumberOfPoints() == 2) {
-    // try cleaning the mesh
+  if (MeshUtils::is_contour(poly_data)) {
+    // mesh unexpectedly collapsed to line cells; try cleaning it
     Mesh m(poly_data);
     m.clean();
     poly_data = m.getVTKMesh();
 
-    if (poly_data->GetNumberOfCells() == 0 || poly_data->GetCell(0)->GetNumberOfPoints() == 2) {
+    if (poly_data->GetNumberOfCells() == 0 || MeshUtils::is_contour(poly_data)) {
       // still failed
       SW_DEBUG("Number of cells: {}", poly_data->GetNumberOfCells());
-      SW_DEBUG("Number of points in first cell: {}", poly_data->GetCell(0)->GetNumberOfPoints());
-      // write out to /tmp
-      // std::string tmpname = "/tmp/bad_mesh.vtk";
-      // MeshUtils::threadSafeWriteMesh(tmpname, mesh);
       throw std::runtime_error(
           fmt::format("Error in mesh, step: {}, file: {}, mesh has invalid cells", step, filename));
     }

--- a/Libs/Mesh/MeshUtils.cpp
+++ b/Libs/Mesh/MeshUtils.cpp
@@ -1153,4 +1153,15 @@ vtkSmartPointer<vtkPolyData> MeshUtils::repair_mesh(vtkSmartPointer<vtkPolyData>
   return final;
 }
 
+bool MeshUtils::is_contour(vtkSmartPointer<vtkPolyData> poly_data) {
+  if (!poly_data) {
+    return false;
+  }
+  // A surface mesh has 2D cells (polygons or triangle strips); a contour has only line cells.
+  if (poly_data->GetNumberOfPolys() > 0 || poly_data->GetNumberOfStrips() > 0) {
+    return false;
+  }
+  return poly_data->GetNumberOfLines() > 0;
+}
+
 }  // namespace shapeworks

--- a/Libs/Mesh/MeshUtils.h
+++ b/Libs/Mesh/MeshUtils.h
@@ -88,5 +88,10 @@ class MeshUtils {
 
     /// Repair mesh: triangulate, optionally extract largest component, clean, fix non-manifold, remove zero-area triangles
     static vtkSmartPointer<vtkPolyData> repair_mesh(vtkSmartPointer<vtkPolyData> mesh, bool extract_largest = true);
+
+    /// Return true if the polydata is a contour (line cells) rather than a surface mesh (face cells).
+    /// A surface mesh has polygon or triangle-strip cells; a contour has only line cells. This is more
+    /// robust than inspecting the first cell, whose type/point-count can vary within a mesh.
+    static bool is_contour(vtkSmartPointer<vtkPolyData> poly_data);
 };
 } // namespace shapeworks

--- a/Libs/Mesh/MeshWarper.cpp
+++ b/Libs/Mesh/MeshWarper.cpp
@@ -91,8 +91,8 @@ void MeshWarper::set_reference_mesh(vtkSmartPointer<vtkPolyData> reference_mesh,
 
   warp_available_ = true;
 
-  // TODO This is temporary for detecting if contour until the contour type is fully supported
-  if (reference_mesh->GetNumberOfCells() > 0 && reference_mesh->GetCell(0)->GetNumberOfPoints() == 2) {
+  // Detect a contour (line cells) so the warp uses the contour path. (#2457)
+  if (MeshUtils::is_contour(reference_mesh)) {
     is_contour_ = true;
     update_progress(1.0);
   }

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -7,7 +7,6 @@
 #include <Utils/StringUtils.h>
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
-#include <vtkCellType.h>
 
 #include <atomic>
 #include <boost/algorithm/string.hpp>
@@ -744,7 +743,7 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
 
     // For mesh domains — prepared poly_data from Phase A
     vtkSmartPointer<vtkPolyData> poly_data;
-    bool is_contour_hack = false;  // true if mesh cells have 2 points (contour detection hack)
+    bool is_contour = false;  // true if the poly_data is a contour (line cells) rather than a surface mesh
 
     // For image domains
     std::optional<Image> image;
@@ -850,11 +849,9 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
         if (pd->GetNumberOfCells() == 0) {
           throw std::invalid_argument("Error, mesh had zero cells: " + filename);
         }
-        // TODO This is a HACK for detecting contours
-        // Line cells may be plain lines (two points) or polylines (more than two points),
-        // so detect a contour by cell type rather than point count. (#2377)
-        int cell_type = pd->GetCellType(0);
-        item.is_contour_hack = (cell_type == VTK_LINE || cell_type == VTK_POLY_LINE);
+        // Detect a contour by cell content (line cells, no faces) rather than inspecting the first
+        // cell, whose type can vary within a mesh. (#2457)
+        item.is_contour = MeshUtils::is_contour(pd);
         item.poly_data = pd;
       } else if (domain_type == DomainType::Contour) {
         Mesh mesh = MeshUtils::threadSafeReadMesh(filename.c_str());
@@ -882,7 +879,7 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
   std::vector<size_t> mesh_work_indices;
   for (size_t idx = 0; idx < work_items.size(); idx++) {
     auto& item = work_items[idx];
-    if (item.domain_type == DomainType::Mesh && !item.is_contour_hack && item.poly_data) {
+    if (item.domain_type == DomainType::Mesh && !item.is_contour && item.poly_data) {
       mesh_work_indices.push_back(idx);
     }
   }
@@ -951,10 +948,10 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
     for (size_t wi_idx : si.work_item_indices) {
       auto& item = work_items[wi_idx];
 
-      if (item.domain_type == DomainType::Mesh && !item.is_contour_hack && item.poly_data) {
+      if (item.domain_type == DomainType::Mesh && !item.is_contour && item.poly_data) {
         // Use pre-built Surface data
         optimize->AddMesh(item.surface, item.geodesics_surface, item.sw_mesh, item.surface_area);
-      } else if (item.domain_type == DomainType::Mesh && item.is_contour_hack) {
+      } else if (item.domain_type == DomainType::Mesh && item.is_contour) {
         optimize->AddContour(item.poly_data);
       } else if (item.domain_type == DomainType::Contour) {
         optimize->AddContour(item.poly_data);

--- a/Testing/MeshTests/MeshTests.cpp
+++ b/Testing/MeshTests/MeshTests.cpp
@@ -1,3 +1,6 @@
+#include <vtkCellArray.h>
+#include <vtkPoints.h>
+
 #include <chrono>
 #include <fstream>
 #include <igl/point_mesh_squared_distance.h>
@@ -59,6 +62,70 @@ TEST(MeshTests, corruptFileThrowsTest) {
   out.close();
 
   ASSERT_ANY_THROW(Mesh mesh(path));
+}
+
+TEST(MeshTests, isContourTest) {
+  auto make_points = []() {
+    auto points = vtkSmartPointer<vtkPoints>::New();
+    for (int i = 0; i < 4; i++) {
+      points->InsertNextPoint(i, 0, 0);
+    }
+    return points;
+  };
+
+  // A surface mesh (two triangles) is not a contour.
+  {
+    auto pd = vtkSmartPointer<vtkPolyData>::New();
+    pd->SetPoints(make_points());
+    auto polys = vtkSmartPointer<vtkCellArray>::New();
+    vtkIdType t1[3] = {0, 1, 2};
+    vtkIdType t2[3] = {1, 2, 3};
+    polys->InsertNextCell(3, t1);
+    polys->InsertNextCell(3, t2);
+    pd->SetPolys(polys);
+    ASSERT_FALSE(MeshUtils::is_contour(pd));
+  }
+
+  // A set of line segments is a contour.
+  {
+    auto pd = vtkSmartPointer<vtkPolyData>::New();
+    pd->SetPoints(make_points());
+    auto lines = vtkSmartPointer<vtkCellArray>::New();
+    vtkIdType l1[2] = {0, 1};
+    vtkIdType l2[2] = {1, 2};
+    lines->InsertNextCell(2, l1);
+    lines->InsertNextCell(2, l2);
+    pd->SetLines(lines);
+    ASSERT_TRUE(MeshUtils::is_contour(pd));
+  }
+
+  // A single polyline (more than two points in one cell) is still a contour.
+  {
+    auto pd = vtkSmartPointer<vtkPolyData>::New();
+    pd->SetPoints(make_points());
+    auto lines = vtkSmartPointer<vtkCellArray>::New();
+    vtkIdType poly[4] = {0, 1, 2, 3};
+    lines->InsertNextCell(4, poly);
+    pd->SetLines(lines);
+    ASSERT_TRUE(MeshUtils::is_contour(pd));
+  }
+
+  // A surface mesh whose first cell is a line (mixed cells) is NOT a contour. The old
+  // first-cell heuristic misclassified this as a contour. (#2457)
+  {
+    auto pd = vtkSmartPointer<vtkPolyData>::New();
+    pd->SetPoints(make_points());
+    auto lines = vtkSmartPointer<vtkCellArray>::New();
+    vtkIdType l1[2] = {0, 1};
+    lines->InsertNextCell(2, l1);
+    pd->SetLines(lines);
+    auto polys = vtkSmartPointer<vtkCellArray>::New();
+    vtkIdType t1[3] = {0, 1, 2};
+    polys->InsertNextCell(3, t1);
+    pd->SetPolys(polys);
+    ASSERT_EQ(pd->GetCell(0)->GetNumberOfPoints(), 2);  // first cell really is the line
+    ASSERT_FALSE(MeshUtils::is_contour(pd));
+  }
 }
 
 TEST(MeshTests, writeTest1) {


### PR DESCRIPTION
Fixes #2457

Add `MeshUtils::is_contour()`, which classifies by cell *content* rather than the first cell: a contour has only line cells, while a surface mesh has polygon or triangle-strip cells (matching the `GetNumberOfPolys() == 0` convention already used in `repair_mesh`).
