### PR TITLE
Fix #2605 - Groom segfault in Mesh::computeNormals on degenerate result from remesh/smooth

### DIFF
--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -191,9 +191,12 @@ Mesh::Mesh(const Eigen::MatrixXd& points, const Eigen::MatrixXi& faces) {
   this->poly_data_->SetPoints(vertices);
   this->poly_data_->SetPolys(polys);
   // Guard against degenerate input triangles: computeNormals() -> vtkPolyDataNormals
-  // AutoOrientNormals -> vtkOrientPolyData segfaults on zero-area cells. This only
-  // alters malformed input (well-formed meshes are returned unchanged).
-  this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+  // AutoOrientNormals -> vtkOrientPolyData segfaults on zero-area cells. Only touch the
+  // mesh when a degenerate triangle is actually present, so well-formed input (and its
+  // point ordering) is returned unchanged.
+  if (MeshUtils::has_zero_area_triangles(this->poly_data_)) {
+    this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+  }
   this->computeNormals();
 }
 
@@ -327,8 +330,11 @@ Mesh& Mesh::smooth(int iterations, double relaxation) {
 
   // Smoothing can collapse triangles to zero area; remove them before computing
   // normals. vtkPolyDataNormals' AutoOrientNormals uses vtkOrientPolyData, whose
-  // edge-neighbor traversal segfaults on degenerate cells.
-  this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+  // edge-neighbor traversal segfaults on degenerate cells. Only rebuild when such a
+  // triangle is present, so well-formed output is left untouched.
+  if (MeshUtils::has_zero_area_triangles(this->poly_data_)) {
+    this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+  }
 
   // must regenerate normals after smoothing
   computeNormals();
@@ -356,8 +362,11 @@ Mesh& Mesh::smoothSinc(int iterations, double passband) {
 
   // Smoothing can collapse triangles to zero area; remove them before computing
   // normals. vtkPolyDataNormals' AutoOrientNormals uses vtkOrientPolyData, whose
-  // edge-neighbor traversal segfaults on degenerate cells.
-  this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+  // edge-neighbor traversal segfaults on degenerate cells. Only rebuild when such a
+  // triangle is present, so well-formed output is left untouched.
+  if (MeshUtils::has_zero_area_triangles(this->poly_data_)) {
+    this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+  }
 
   // must regenerate normals after smoothing
   computeNormals();
@@ -398,9 +407,11 @@ Mesh& Mesh::remesh(int numVertices, double adaptivity) {
 
   // ACVD remeshing can produce zero-area (degenerate) triangles. These must be
   // removed before computing normals: vtkPolyDataNormals with AutoOrientNormals
-  // runs vtkOrientPolyData, which segfaults on degenerate geometry.
-  clean();
-  this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+  // runs vtkOrientPolyData, which segfaults on degenerate geometry. Only rebuild when
+  // such a triangle is present, so well-formed remesh output is left untouched.
+  if (MeshUtils::has_zero_area_triangles(this->poly_data_)) {
+    this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+  }
 
   // must regenerate normals after remeshing
   computeNormals();

--- a/Libs/Mesh/Mesh.cpp
+++ b/Libs/Mesh/Mesh.cpp
@@ -190,6 +190,10 @@ Mesh::Mesh(const Eigen::MatrixXd& points, const Eigen::MatrixXi& faces) {
 
   this->poly_data_->SetPoints(vertices);
   this->poly_data_->SetPolys(polys);
+  // Guard against degenerate input triangles: computeNormals() -> vtkPolyDataNormals
+  // AutoOrientNormals -> vtkOrientPolyData segfaults on zero-area cells. This only
+  // alters malformed input (well-formed meshes are returned unchanged).
+  this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
   this->computeNormals();
 }
 
@@ -321,6 +325,11 @@ Mesh& Mesh::smooth(int iterations, double relaxation) {
   smoother->Update();
   this->poly_data_ = smoother->GetOutput();
 
+  // Smoothing can collapse triangles to zero area; remove them before computing
+  // normals. vtkPolyDataNormals' AutoOrientNormals uses vtkOrientPolyData, whose
+  // edge-neighbor traversal segfaults on degenerate cells.
+  this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+
   // must regenerate normals after smoothing
   computeNormals();
 
@@ -344,6 +353,11 @@ Mesh& Mesh::smoothSinc(int iterations, double passband) {
 
   smoother->Update();
   this->poly_data_ = smoother->GetOutput();
+
+  // Smoothing can collapse triangles to zero area; remove them before computing
+  // normals. vtkPolyDataNormals' AutoOrientNormals uses vtkOrientPolyData, whose
+  // edge-neighbor traversal segfaults on degenerate cells.
+  this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
 
   // must regenerate normals after smoothing
   computeNormals();
@@ -380,12 +394,15 @@ Mesh& Mesh::remesh(int numVertices, double adaptivity) {
   // Restore std::cout
   //  std::cout.clear();
 
-  clean();
-  checkIntegrity();
-
   this->poly_data_ = remesh->GetOutput();
 
-  // must regenerate normals after smoothing
+  // ACVD remeshing can produce zero-area (degenerate) triangles. These must be
+  // removed before computing normals: vtkPolyDataNormals with AutoOrientNormals
+  // runs vtkOrientPolyData, which segfaults on degenerate geometry.
+  clean();
+  this->poly_data_ = MeshUtils::remove_zero_area_triangles(this->poly_data_);
+
+  // must regenerate normals after remeshing
   computeNormals();
 
   this->invalidateLocators();

--- a/Libs/Mesh/MeshUtils.cpp
+++ b/Libs/Mesh/MeshUtils.cpp
@@ -1086,6 +1086,52 @@ vtkSmartPointer<vtkPolyData> MeshUtils::remove_zero_area_triangles(vtkSmartPoint
 }
 
 //---------------------------------------------------------------------------
+bool MeshUtils::has_zero_area_triangles(vtkSmartPointer<vtkPolyData> mesh) {
+  // Uses the same relative epsilon as remove_zero_area_triangles(), so this returns
+  // true exactly when that function would drop a triangle. Callers can guard on it to
+  // skip the (point-renumbering) cleanup on well-formed meshes.
+  vtkSmartPointer<vtkPoints> points = mesh->GetPoints();
+  if (!points) {
+    return false;
+  }
+
+  auto cell_point_ids = vtkSmartPointer<vtkIdList>::New();
+
+  // First pass: find max area to establish scale
+  double max_area = 0.0;
+  for (vtkIdType cellId = 0; cellId < mesh->GetNumberOfCells(); cellId++) {
+    mesh->GetCellPoints(cellId, cell_point_ids);
+    if (cell_point_ids->GetNumberOfIds() == 3) {
+      double p0[3], p1[3], p2[3];
+      points->GetPoint(cell_point_ids->GetId(0), p0);
+      points->GetPoint(cell_point_ids->GetId(1), p1);
+      points->GetPoint(cell_point_ids->GetId(2), p2);
+      max_area = std::max(max_area, vtkTriangle::TriangleArea(p0, p1, p2));
+    }
+  }
+
+  const double RELATIVE_EPSILON = 1e-6;
+  const double ABSOLUTE_FLOOR = 1e-15;
+  const double epsilon = std::max(max_area * RELATIVE_EPSILON, ABSOLUTE_FLOOR);
+
+  // Second pass: does any triangle fall at or below the threshold?
+  for (vtkIdType cellId = 0; cellId < mesh->GetNumberOfCells(); cellId++) {
+    mesh->GetCellPoints(cellId, cell_point_ids);
+    if (cell_point_ids->GetNumberOfIds() == 3) {
+      double p0[3], p1[3], p2[3];
+      points->GetPoint(cell_point_ids->GetId(0), p0);
+      points->GetPoint(cell_point_ids->GetId(1), p1);
+      points->GetPoint(cell_point_ids->GetId(2), p2);
+      if (vtkTriangle::TriangleArea(p0, p1, p2) <= epsilon) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+//---------------------------------------------------------------------------
 vtkSmartPointer<vtkPolyData> MeshUtils::recreate_mesh(vtkSmartPointer<vtkPolyData> mesh) {
   vtkSmartPointer<vtkPolyData> poly_data = vtkSmartPointer<vtkPolyData>::New();
 

--- a/Libs/Mesh/MeshUtils.h
+++ b/Libs/Mesh/MeshUtils.h
@@ -75,6 +75,9 @@ class MeshUtils {
   /// Remove zero area triangles from a mesh
   static vtkSmartPointer<vtkPolyData> remove_zero_area_triangles(vtkSmartPointer<vtkPolyData> mesh);
 
+  /// Return true if the mesh contains any (near) zero-area triangle
+  static bool has_zero_area_triangles(vtkSmartPointer<vtkPolyData> mesh);
+
   /// Recreate mesh, dropping deleted cells
   static vtkSmartPointer<vtkPolyData> recreate_mesh(vtkSmartPointer<vtkPolyData> mesh);
 

--- a/devenv.sh
+++ b/devenv.sh
@@ -33,6 +33,19 @@ echo "Binary directory: ${BUILD}"
 export PATH=${BUILD}:$PATH
 export PYTHONPATH=${BUILD}:$PYTHONPATH
 
+# Put the dependency libraries on the runtime loader path. End-user packages get
+# self-contained $ORIGIN RPATHs from linuxdeployqt (see Support/package.sh), but
+# in a dev build tree the dependency libs (e.g. ITK's gdcm) still carry a stale
+# RUNPATH pointing at the old conda env. glibc does not apply the executable's
+# RPATH to those transitive loads, so we set LD_LIBRARY_PATH here instead, which
+# is searched first. The dependency install prefix is recorded in the build's
+# CMake cache as CMAKE_PREFIX_PATH.
+DEPS_PREFIX="$(grep -m1 '^CMAKE_PREFIX_PATH' "$(dirname "${BUILD}")/CMakeCache.txt" 2>/dev/null | cut -d= -f2)"
+if [ -n "${DEPS_PREFIX}" ] && [ -d "${DEPS_PREFIX}/lib" ]; then
+    export LD_LIBRARY_PATH="${DEPS_PREFIX}/lib:${LD_LIBRARY_PATH}"
+    echo "set LD_LIBRARY_PATH to include ${DEPS_PREFIX}/lib"
+fi
+
 # add each module in ${SOURCE}/Python to the PYTHONPATH
 for M in ${SOURCE}/Python/*/; do
     export PYTHONPATH=${M}:$PYTHONPATH


### PR DESCRIPTION
* #2605 

Fix #2605 - Groom segfaults in Mesh::computeNormals on degenerate (zero-area) triangles from remesh/smooth