### PR TITLE
Fix particle/time estimates when using initial landmarks (#2275)

### DIFF
--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -2092,30 +2092,44 @@ void Optimize::SetEarlyStoppingConfig(EarlyStoppingConfig config) { m_sampler->S
 void Optimize::ComputeTotalIterations() {
   total_particle_iterations_ = 0;
 
-  int highest_particle_count = *std::max_element(m_number_of_particles.begin(), m_number_of_particles.end());
+  const int domains_per_shape = static_cast<int>(m_number_of_particles.size());
 
-  int number_of_splits = static_cast<int>(std::log2(static_cast<double>(highest_particle_count)));
-
-  int num_particles = 2;
-  for (int i = 0; i < number_of_splits; i++) {
-    for (int d = 0; d < m_number_of_particles.size(); d++) {
-      double add = m_iterations_per_split * std::min(num_particles, m_number_of_particles[d]);
-      total_particle_iterations_ += add;
+  // Splits double each domain's particles until it reaches its target, so the split count is set by
+  // the domain seeded with the fewest particles. Initial landmarks/points seed many particles and
+  // reduce it; single-seeded (e.g. non-fixed) domains keep it high (#2275).
+  int number_of_splits = 0;
+  for (int j = 0; j < m_num_shapes; j++) {
+    int target = m_number_of_particles[j % domains_per_shape];
+    int seed = std::min(std::max(1, m_sampler->GetInitialParticleCount(j)), target);
+    int splits = 0;
+    for (int count = seed; count < target; count *= 2) {
+      splits++;
     }
+    number_of_splits = std::max(number_of_splits, splits);
+  }
 
-    if (m_use_shape_statistics_after > 0 && num_particles >= m_use_shape_statistics_after) {
-      for (int d = 0; d < m_number_of_particles.size(); d++) {
-        total_particle_iterations_ += m_optimization_iterations * std::min(num_particles, m_number_of_particles[d]);
+  // Progress accumulates over the first shape's domains (see SetIterationCallback), so estimate the
+  // same way: track their particle counts as they split.
+  std::vector<int> current_particles(domains_per_shape);
+  for (int d = 0; d < domains_per_shape; d++) {
+    int initial = std::max(1, m_sampler->GetInitialParticleCount(d));
+    current_particles[d] = std::min(initial, m_number_of_particles[d]);
+  }
+
+  for (int i = 0; i < number_of_splits; i++) {
+    for (int d = 0; d < domains_per_shape; d++) {
+      current_particles[d] = std::min(current_particles[d] * 2, m_number_of_particles[d]);
+      total_particle_iterations_ += m_iterations_per_split * current_particles[d];
+
+      if (m_use_shape_statistics_after > 0 && current_particles[d] >= m_use_shape_statistics_after) {
+        total_particle_iterations_ += m_optimization_iterations * current_particles[d];
       }
     }
-
-    num_particles *= 2;
   }
 
   if (m_use_shape_statistics_after <= 0) {
-    for (int d = 0; d < m_number_of_particles.size(); d++) {
-      double add = m_optimization_iterations * std::min(num_particles, m_number_of_particles[d]);
-      total_particle_iterations_ += add;
+    for (int d = 0; d < domains_per_shape; d++) {
+      total_particle_iterations_ += m_optimization_iterations * m_number_of_particles[d];
     }
   }
 

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -314,6 +314,12 @@ class Optimize {
 
   void UpdateProgress();
 
+  //! Return the estimated total number of particle-iterations used for progress reporting
+  int GetTotalParticleIterations() const { return total_particle_iterations_; }
+
+  //! Return the number of particle-iterations completed so far
+  int GetCompletedParticleIterations() const { return current_particle_iterations_; }
+
   void set_particle_format(std::string format) { particle_format_ = format; }
 
  protected:

--- a/Libs/Optimize/Sampler.cpp
+++ b/Libs/Optimize/Sampler.cpp
@@ -140,6 +140,21 @@ void Sampler::initialize_initial_positions() {
 }
 
 //---------------------------------------------------------------------------
+int Sampler::GetInitialParticleCount(int domain) const {
+  if (domain >= 0 && domain < static_cast<int>(initial_points_.size()) && !initial_points_[domain].empty()) {
+    return static_cast<int>(initial_points_[domain].size());
+  }
+  if (domain >= 0 && domain < static_cast<int>(m_PointsFiles.size()) && !m_PointsFiles[domain].empty()) {
+    try {
+      return static_cast<int>(particles::read_particles_as_vector(m_PointsFiles[domain]).size());
+    } catch (const std::exception& e) {
+      SW_WARN("Unable to read initial points file '{}' for iteration estimate: {}", m_PointsFiles[domain], e.what());
+    }
+  }
+  return 1;
+}
+
+//---------------------------------------------------------------------------
 void Sampler::InitializeOptimizationFunctions() {
   // Set the minimum neighborhood radius and maximum sigma based on the
   // domain of the 1st input image.

--- a/Libs/Optimize/Sampler.h
+++ b/Libs/Optimize/Sampler.h
@@ -4,21 +4,21 @@
 #include <Mesh/Mesh.h>
 
 #include "CorrespondenceMode.h"
+#include "EarlyStoppingConfig.h"
 #include "GradientDescentOptimizer.h"
 #include "Libs/Optimize/Container/GenericContainerArray.h"
 #include "Libs/Optimize/Container/MeanCurvatureContainer.h"
 #include "Libs/Optimize/Domain/Surface.h"
 #include "Libs/Optimize/Function/CorrespondenceFunction.h"
-#include "Libs/Optimize/Function/SamplingFunction.h"
 #include "Libs/Optimize/Function/DisentangledCorrespondenceFunction.h"
 #include "Libs/Optimize/Function/DualVectorFunction.h"
 #include "Libs/Optimize/Function/LegacyCorrespondenceFunction.h"
+#include "Libs/Optimize/Function/SamplingFunction.h"
 #include "Libs/Optimize/Matrix/LinearRegressionShapeMatrix.h"
 #include "Libs/Optimize/Matrix/MixedEffectsShapeMatrix.h"
 #include "Libs/Optimize/Neighborhood/ParticleNeighborhood.h"
 #include "ParticleSystem.h"
 #include "vnl/vnl_matrix_fixed.h"
-#include "EarlyStoppingConfig.h"
 
 // Uncomment to visualize FFCs with scalar and vector fields
 // #define VIZFFC
@@ -89,6 +89,10 @@ class Sampler {
   void SetInitialPoints(std::vector<std::vector<itk::Point<double>>> initial_points) {
     initial_points_ = initial_points;
   }
+
+  //! Return the number of particles the given domain is seeded with (from initial points or a
+  //! point/landmark file), or 1 if it starts from a single seed point.
+  int GetInitialParticleCount(int domain) const;
 
   void AddImage(ImageType::Pointer image, double narrow_band, std::string name = "");
 
@@ -195,9 +199,7 @@ class Sampler {
 
   const DualVectorFunction* GetLinkingFunction() const { return m_LinkingFunction.get(); }
 
-  const LegacyCorrespondenceFunction* GetEnsembleEntropyFunction() const {
-    return m_EnsembleEntropyFunction.get();
-  }
+  const LegacyCorrespondenceFunction* GetEnsembleEntropyFunction() const { return m_EnsembleEntropyFunction.get(); }
 
   const DisentangledCorrespondenceFunction* GetDisentangledEnsembleEntropyFunction() const {
     return m_DisentangledEnsembleEntropyFunction.get();
@@ -348,7 +350,7 @@ class Sampler {
 
   std::vector<std::vector<itk::Point<double>>> initial_points_;
 
-  EarlyStoppingConfig early_stopping_config_; // config for early stopping
+  EarlyStoppingConfig early_stopping_config_;  // config for early stopping
 
   unsigned int m_verbosity;
 };

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -190,6 +190,27 @@ TEST(OptimizeTests, fixed_domain) {
 }
 
 //---------------------------------------------------------------------------
+// #2275: the progress/time estimate (total_particle_iterations_) assumed every domain starts from a
+// single seed particle and doubles at each split.  When a domain is seeded with initial points (as
+// with initial landmarks or fixed domains) it starts with many particles and does fewer splits, so
+// the estimate overcounted.  Verify the estimate matches the iterations actually performed, which is
+// what keeps the progress bar and time estimate accurate.
+TEST(OptimizeTests, initial_points_iteration_estimate) {
+  prep_temp("/optimize/fixed_domain", "estimate");
+
+  Optimize app;
+  ProjectHandle project = std::make_shared<Project>();
+  ASSERT_TRUE(project->load("optimize.swproj"));
+  OptimizeParameters params(project);
+  ASSERT_TRUE(params.set_up_optimize(&app));
+  ASSERT_TRUE(app.Run());
+
+  // The accumulated iterations should exactly reach the pre-computed estimate (progress hits 100%).
+  ASSERT_GT(app.GetTotalParticleIterations(), 0);
+  ASSERT_EQ(app.GetCompletedParticleIterations(), app.GetTotalParticleIterations());
+}
+
+//---------------------------------------------------------------------------
 // #2192: when using fixed domains, the requested number of particles must match
 // the existing (original) particle count.  A mismatch should be reported as an
 // error rather than silently producing a broken model.


### PR DESCRIPTION
* #2275 

Fixes #2275.

Fix particle/time estimates when using initial landmarks
