### PR TITLE
Add world-coordinate scale bar to Studio (#2259)

### DIFF
--- a/Studio/Data/Preferences.cpp
+++ b/Studio/Data/Preferences.cpp
@@ -120,6 +120,18 @@ bool Preferences::get_show_bounding_box() { return settings_.value("Project/show
 void Preferences::set_show_bounding_box(bool value) { settings_.setValue("Project/show_bounding_box", value); }
 
 //-----------------------------------------------------------------------------
+bool Preferences::get_show_scale_bar() { return settings_.value("Project/show_scale_bar", false).toBool(); }
+
+//-----------------------------------------------------------------------------
+void Preferences::set_show_scale_bar(bool value) { settings_.setValue("Project/show_scale_bar", value); }
+
+//-----------------------------------------------------------------------------
+int Preferences::get_scale_bar_font_size() { return settings_.value("Project/scale_bar_font_size", 10).toInt(); }
+
+//-----------------------------------------------------------------------------
+void Preferences::set_scale_bar_font_size(int value) { settings_.setValue("Project/scale_bar_font_size", value); }
+
+//-----------------------------------------------------------------------------
 float Preferences::get_pca_range() { return settings_.value("Analysis/pca_range", 2.0).toFloat(); }
 
 //-----------------------------------------------------------------------------

--- a/Studio/Data/Preferences.h
+++ b/Studio/Data/Preferences.h
@@ -65,6 +65,12 @@ class Preferences : public QObject {
   bool get_show_bounding_box();
   void set_show_bounding_box(bool value);
 
+  bool get_show_scale_bar();
+  void set_show_scale_bar(bool value);
+
+  int get_scale_bar_font_size();
+  void set_scale_bar_font_size(int value);
+
   float get_pca_range();
   void set_pca_range(float value);
 

--- a/Studio/Interface/ShapeWorksStudioApp.cpp
+++ b/Studio/Interface/ShapeWorksStudioApp.cpp
@@ -944,6 +944,25 @@ void ShapeWorksStudioApp::create_iso_submenu() {
   connect(bounding_box_checkbox_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
   layout->addWidget(bounding_box_checkbox_, static_cast<int>(names.size()), 0, 1, 2);
 
+  scale_bar_checkbox_ = new QCheckBox("Show scale bar", widget);
+  scale_bar_checkbox_->setChecked(preferences_.get_show_scale_bar());
+  connect(scale_bar_checkbox_, &QCheckBox::clicked, this, &ShapeWorksStudioApp::handle_glyph_changed);
+  layout->addWidget(scale_bar_checkbox_, static_cast<int>(names.size()) + 1, 0, 1, 2);
+
+  QLabel* scale_bar_font_label = new QLabel("Scale bar font: ");
+  layout->addWidget(scale_bar_font_label, static_cast<int>(names.size()) + 2, 0, 1, 1);
+  scale_bar_font_slider_ = new CustomSlider(widget);
+  scale_bar_font_slider_->setOrientation(Qt::Horizontal);
+  scale_bar_font_slider_->setMinimum(5);
+  scale_bar_font_slider_->setMaximum(30);
+  scale_bar_font_slider_->setPageStep(5);
+  scale_bar_font_slider_->setTickPosition(QSlider::TicksBelow);
+  scale_bar_font_slider_->setTickInterval(5);
+  scale_bar_font_slider_->setMinimumWidth(200);
+  scale_bar_font_slider_->setValue(preferences_.get_scale_bar_font_size());
+  connect(scale_bar_font_slider_, &CustomSlider::valueChanged, this, &ShapeWorksStudioApp::handle_glyph_changed);
+  layout->addWidget(scale_bar_font_slider_, static_cast<int>(names.size()) + 2, 1, 1, 1);
+
   QWidgetAction* widget_action = new QWidgetAction(widget);
   widget_action->setDefaultWidget(widget);
   menu->addAction(widget_action);
@@ -1451,6 +1470,13 @@ void ShapeWorksStudioApp::handle_glyph_changed() {
   if (bounding_box_checkbox_) {
     preferences_.set_show_bounding_box(bounding_box_checkbox_->isChecked());
     visualizer_->set_show_bounding_box(bounding_box_checkbox_->isChecked());
+  }
+  if (scale_bar_checkbox_) {
+    preferences_.set_show_scale_bar(scale_bar_checkbox_->isChecked());
+    visualizer_->set_show_scale_bar(scale_bar_checkbox_->isChecked());
+  }
+  if (scale_bar_font_slider_) {
+    preferences_.set_scale_bar_font_size(scale_bar_font_slider_->value());
   }
   preferences_.set_glyph_size(glyph_size_slider_->value() * glyph_slider_world_per_unit());
   preferences_.set_glyph_quality(glyph_quality_slider_->value());

--- a/Studio/Interface/ShapeWorksStudioApp.h
+++ b/Studio/Interface/ShapeWorksStudioApp.h
@@ -257,6 +257,8 @@ class ShapeWorksStudioApp : public QMainWindow {
   QCheckBox* glyph_auto_size_;
   QCheckBox* glyph_arrow_scale_{nullptr};
   QCheckBox* bounding_box_checkbox_{nullptr};
+  QCheckBox* scale_bar_checkbox_{nullptr};
+  CustomSlider* scale_bar_font_slider_{nullptr};
   QList<QAction*> recent_file_actions_;
   LogWindow log_window_;
   QPointer<StatusBarWidget> status_bar_;

--- a/Studio/Visualization/Viewer.cpp
+++ b/Studio/Visualization/Viewer.cpp
@@ -2,11 +2,13 @@
 #include <Visualization/StudioImageActorPointPlacer.h>
 #include <vtkArrowSource.h>
 #include <vtkBoundingBox.h>
+#include <vtkCallbackCommand.h>
 #include <vtkCamera.h>
 #include <vtkCell.h>
 #include <vtkCellPicker.h>
 #include <vtkColorSeries.h>
 #include <vtkCornerAnnotation.h>
+#include <vtkCubeAxesActor.h>
 #include <vtkFloatArray.h>
 #include <vtkGlyph3D.h>
 #include <vtkHandleWidget.h>
@@ -187,12 +189,48 @@ Viewer::Viewer() {
   bounding_box_actor_->GetProperty()->LightingOff();
   bounding_box_actor_->PickableOff();
 
+  // Scale bar: labeled world-coordinate tick marks along the edges of the shape's bounding box.
+  // This reads correctly in a perspective view (unlike a 2D legend scale bar). Bounds and camera
+  // are set in update_actors(). White axes/labels to match the dark viewer background.
+  scale_bar_actor_ = vtkSmartPointer<vtkCubeAxesActor>::New();
+  // Closest-triad mode draws a single ruler per axis (meeting at the corner nearest the camera).
+  // Outer-edges mode draws two rulers per axis, whose labels overlap in near-axis-aligned views.
+  scale_bar_actor_->SetFlyModeToClosestTriad();
+  scale_bar_actor_->XAxisMinorTickVisibilityOff();
+  scale_bar_actor_->YAxisMinorTickVisibilityOff();
+  scale_bar_actor_->ZAxisMinorTickVisibilityOff();
+  // Short, non-empty axis titles. Empty titles feed empty text to vtkVectorText, which errors.
+  scale_bar_actor_->SetXTitle("X");
+  scale_bar_actor_->SetYTitle("Y");
+  scale_bar_actor_->SetZTitle("Z");
+  scale_bar_actor_->GetXAxesLinesProperty()->SetColor(1.0, 1.0, 1.0);
+  scale_bar_actor_->GetYAxesLinesProperty()->SetColor(1.0, 1.0, 1.0);
+  scale_bar_actor_->GetZAxesLinesProperty()->SetColor(1.0, 1.0, 1.0);
+  for (int i = 0; i < 3; i++) {
+    scale_bar_actor_->GetLabelTextProperty(i)->SetColor(1.0, 1.0, 1.0);
+    scale_bar_actor_->GetTitleTextProperty(i)->SetColor(1.0, 1.0, 1.0);
+  }
+  scale_bar_actor_->PickableOff();
+
+  scale_bar_render_callback_ = vtkSmartPointer<vtkCallbackCommand>::New();
+  scale_bar_render_callback_->SetCallback(Viewer::on_render_start);
+  scale_bar_render_callback_->SetClientData(this);
+
   corner_annotation_ = vtkSmartPointer<vtkCornerAnnotation>::New();
   corner_annotation_->SetLinearFontScaleFactor(2);
   corner_annotation_->SetNonlinearFontScaleFactor(1);
   corner_annotation_->SetMaximumFontSize(32);
   corner_annotation_->SetMaximumLineHeight(0.03);
   corner_annotation_->SetMinimumFontSize(1);
+}
+
+//-----------------------------------------------------------------------------
+Viewer::~Viewer() {
+  // Remove the scale-bar render observer so it does not fire with a dangling 'this' after the
+  // viewer is destroyed (renderers are pooled and reused across projects).
+  if (renderer_ && scale_bar_observer_tag_) {
+    renderer_->RemoveObserver(scale_bar_observer_tag_);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -955,7 +993,19 @@ void Viewer::set_color_series(ColorMap color_series) {
 }
 
 //-----------------------------------------------------------------------------
-void Viewer::set_renderer(vtkSmartPointer<vtkRenderer> renderer) { renderer_ = renderer; }
+void Viewer::set_renderer(vtkSmartPointer<vtkRenderer> renderer) {
+  if (renderer_ && scale_bar_observer_tag_) {
+    renderer_->RemoveObserver(scale_bar_observer_tag_);
+    scale_bar_observer_tag_ = 0;
+  }
+  renderer_ = renderer;
+  // Recompute the scale-bar font at the start of each render so it can follow zoom (see
+  // update_scale_bar_font()). StartEvent (rather than the camera's ModifiedEvent) avoids firing
+  // re-entrantly from ResetCameraClippingRange while the renderer's transforms are mid-update.
+  if (renderer_) {
+    scale_bar_observer_tag_ = renderer_->AddObserver(vtkCommand::StartEvent, scale_bar_render_callback_);
+  }
+}
 
 //-----------------------------------------------------------------------------
 vtkSmartPointer<vtkRenderer> Viewer::get_renderer() { return renderer_; }
@@ -1030,6 +1080,94 @@ void Viewer::set_show_surface(bool show) {
 void Viewer::set_show_bounding_box(bool show) {
   show_bounding_box_ = show;
   update_actors();
+}
+
+//-----------------------------------------------------------------------------
+void Viewer::set_show_scale_bar(bool show) {
+  show_scale_bar_ = show;
+  update_actors();
+}
+
+//-----------------------------------------------------------------------------
+void Viewer::set_scale_bar_font_size(double size) {
+  scale_bar_font_base_ = size;
+  update_scale_bar_font();
+}
+
+//-----------------------------------------------------------------------------
+void Viewer::on_render_start(vtkObject* /*caller*/, unsigned long /*event*/, void* client_data,
+                             void* /*call_data*/) {
+  auto* self = static_cast<Viewer*>(client_data);
+  if (self) {
+    self->update_scale_bar_font();
+  }
+}
+
+//-----------------------------------------------------------------------------
+void Viewer::update_scale_bar_font() {
+  if (!show_scale_bar_ || !scale_bar_bounds_valid_ || !renderer_ || updating_scale_bar_font_) {
+    return;
+  }
+  updating_scale_bar_font_ = true;
+  int* viewport_size = renderer_->GetSize();
+  if (!viewport_size || viewport_size[0] == 0 || viewport_size[1] == 0) {
+    updating_scale_bar_font_ = false;
+    return;
+  }
+
+  // Project the 8 corners of the bounding box to screen and measure its on-screen size.
+  const double* b = scale_bar_bounds_;
+  double min_x = 1e30, min_y = 1e30, max_x = -1e30, max_y = -1e30;
+  for (int i = 0; i < 8; i++) {
+    double world[4] = {(i & 1) ? b[1] : b[0], (i & 2) ? b[3] : b[2], (i & 4) ? b[5] : b[4], 1.0};
+    renderer_->SetWorldPoint(world);
+    renderer_->WorldToDisplay();
+    double display[3];
+    renderer_->GetDisplayPoint(display);
+    min_x = std::min(min_x, display[0]);
+    max_x = std::max(max_x, display[0]);
+    min_y = std::min(min_y, display[1]);
+    max_y = std::max(max_y, display[1]);
+  }
+  double box_diagonal = std::sqrt(std::pow(max_x - min_x, 2) + std::pow(max_y - min_y, 2));
+  double viewport_diagonal = std::sqrt(std::pow(viewport_size[0], 2) + std::pow(viewport_size[1], 2));
+
+  // Scale the font by how much of the viewport the shape fills. At a fit-to-view size (~80% of the
+  // viewport) the font is the requested size; zooming out shrinks it so the labels do not collide.
+  double fraction = std::min(1.0, box_diagonal / (0.8 * viewport_diagonal));
+  double font = std::max(4.0, std::min(scale_bar_font_base_, scale_bar_font_base_ * fraction));
+  if (std::abs(font - scale_bar_actor_->GetScreenSize()) > 0.5) {
+    scale_bar_actor_->SetScreenSize(font);
+  }
+
+  // Hide the labels on any axis that is too foreshortened to hold them. When the view is rotated so
+  // one axis points nearly into the screen, its labels collapse onto each other; measure each axis's
+  // on-screen length and drop the labels on any axis much shorter than the longest one.
+  double center[3] = {(b[0] + b[1]) / 2, (b[2] + b[3]) / 2, (b[4] + b[5]) / 2};
+  auto axis_screen_length = [&](int axis) {
+    double lo[4] = {center[0], center[1], center[2], 1.0};
+    double hi[4] = {center[0], center[1], center[2], 1.0};
+    lo[axis] = b[2 * axis];
+    hi[axis] = b[2 * axis + 1];
+    double lo_display[3], hi_display[3];
+    renderer_->SetWorldPoint(lo);
+    renderer_->WorldToDisplay();
+    renderer_->GetDisplayPoint(lo_display);
+    renderer_->SetWorldPoint(hi);
+    renderer_->WorldToDisplay();
+    renderer_->GetDisplayPoint(hi_display);
+    return std::sqrt(std::pow(hi_display[0] - lo_display[0], 2) + std::pow(hi_display[1] - lo_display[1], 2));
+  };
+  double length_x = axis_screen_length(0);
+  double length_y = axis_screen_length(1);
+  double length_z = axis_screen_length(2);
+  double length_max = std::max(length_x, std::max(length_y, length_z));
+  const double min_ratio = 0.3;  // hide labels on an axis shorter than 30% of the longest axis
+  scale_bar_actor_->SetXAxisLabelVisibility(length_x >= min_ratio * length_max);
+  scale_bar_actor_->SetYAxisLabelVisibility(length_y >= min_ratio * length_max);
+  scale_bar_actor_->SetZAxisLabelVisibility(length_z >= min_ratio * length_max);
+
+  updating_scale_bar_font_ = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -1145,6 +1283,7 @@ void Viewer::update_actors() {
   renderer_->RemoveActor(arrow_glyph_actor_);
   renderer_->RemoveActor(scalar_bar_actor_);
   renderer_->RemoveActor(bounding_box_actor_);
+  renderer_->RemoveActor(scale_bar_actor_);
 
   cell_picker_->InitializePickList();
   prop_picker_->InitializePickList();
@@ -1203,7 +1342,8 @@ void Viewer::update_actors() {
     renderer_->AddActor(scalar_bar_actor_);
   }
 
-  if (show_bounding_box_) {
+  scale_bar_bounds_valid_ = false;
+  if (show_bounding_box_ || show_scale_bar_) {
     // Union the bounds of the currently-displayed geometry. Actor bounds already reflect the
     // local-to-world transform, so the box wraps the shape as it appears on screen.
     vtkBoundingBox bbox;
@@ -1217,8 +1357,18 @@ void Viewer::update_actors() {
     if (bbox.IsValid()) {
       double bounds[6];
       bbox.GetBounds(bounds);
-      bounding_box_source_->SetBounds(bounds);
-      renderer_->AddActor(bounding_box_actor_);
+      if (show_bounding_box_) {
+        bounding_box_source_->SetBounds(bounds);
+        renderer_->AddActor(bounding_box_actor_);
+      }
+      if (show_scale_bar_) {
+        scale_bar_actor_->SetBounds(bounds);
+        scale_bar_actor_->SetCamera(renderer_->GetActiveCamera());
+        std::copy(bounds, bounds + 6, scale_bar_bounds_);
+        scale_bar_bounds_valid_ = true;
+        renderer_->AddActor(scale_bar_actor_);
+        update_scale_bar_font();
+      }
     }
   }
 

--- a/Studio/Visualization/Viewer.h
+++ b/Studio/Visualization/Viewer.h
@@ -16,6 +16,8 @@ class vtkCamera;
 class vtkGlyph3D;
 class vtkSphereSource;
 class vtkArrowSource;
+class vtkCallbackCommand;
+class vtkCubeAxesActor;
 class vtkOutlineSource;
 class vtkTransformPolyDataFilter;
 class vtkScalarBarActor;
@@ -65,7 +67,7 @@ enum class ViewOrientation { Anterior, Posterior, Left, Right, Superior, Inferio
 class Viewer {
  public:
   Viewer();
-  ~Viewer() = default;
+  ~Viewer();
 
   void set_renderer(vtkSmartPointer<vtkRenderer> renderer);
   vtkSmartPointer<vtkRenderer> get_renderer();
@@ -90,6 +92,8 @@ class Viewer {
   void set_show_glyphs(bool show);
   void set_show_surface(bool show);
   void set_show_bounding_box(bool show);
+  void set_show_scale_bar(bool show);
+  void set_scale_bar_font_size(double size);
   void set_scale_arrows(bool scale);
 
   void update_points();
@@ -179,6 +183,13 @@ class Viewer {
  private:
   void initialize_surfaces();
 
+  //! Recompute the scale-bar label font from the bounding box's current on-screen size so labels
+  //! shrink as the shape is zoomed out (they are otherwise a fixed screen size and collide).
+  void update_scale_bar_font();
+
+  //! Renderer StartEvent callback: forwards to update_scale_bar_font() so the labels track zoom.
+  static void on_render_start(vtkObject* caller, unsigned long event, void* client_data, void* call_data);
+
   void display_vector_field();
 
   void compute_point_differences(const Eigen::VectorXd& points, vtkSmartPointer<vtkFloatArray> magnitudes,
@@ -199,6 +210,7 @@ class Viewer {
   bool show_glyphs_ = true;
   bool show_surface_ = true;
   bool show_bounding_box_ = false;
+  bool show_scale_bar_ = false;
 
   double glyph_size_ = 1.0f;
   double glyph_quality_ = 5.0f;
@@ -240,6 +252,14 @@ class Viewer {
   vtkSmartPointer<vtkOutlineSource> bounding_box_source_;
   vtkSmartPointer<vtkPolyDataMapper> bounding_box_mapper_;
   vtkSmartPointer<vtkActor> bounding_box_actor_;
+
+  vtkSmartPointer<vtkCubeAxesActor> scale_bar_actor_;
+  vtkSmartPointer<vtkCallbackCommand> scale_bar_render_callback_;
+  unsigned long scale_bar_observer_tag_ = 0;
+  double scale_bar_font_base_ = 10.0;             // requested font (slider); acts as the upper bound
+  double scale_bar_bounds_[6] = {0, -1, 0, -1, 0, -1};  // bounds of the last drawn scale bar (invalid by default)
+  bool scale_bar_bounds_valid_ = false;
+  bool updating_scale_bar_font_ = false;
 
   vtkSmartPointer<vtkCornerAnnotation> corner_annotation_;
 

--- a/Studio/Visualization/Visualizer.cpp
+++ b/Studio/Visualization/Visualizer.cpp
@@ -249,6 +249,9 @@ void Visualizer::set_show_surface(bool show) { show_surface_ = show; }
 void Visualizer::set_show_bounding_box(bool show) { show_bounding_box_ = show; }
 
 //-----------------------------------------------------------------------------
+void Visualizer::set_show_scale_bar(bool show) { show_scale_bar_ = show; }
+
+//-----------------------------------------------------------------------------
 void Visualizer::update_viewer_properties() {
   double size = preferences_.get_glyph_size();
   double quality = preferences_.get_glyph_quality();
@@ -269,6 +272,8 @@ void Visualizer::update_viewer_properties() {
       viewer->set_show_glyphs(show_glyphs_);
       viewer->set_show_surface(show_surface_);
       viewer->set_show_bounding_box(show_bounding_box_);
+      viewer->set_show_scale_bar(show_scale_bar_);
+      viewer->set_scale_bar_font_size(preferences_.get_scale_bar_font_size());
       viewer->set_scale_arrows(preferences_.get_glyph_scale_arrows());
       viewer->set_color_scheme(preferences_.get_color_scheme());
     }

--- a/Studio/Visualization/Visualizer.h
+++ b/Studio/Visualization/Visualizer.h
@@ -51,6 +51,9 @@ class Visualizer : public QObject {
   /// turn on/off the shape bounding box
   void set_show_bounding_box(bool show);
 
+  /// turn on/off the world-coordinate scale bar
+  void set_show_scale_bar(bool show);
+
   /// update the display using the current settings
   void display_samples();
 
@@ -185,6 +188,7 @@ class Visualizer : public QObject {
   bool show_glyphs_ = true;
   bool show_surface_ = true;
   bool show_bounding_box_ = false;
+  bool show_scale_bar_ = false;
 
   LightboxHandle lightbox_;
   SessionHandle session_;


### PR DESCRIPTION
Adds a "Show scale bar" option to Studio that overlays a labeled world-coordinate ruler around the shape, so the physical size of the data is readable directly in the 3D view.

Fixes #2259