### PR TITLE
Scale the glyph-size slider and auto size to the shape's overall size

### DIFF
--- a/Studio/Data/Session.cpp
+++ b/Studio/Data/Session.cpp
@@ -649,6 +649,7 @@ void Session::update_procrustes_transforms(std::vector<std::vector<std::vector<d
 //---------------------------------------------------------------------------
 double Session::update_auto_glyph_size() {
   auto_glyph_size_ = 1;
+  glyph_size_scale_ = 0;
   if (shapes_.empty()) {
     return auto_glyph_size_;
   }
@@ -707,14 +708,18 @@ double Session::update_auto_glyph_size() {
     if (extent <= 0) {
       return auto_glyph_size_;  // no mesh available yet; keep the default
     }
+    glyph_size_scale_ = extent;
     auto_glyph_size_ = extent / 40.0;  // ~2.5% of the shape extent
-    auto_glyph_size_ = std::max<double>(0.1, auto_glyph_size_);
-    auto_glyph_size_ = std::min<double>(10.0, auto_glyph_size_);
+    // Bound to [0.1%, 10%] of the shape's largest dimension so the auto size stays sensible (and
+    // within the slider range) for very small or very large shapes. (#2459)
+    auto_glyph_size_ = std::max<double>(glyph_size_scale_ / 1000.0, auto_glyph_size_);
+    auto_glyph_size_ = std::min<double>(glyph_size_scale_ / 10.0, auto_glyph_size_);
     return auto_glyph_size_;
   }
+  glyph_size_scale_ = max_range;
   auto_glyph_size_ = max_range / std::sqrt(static_cast<double>(num_particles)) / 2;
-  auto_glyph_size_ = std::max<double>(0.1, auto_glyph_size_);
-  auto_glyph_size_ = std::min<double>(10.0, auto_glyph_size_);
+  auto_glyph_size_ = std::max<double>(glyph_size_scale_ / 1000.0, auto_glyph_size_);
+  auto_glyph_size_ = std::min<double>(glyph_size_scale_ / 10.0, auto_glyph_size_);
 
   return auto_glyph_size_;
 }
@@ -945,6 +950,8 @@ Point3 Session::get_point(const Eigen::VectorXd& points, int i) {
 
 //---------------------------------------------------------------------------
 double Session::get_auto_glyph_size() { return auto_glyph_size_; }
+
+double Session::get_glyph_size_scale() { return glyph_size_scale_; }
 
 //---------------------------------------------------------------------------
 void Session::clear_particles() {

--- a/Studio/Data/Session.h
+++ b/Studio/Data/Session.h
@@ -147,6 +147,10 @@ class Session : public QObject, public QEnableSharedFromThis<Session> {
 
   double get_auto_glyph_size();
 
+  //! Largest dimension (X, Y, or Z) of the current shapes, used to scale the glyph-size slider
+  //! bounds to the data. Zero when no shape is loaded. Updated by update_auto_glyph_size().
+  double get_glyph_size_scale();
+
   static Point3 get_point(const Eigen::VectorXd& points, int i);
 
   //! clear particles from session (e.g. groom start, optimize start)
@@ -366,6 +370,8 @@ class Session : public QObject, public QEnableSharedFromThis<Session> {
   std::shared_ptr<Project> project_{new Project()};
 
   double auto_glyph_size_ = -1;
+
+  double glyph_size_scale_ = 0;  // largest dimension of the current shapes (0 if none)
 
   int active_landmark_domain_ = -1;
   int placing_landmark_ = -1;

--- a/Studio/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/Interface/ShapeWorksStudioApp.cpp
@@ -851,13 +851,13 @@ void ShapeWorksStudioApp::create_glyph_submenu() {
   widget->setLayout(layout);
 
   glyph_quality_slider_->setValue(preferences_.get_glyph_quality());
-  glyph_size_slider_->setValue(preferences_.get_glyph_size() * 10.0);
+  glyph_size_slider_->setValue(preferences_.get_glyph_size() / glyph_slider_world_per_unit());
   glyph_auto_size_->setChecked(preferences_.get_glyph_auto_size());
   glyph_arrow_scale_->setChecked(preferences_.get_glyph_scale_arrows());
   glyph_size_slider_->setEnabled(!glyph_auto_size_->isChecked());
 
   glyph_quality_label_->setText(QString::number(preferences_.get_glyph_quality()));
-  glyph_size_label_->setText(QString::number(preferences_.get_glyph_size()));
+  glyph_size_label_->setText(QString::number(preferences_.get_glyph_size(), 'g', 3));
 
   connect(glyph_size_slider_, &CustomSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed);
   connect(glyph_quality_slider_, &CustomSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed);
@@ -896,7 +896,7 @@ void ShapeWorksStudioApp::create_glyph_submenu() {
   ui_->glyphs_visible_button->setMenu(menu);
 
   glyph_quality_label_->setText(QString::number(preferences_.get_glyph_quality()));
-  glyph_size_label_->setText(QString::number(preferences_.get_glyph_size()));
+  glyph_size_label_->setText(QString::number(preferences_.get_glyph_size(), 'g', 3));
 }
 
 //---------------------------------------------------------------------------
@@ -1433,6 +1433,18 @@ void ShapeWorksStudioApp::handle_display_setting_changed() {
 }
 
 //---------------------------------------------------------------------------
+double ShapeWorksStudioApp::glyph_slider_world_per_unit() {
+  // The slider spans [1, 100]. Map its full range to [0.1%, 10%] of the shape's largest dimension,
+  // so slider step = scale / 1000. When no shape is loaded, fall back to the original fixed mapping
+  // (slider 1..100 -> world 0.1..10), which matches a shape whose largest dimension is 100.
+  double scale = session_ ? session_->get_glyph_size_scale() : 0.0;
+  if (scale <= 0.0) {
+    return 0.1;
+  }
+  return scale / 1000.0;
+}
+
+//---------------------------------------------------------------------------
 void ShapeWorksStudioApp::handle_glyph_changed() {
   visualizer_->set_show_surface(ui_->surface_visible_button->isChecked());
   visualizer_->set_show_glyphs(ui_->glyphs_visible_button->isChecked());
@@ -1440,7 +1452,7 @@ void ShapeWorksStudioApp::handle_glyph_changed() {
     preferences_.set_show_bounding_box(bounding_box_checkbox_->isChecked());
     visualizer_->set_show_bounding_box(bounding_box_checkbox_->isChecked());
   }
-  preferences_.set_glyph_size(glyph_size_slider_->value() / 10.0);
+  preferences_.set_glyph_size(glyph_size_slider_->value() * glyph_slider_world_per_unit());
   preferences_.set_glyph_quality(glyph_quality_slider_->value());
   preferences_.set_glyph_auto_size(glyph_auto_size_->isChecked());
   preferences_.set_glyph_scale_arrows(glyph_arrow_scale_->isChecked());
@@ -1448,12 +1460,12 @@ void ShapeWorksStudioApp::handle_glyph_changed() {
   if (glyph_auto_size_->isChecked()) {
     auto glyph_size = session_->get_auto_glyph_size();
     if (glyph_size > 0) {
-      glyph_size_slider_->setValue(glyph_size * 10.0);
+      glyph_size_slider_->setValue(glyph_size / glyph_slider_world_per_unit());
     }
   }
 
   glyph_quality_label_->setText(QString::number(preferences_.get_glyph_quality()));
-  glyph_size_label_->setText(QString::number(preferences_.get_glyph_size()));
+  glyph_size_label_->setText(QString::number(preferences_.get_glyph_size(), 'g', 3));
 
   std::vector<bool> domains_to_display;
   for (auto& checkbox : domain_particle_checkboxes_) {

--- a/Studio/Interface/ShapeWorksStudioApp.h
+++ b/Studio/Interface/ShapeWorksStudioApp.h
@@ -216,6 +216,11 @@ class ShapeWorksStudioApp : public QMainWindow {
   void set_message(MessageType message_type, QString message);
 
   void create_glyph_submenu();
+
+  //! World-glyph-size represented by one step of the glyph-size slider. Scales with the shape's
+  //! largest dimension so the slider's range stays useful for very small or very large shapes.
+  double glyph_slider_world_per_unit();
+
   void create_iso_submenu();
   void create_compare_submenu();
 


### PR DESCRIPTION
* #2459 

Resolves #2459

The glyph-size slider mapped its [1, 100] range to a fixed world-unit range of [0.1, 10], and the auto glyph size was clamped to the same fixed [0.1, 10]. So on abnormally small or large shapes both hit those limits well before reaching a usable size.

Scale both to the shape's largest dimension instead: Session exposes get_glyph_size_scale() (the largest X/Y/Z extent), the slider maps to [0.1%, 10%] of it (step = scale / 1000), and the auto size is clamped to the same [0.1%, 10%] range. A shape whose largest dimension is 100 behaves identically to before, with a fallback to that mapping when no shape is loaded. Also round the displayed glyph size to 3 significant figures.