### PR TITLE
Add registration-based particle initialization

### DIFF
--- a/Applications/shapeworks/Commands.h
+++ b/Applications/shapeworks/Commands.h
@@ -45,6 +45,7 @@ COMMAND_DECLARE(DivideImage, ImageCommand);
 COMMAND_DECLARE(ImageToMesh, ImageCommand);
 COMMAND_DECLARE(SetRegion, ImageCommand);
 COMMAND_DECLARE(Isolate, ImageCommand);
+COMMAND_DECLARE(TransferParticles, ImageCommand);
 
 // Particle System Commands
 COMMAND_DECLARE(ReadParticleSystem, ParticleSystemCommand);

--- a/Applications/shapeworks/ImageCommands.cpp
+++ b/Applications/shapeworks/ImageCommands.cpp
@@ -1,6 +1,8 @@
 #include "Commands.h"
 #include "Image.h"
+#include "ImageRegistration.h"
 #include "ImageUtils.h"
+#include "ParticleFile.h"
 
 namespace shapeworks {
 
@@ -1381,6 +1383,91 @@ bool Isolate::execute(const optparse::Values &options, SharedCommandData &shared
   int minsize = static_cast<int>(options.get("minsize"));
 
   sharedData.image.isolate(minsize);
+  return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// TransferParticles
+///////////////////////////////////////////////////////////////////////////////
+void TransferParticles::buildParser()
+{
+  const std::string prog = "transfer-particles";
+  const std::string desc = "transfers a particle set from the current image, used as the registration reference, onto a target image by deformably registering the two";
+  parser.prog(prog).description(desc);
+
+  parser.add_option("--target").action("store").type("string").set_default("").help("Distance transform of the target image.");
+  parser.add_option("--particles").action("store").type("string").set_default("").help("Particle file holding the reference particles.");
+  parser.add_option("--output").action("store").type("string").set_default("").help("Particle file to write the transferred particles to.");
+  parser.add_option("--transform").action("store").type("string").set_default("SyN").help("Registration stages to run: Rigid, Affine or SyN [default: %default].");
+  parser.add_option("--band").action("store").type("double").set_default(5.0).help("Half-width of the distance transform band retained for registration [default: %default].");
+  parser.add_option("--gradstep").action("store").type("double").set_default(0.25).help("SyN gradient step size [default: %default].");
+  parser.add_option("--flowsigma").action("store").type("double").set_default(3.0).help("Variance for smoothing the SyN update field [default: %default].");
+  parser.add_option("--totalsigma").action("store").type("double").set_default(0.0).help("Variance for smoothing the SyN total field [default: %default].");
+  parser.add_option("--warped").action("store").type("string").set_default("").help("Optional path to write the warped target image for inspection.");
+
+  Command::buildParser();
+}
+
+bool TransferParticles::execute(const optparse::Values &options, SharedCommandData &sharedData)
+{
+  if (!sharedData.validImage())
+  {
+    std::cerr << "No image to operate on\n";
+    return false;
+  }
+
+  std::string target_name = static_cast<std::string>(options.get("target"));
+  std::string particles_name = static_cast<std::string>(options.get("particles"));
+  std::string output_name = static_cast<std::string>(options.get("output"));
+  std::string transform_name = static_cast<std::string>(options.get("transform"));
+  std::string warped_name = static_cast<std::string>(options.get("warped"));
+  double band = static_cast<double>(options.get("band"));
+
+  if (target_name == "" || particles_name == "" || output_name == "")
+  {
+    std::cerr << "Must specify --target, --particles and --output\n";
+    return false;
+  }
+
+  ImageRegistration::TransformType transform_type;
+  if (transform_name == "Rigid")
+  {
+    transform_type = ImageRegistration::TransformType::Rigid;
+  }
+  else if (transform_name == "Affine")
+  {
+    transform_type = ImageRegistration::TransformType::Affine;
+  }
+  else if (transform_name == "SyN")
+  {
+    transform_type = ImageRegistration::TransformType::SyN;
+  }
+  else
+  {
+    std::cerr << "Unknown transform type '" << transform_name << "', expected Rigid, Affine or SyN\n";
+    return false;
+  }
+
+  Image target(target_name);
+
+  ImageRegistration registration;
+  registration.set_transform_type(transform_type);
+  registration.set_gradient_step(static_cast<double>(options.get("gradstep")));
+  registration.set_update_field_variance(static_cast<double>(options.get("flowsigma")));
+  registration.set_total_field_variance(static_cast<double>(options.get("totalsigma")));
+
+  // the reference is the fixed image, so the resulting transform carries its particles onto the target
+  registration.run(ImageRegistration::make_registration_image(sharedData.image, band),
+                   ImageRegistration::make_registration_image(target, band));
+
+  auto particles = particles::read_particles_as_vector(particles_name);
+  particles::write_particles_from_vector(output_name, registration.transform_points(particles));
+
+  if (warped_name != "")
+  {
+    registration.warped_moving().write(warped_name);
+  }
+
   return true;
 }
 

--- a/Applications/shapeworks/shapeworks.cpp
+++ b/Applications/shapeworks/shapeworks.cpp
@@ -54,6 +54,7 @@ int main(int argc, char *argv[])
   shapeworks.addCommand(CompareImage::getCommand());
   shapeworks.addCommand(SetRegion::getCommand());
   shapeworks.addCommand(Isolate::getCommand());
+  shapeworks.addCommand(TransferParticles::getCommand());
 
   // Particle System Commands
   shapeworks.addCommand(ReadParticleSystem::getCommand());

--- a/Libs/Image/CMakeLists.txt
+++ b/Libs/Image/CMakeLists.txt
@@ -3,11 +3,13 @@ set(Image_sources
   Image.cpp
   VectorImage.cpp
   ImageUtils.cpp
+  ImageRegistration.cpp
   )
 set(Image_headers
   Image.h
   VectorImage.h
   ImageUtils.h
+  ImageRegistration.h
   )
 add_library(Image STATIC
   ${Image_sources}

--- a/Libs/Image/ImageRegistration.cpp
+++ b/Libs/Image/ImageRegistration.cpp
@@ -1,11 +1,14 @@
 #include "ImageRegistration.h"
 
+#include "ShapeworksUtils.h"
+
 #include <itkANTSNeighborhoodCorrelationImageToImageMetricv4.h>
 #include <itkAffineTransform.h>
 #include <itkCenteredTransformInitializer.h>
 #include <itkConjugateGradientLineSearchOptimizerv4.h>
 #include <itkDisplacementFieldTransform.h>
 #include <itkDisplacementFieldTransformParametersAdaptor.h>
+#include <itkHDF5TransformIOFactory.h>
 #include <itkImageRegionIterator.h>
 #include <itkImageRegistrationMethodv4.h>
 #include <itkLinearInterpolateImageFunction.h>
@@ -13,6 +16,11 @@
 #include <itkRegistrationParameterScalesFromPhysicalShift.h>
 #include <itkResampleImageFilter.h>
 #include <itkShrinkImageFilter.h>
+#include <itkCastImageFilter.h>
+#include <itkImageFileReader.h>
+#include <itkImageFileWriter.h>
+#include <itkTransformFileReader.h>
+#include <itkTransformFileWriter.h>
 #include <itkSyNImageRegistrationMethod.h>
 #include <itkVersorRigid3DTransform.h>
 
@@ -490,6 +498,115 @@ ImageRegistration::CompositeTransformType::Pointer ImageRegistration::get_transf
     throw std::runtime_error("get_transform called before run()");
   }
   return impl_->composite;
+}
+
+//---------------------------------------------------------------------------
+/// The displacement field is far larger than everything else combined, so it is kept beside the
+/// linear transforms as an image of floats rather than inside the transform file as raw doubles.
+/// Float carries the field to well under a micron, which is far finer than it is accurate.
+static std::string displacement_field_path(const std::string& filename) { return filename + ".field.nrrd"; }
+
+
+//---------------------------------------------------------------------------
+void ImageRegistration::save_transform(const std::string& filename) const {
+  if (!impl_->composite) {
+    throw std::runtime_error("save_transform called before run()");
+  }
+
+  itk::HDF5TransformIOFactory::RegisterOneFactory();
+
+  using StoredFieldType = itk::Image<itk::Vector<float, 3>, 3>;
+
+  auto linear = CompositeTransformType::New();
+  StoredFieldType::Pointer stored_field;
+
+  for (size_t i = 0; i < impl_->composite->GetNumberOfTransforms(); i++) {
+    auto transform = impl_->composite->GetNthTransform(i);
+    auto* field = dynamic_cast<DisplacementFieldTransformType*>(transform.GetPointer());
+    if (!field) {
+      linear->AddTransform(transform);
+      continue;
+    }
+    // only the forward field is needed to carry points across; the inverse would double the size
+    using CastType = itk::CastImageFilter<DisplacementFieldTransformType::DisplacementFieldType, StoredFieldType>;
+    // stored at full resolution: the field carries real detail, and halving it costs a sixth of the
+    // registration's own accuracy, which is the opposite of the point
+    auto cast = CastType::New();
+    cast->SetInput(field->GetDisplacementField());
+    cast->Update();
+    stored_field = cast->GetOutput();
+  }
+
+  try {
+    auto writer = itk::TransformFileWriterTemplate<double>::New();
+    writer->SetFileName(filename);
+    writer->SetInput(linear);
+    writer->Update();
+
+    if (stored_field) {
+      auto field_writer = itk::ImageFileWriter<StoredFieldType>::New();
+      field_writer->SetFileName(displacement_field_path(filename));
+      field_writer->SetInput(stored_field);
+      field_writer->UseCompressionOn();
+      field_writer->Update();
+    }
+  } catch (const itk::ExceptionObject& e) {
+    throw std::runtime_error(std::string("unable to write transform \"") + filename + "\": " + e.what());
+  }
+}
+
+//---------------------------------------------------------------------------
+bool ImageRegistration::load_transform(const std::string& filename) {
+  itk::HDF5TransformIOFactory::RegisterOneFactory();
+
+  using StoredFieldType = itk::Image<itk::Vector<float, 3>, 3>;
+
+  auto composite = CompositeTransformType::New();
+  try {
+    auto reader = itk::TransformFileReaderTemplate<double>::New();
+    reader->SetFileName(filename);
+    reader->Update();
+
+    for (const auto& transform : *reader->GetTransformList()) {
+      auto* casted = dynamic_cast<CompositeTransformType::TransformType*>(transform.GetPointer());
+      if (!casted) {
+        return false;
+      }
+      // a composite reads back as its individual transforms, in the order they were added
+      if (auto* nested = dynamic_cast<CompositeTransformType*>(casted)) {
+        for (size_t i = 0; i < nested->GetNumberOfTransforms(); i++) {
+          composite->AddTransform(nested->GetNthTransform(i));
+        }
+      } else {
+        composite->AddTransform(casted);
+      }
+    }
+
+    const auto field_file = displacement_field_path(filename);
+    if (ShapeWorksUtils::file_exists(field_file)) {
+      auto field_reader = itk::ImageFileReader<StoredFieldType>::New();
+      field_reader->SetFileName(field_file);
+      field_reader->Update();
+
+      using CastType = itk::CastImageFilter<StoredFieldType, DisplacementFieldTransformType::DisplacementFieldType>;
+      auto cast = CastType::New();
+      cast->SetInput(field_reader->GetOutput());
+      cast->Update();
+
+      auto field_transform = DisplacementFieldTransformType::New();
+      field_transform->SetDisplacementField(cast->GetOutput());
+      composite->AddTransform(field_transform);
+    }
+  } catch (const itk::ExceptionObject&) {
+    return false;  // a cache that cannot be read is simply not a cache hit
+  }
+
+  if (composite->GetNumberOfTransforms() == 0) {
+    return false;
+  }
+
+  impl_->composite = composite;
+  return true;
 }
 
 //---------------------------------------------------------------------------

--- a/Libs/Image/ImageRegistration.cpp
+++ b/Libs/Image/ImageRegistration.cpp
@@ -1,0 +1,515 @@
+#include "ImageRegistration.h"
+
+#include <itkANTSNeighborhoodCorrelationImageToImageMetricv4.h>
+#include <itkAffineTransform.h>
+#include <itkCenteredTransformInitializer.h>
+#include <itkConjugateGradientLineSearchOptimizerv4.h>
+#include <itkDisplacementFieldTransform.h>
+#include <itkDisplacementFieldTransformParametersAdaptor.h>
+#include <itkImageRegionIterator.h>
+#include <itkImageRegistrationMethodv4.h>
+#include <itkLinearInterpolateImageFunction.h>
+#include <itkMeanSquaresImageToImageMetricv4.h>
+#include <itkRegistrationParameterScalesFromPhysicalShift.h>
+#include <itkResampleImageFilter.h>
+#include <itkShrinkImageFilter.h>
+#include <itkSyNImageRegistrationMethod.h>
+#include <itkVersorRigid3DTransform.h>
+
+#include <algorithm>
+#include <functional>
+
+namespace shapeworks {
+
+namespace {
+
+using ImageType = Image::ImageType;
+using RigidTransformType = itk::VersorRigid3DTransform<double>;
+using AffineTransformType = itk::AffineTransform<double, 3>;
+using DisplacementFieldTransformType = itk::DisplacementFieldTransform<double, 3>;
+using CompositeTransformType = itk::CompositeTransform<double, 3>;
+// Both inputs are prepared the same way by make_registration_image, so they are effectively the same
+// modality.  A mutual information metric, which ANTs uses because it registers arbitrary modalities,
+// is poorly conditioned here and lets the line search diverge; matching intensities directly is both
+// correct for this input and far more stable.
+using LinearMetricType = itk::MeanSquaresImageToImageMetricv4<ImageType, ImageType>;
+using CorrelationMetricType = itk::ANTSNeighborhoodCorrelationImageToImageMetricv4<ImageType, ImageType>;
+using OptimizerType = itk::ConjugateGradientLineSearchOptimizerv4Template<double>;
+
+constexpr double kLineSearchLowerLimit = 0.0;
+constexpr double kLineSearchUpperLimit = 2.0;
+constexpr double kLineSearchEpsilon = 0.2;
+
+// A heavily shrunk level of an already small image carries almost no signal, and the optimizer
+// responds by taking a large wrong step that the finer levels never recover from.  Never shrink a
+// dimension below this many voxels.
+constexpr unsigned int kMinimumLevelSize = 16;
+
+// The furthest a single optimizer step may move a point, as a fraction of the largest physical
+// dimension of the images being registered.
+constexpr double kMaximumStepFraction = 0.1;
+
+//---------------------------------------------------------------------------
+/// Reduce the requested shrink factors so that no level shrinks the image below kMinimumLevelSize.
+std::vector<unsigned int> clamp_shrink_factors(const std::vector<unsigned int>& shrink_factors,
+                                               const ImageType* image) {
+  const auto size = image->GetBufferedRegion().GetSize();
+  const auto smallest = std::min({size[0], size[1], size[2]});
+  const auto largest_useful = std::max(1u, static_cast<unsigned int>(smallest / kMinimumLevelSize));
+
+  std::vector<unsigned int> clamped;
+  clamped.reserve(shrink_factors.size());
+  for (const auto factor : shrink_factors) {
+    clamped.push_back(std::min(std::max(1u, factor), largest_useful));
+  }
+  return clamped;
+}
+
+//---------------------------------------------------------------------------
+/// Build an optimizer with the scale estimator wired to the given metric, so that rotation,
+/// translation and scaling parameters all step by a comparable physical distance.
+template <typename TMetric>
+OptimizerType::Pointer make_optimizer(TMetric* metric, unsigned int iterations, const ImageType* fixed) {
+  using ScalesEstimatorType = itk::RegistrationParameterScalesFromPhysicalShift<TMetric>;
+  auto scales_estimator = ScalesEstimatorType::New();
+  scales_estimator->SetMetric(metric);
+  scales_estimator->SetTransformForward(true);
+
+  // The metric is flat wherever the two shapes do not overlap at all, so an unbounded step can throw
+  // the transform into that dead zone, where there is no gradient left to bring it back.  Cap how far
+  // a single step may move any point, relative to the size of what is being registered.
+  const auto size = fixed->GetBufferedRegion().GetSize();
+  const auto spacing = fixed->GetSpacing();
+  double largest_extent = 0.0;
+  for (unsigned int i = 0; i < 3; i++) {
+    largest_extent = std::max(largest_extent, size[i] * spacing[i]);
+  }
+
+  auto optimizer = OptimizerType::New();
+  optimizer->SetNumberOfIterations(iterations);
+  optimizer->SetScalesEstimator(scales_estimator);
+  optimizer->SetMaximumStepSizeInPhysicalUnits(largest_extent * kMaximumStepFraction);
+  optimizer->SetDoEstimateLearningRateOnce(false);
+  optimizer->SetDoEstimateLearningRateAtEachIteration(true);
+  optimizer->SetLowerLimit(kLineSearchLowerLimit);
+  optimizer->SetUpperLimit(kLineSearchUpperLimit);
+  optimizer->SetEpsilon(kLineSearchEpsilon);
+  // keep whatever scored best rather than wherever the last step happened to land
+  optimizer->SetReturnBestParametersAndValue(true);
+  return optimizer;
+}
+
+//---------------------------------------------------------------------------
+/// ITK drives every resolution level with a single optimizer, so the iteration count would otherwise
+/// be the same at all of them.  This resets it as each level starts, which lets the coarse levels --
+/// where iterating is cheap and most of the alignment is won -- run far longer than the finest one.
+template <typename TRegistration>
+class LevelIterationCommand : public itk::Command {
+ public:
+  using Self = LevelIterationCommand;
+  using Pointer = itk::SmartPointer<Self>;
+  itkNewMacro(Self);
+
+  void set_iterations(const std::vector<unsigned int>& iterations) { iterations_ = iterations; }
+
+  void Execute(itk::Object* caller, const itk::EventObject& event) override {
+    Execute(const_cast<const itk::Object*>(caller), event);
+  }
+
+  void Execute(const itk::Object* caller, const itk::EventObject& event) override {
+    if (!itk::MultiResolutionIterationEvent().CheckEvent(&event)) {
+      return;
+    }
+    const auto* registration = dynamic_cast<const TRegistration*>(caller);
+    if (!registration) {
+      return;
+    }
+    const auto level = registration->GetCurrentLevel();
+    if (level >= iterations_.size()) {
+      return;
+    }
+    auto* optimizer = const_cast<OptimizerType*>(dynamic_cast<const OptimizerType*>(registration->GetOptimizer()));
+    if (optimizer) {
+      optimizer->SetNumberOfIterations(iterations_[level]);
+    }
+  }
+
+ protected:
+  LevelIterationCommand() = default;
+
+ private:
+  std::vector<unsigned int> iterations_;
+};
+
+//---------------------------------------------------------------------------
+/// Convert our per-level settings into the array types the ITK registration methods expect.
+template <typename TRegistration>
+void apply_multi_resolution_schedule(TRegistration* registration, const std::vector<unsigned int>& shrink_factors,
+                                     const std::vector<double>& smoothing_sigmas) {
+  const auto levels = static_cast<unsigned int>(shrink_factors.size());
+
+  typename TRegistration::ShrinkFactorsArrayType shrink_array;
+  shrink_array.SetSize(levels);
+  typename TRegistration::SmoothingSigmasArrayType sigma_array;
+  sigma_array.SetSize(levels);
+
+  for (unsigned int level = 0; level < levels; level++) {
+    shrink_array[level] = shrink_factors[level];
+    sigma_array[level] = smoothing_sigmas[level];
+  }
+
+  registration->SetNumberOfLevels(levels);
+  registration->SetShrinkFactorsPerLevel(shrink_array);
+  registration->SetSmoothingSigmasPerLevel(sigma_array);
+  registration->SmoothingSigmasAreSpecifiedInPhysicalUnitsOn();
+}
+
+}  // namespace
+
+//---------------------------------------------------------------------------
+class ImageRegistration::Impl {
+ public:
+  TransformType transform_type = TransformType::SyN;
+  double gradient_step = 0.25;
+  double update_field_variance = 3.0;
+  double total_field_variance = 0.0;
+
+  // Deformable schedule.  The finest level is deliberately cheap: the displacement field is smooth,
+  // so little is gained there while it is by far the most expensive level to iterate on.
+  std::vector<unsigned int> iterations = {40, 20, 0};
+  std::vector<unsigned int> shrink_factors = {4, 2, 1};
+  std::vector<double> smoothing_sigmas = {2.0, 1.0, 0.0};
+
+  // Linear (rigid and affine) schedule, which starts coarser and iterates much harder than the
+  // deformable one.  Those coarse levels are cheap, and skimping on them leaves the linear stages
+  // unconverged, which the deformable stage then cannot recover from.
+  std::vector<unsigned int> linear_iterations = {2100, 1200, 1200, 10};
+  std::vector<unsigned int> linear_shrink_factors = {6, 4, 2, 1};
+  std::vector<double> linear_smoothing_sigmas = {3.0, 2.0, 1.0, 0.0};
+
+  //! shrink factors reduced to suit the size of the images actually being registered
+  std::vector<unsigned int> effective_shrink_factors;
+  std::vector<unsigned int> effective_linear_shrink_factors;
+  unsigned int correlation_radius = 4;
+
+  CompositeTransformType::Pointer composite;
+  ImageType::Pointer fixed;
+  ImageType::Pointer moving;
+
+  void run_rigid();
+  void run_affine();
+  void run_syn();
+
+  //! per-level adaptors that resample the displacement field as the SyN stage moves up the pyramid
+  std::vector<typename itk::SyNImageRegistrationMethod<ImageType, ImageType,
+                                                       DisplacementFieldTransformType>::TransformParametersAdaptorPointer>
+  make_field_adaptors() const;
+};
+
+//---------------------------------------------------------------------------
+void ImageRegistration::Impl::run_rigid() {
+  auto rigid = RigidTransformType::New();
+
+  // seed the rigid transform by aligning the centers of mass, which gets the optimizer close enough
+  // that it does not have to search for gross translation
+  using InitializerType = itk::CenteredTransformInitializer<RigidTransformType, ImageType, ImageType>;
+  auto initializer = InitializerType::New();
+  initializer->SetTransform(rigid);
+  initializer->SetFixedImage(fixed);
+  initializer->SetMovingImage(moving);
+  initializer->MomentsOn();
+  initializer->InitializeTransform();
+
+  auto metric = LinearMetricType::New();
+
+  using RegistrationType = itk::ImageRegistrationMethodv4<ImageType, ImageType, RigidTransformType>;
+  auto registration = RegistrationType::New();
+  registration->SetFixedImage(fixed);
+  registration->SetMovingImage(moving);
+  registration->SetMetric(metric);
+  registration->SetInitialTransform(rigid);
+  registration->InPlaceOn();
+  registration->SetOptimizer(make_optimizer(metric.GetPointer(), linear_iterations.front(), fixed));
+  apply_multi_resolution_schedule(registration.GetPointer(), effective_linear_shrink_factors, linear_smoothing_sigmas);
+
+  auto level_command = LevelIterationCommand<RegistrationType>::New();
+  level_command->set_iterations(linear_iterations);
+  registration->AddObserver(itk::MultiResolutionIterationEvent(), level_command);
+
+  registration->Update();
+
+  composite->AddTransform(registration->GetModifiableTransform());
+}
+
+//---------------------------------------------------------------------------
+void ImageRegistration::Impl::run_affine() {
+  auto metric = LinearMetricType::New();
+
+  using RegistrationType = itk::ImageRegistrationMethodv4<ImageType, ImageType, AffineTransformType>;
+  auto registration = RegistrationType::New();
+  registration->SetFixedImage(fixed);
+  registration->SetMovingImage(moving);
+  registration->SetMetric(metric);
+  // the rigid result carries the coarse alignment; the affine stage only has to find the residual
+  registration->SetMovingInitialTransform(composite);
+  registration->SetInitialTransform(AffineTransformType::New());
+  registration->InPlaceOn();
+  registration->SetOptimizer(make_optimizer(metric.GetPointer(), linear_iterations.front(), fixed));
+  apply_multi_resolution_schedule(registration.GetPointer(), effective_linear_shrink_factors, linear_smoothing_sigmas);
+
+  auto level_command = LevelIterationCommand<RegistrationType>::New();
+  level_command->set_iterations(linear_iterations);
+  registration->AddObserver(itk::MultiResolutionIterationEvent(), level_command);
+
+  registration->Update();
+
+  composite->AddTransform(registration->GetModifiableTransform());
+}
+
+//---------------------------------------------------------------------------
+auto ImageRegistration::Impl::make_field_adaptors() const
+    -> std::vector<typename itk::SyNImageRegistrationMethod<
+        ImageType, ImageType, DisplacementFieldTransformType>::TransformParametersAdaptorPointer> {
+  using RegistrationType = itk::SyNImageRegistrationMethod<ImageType, ImageType, DisplacementFieldTransformType>;
+  using AdaptorType = itk::DisplacementFieldTransformParametersAdaptor<DisplacementFieldTransformType>;
+
+  std::vector<typename RegistrationType::TransformParametersAdaptorPointer> adaptors;
+
+  for (const auto shrink_factor : effective_shrink_factors) {
+    // the displacement field lives on the virtual (fixed) domain, so mirror how the registration
+    // shrinks that domain at this level
+    auto shrink_filter = itk::ShrinkImageFilter<ImageType, ImageType>::New();
+    shrink_filter->SetShrinkFactors(shrink_factor);
+    shrink_filter->SetInput(fixed);
+    shrink_filter->Update();
+    const auto level_image = shrink_filter->GetOutput();
+
+    auto adaptor = AdaptorType::New();
+    adaptor->SetRequiredSpacing(level_image->GetSpacing());
+    adaptor->SetRequiredSize(level_image->GetBufferedRegion().GetSize());
+    adaptor->SetRequiredDirection(level_image->GetDirection());
+    adaptor->SetRequiredOrigin(level_image->GetOrigin());
+
+    adaptors.push_back(adaptor.GetPointer());
+  }
+
+  return adaptors;
+}
+
+//---------------------------------------------------------------------------
+void ImageRegistration::Impl::run_syn() {
+  auto metric = CorrelationMetricType::New();
+  CorrelationMetricType::RadiusType radius;
+  radius.Fill(correlation_radius);
+  metric->SetRadius(radius);
+
+  // the output transform must own a displacement field before registration starts; allocate an
+  // identity (all zero) field over the fixed image domain
+  using DisplacementFieldType = DisplacementFieldTransformType::DisplacementFieldType;
+  auto make_zero_field = [this]() {
+    auto field = DisplacementFieldType::New();
+    field->CopyInformation(this->fixed);
+    field->SetRegions(this->fixed->GetBufferedRegion());
+    field->AllocateInitialized();
+    return field;
+  };
+
+  auto output_transform = DisplacementFieldTransformType::New();
+  output_transform->SetDisplacementField(make_zero_field());
+  output_transform->SetInverseDisplacementField(make_zero_field());
+
+  using RegistrationType = itk::SyNImageRegistrationMethod<ImageType, ImageType, DisplacementFieldTransformType>;
+  auto registration = RegistrationType::New();
+  registration->SetFixedImage(fixed);
+  registration->SetMovingImage(moving);
+  registration->SetMetric(metric);
+  registration->SetMovingInitialTransform(composite);
+  registration->SetInitialTransform(output_transform);
+  registration->InPlaceOn();
+
+  typename RegistrationType::NumberOfIterationsArrayType iteration_array;
+  iteration_array.SetSize(iterations.size());
+  for (size_t level = 0; level < iterations.size(); level++) {
+    iteration_array[level] = iterations[level];
+  }
+  registration->SetNumberOfIterationsPerLevel(iteration_array);
+
+  apply_multi_resolution_schedule(registration.GetPointer(), effective_shrink_factors, smoothing_sigmas);
+  auto adaptors = make_field_adaptors();  // ITK takes this by non-const reference
+  registration->SetTransformParametersAdaptorsPerLevel(adaptors);
+
+  registration->SetLearningRate(gradient_step);
+  registration->SetGaussianSmoothingVarianceForTheUpdateField(update_field_variance);
+  registration->SetGaussianSmoothingVarianceForTheTotalField(total_field_variance);
+
+  registration->Update();
+
+  composite->AddTransform(registration->GetModifiableTransform());
+}
+
+//---------------------------------------------------------------------------
+ImageRegistration::ImageRegistration() : impl_(std::make_unique<Impl>()) {}
+
+//---------------------------------------------------------------------------
+ImageRegistration::~ImageRegistration() = default;
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_transform_type(TransformType type) { impl_->transform_type = type; }
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_gradient_step(double step) { impl_->gradient_step = step; }
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_update_field_variance(double variance) { impl_->update_field_variance = variance; }
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_total_field_variance(double variance) { impl_->total_field_variance = variance; }
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_iterations(const std::vector<unsigned int>& iterations) {
+  if (iterations.empty()) {
+    throw std::invalid_argument("registration iterations must not be empty");
+  }
+  impl_->iterations = iterations;
+}
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_shrink_factors(const std::vector<unsigned int>& shrink_factors) {
+  if (shrink_factors.empty()) {
+    throw std::invalid_argument("registration shrink factors must not be empty");
+  }
+  impl_->shrink_factors = shrink_factors;
+}
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_smoothing_sigmas(const std::vector<double>& sigmas) {
+  if (sigmas.empty()) {
+    throw std::invalid_argument("registration smoothing sigmas must not be empty");
+  }
+  impl_->smoothing_sigmas = sigmas;
+}
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_linear_iterations(const std::vector<unsigned int>& iterations) {
+  if (iterations.empty()) {
+    throw std::invalid_argument("linear registration iterations must not be empty");
+  }
+  impl_->linear_iterations = iterations;
+}
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_linear_shrink_factors(const std::vector<unsigned int>& shrink_factors) {
+  if (shrink_factors.empty()) {
+    throw std::invalid_argument("linear registration shrink factors must not be empty");
+  }
+  impl_->linear_shrink_factors = shrink_factors;
+}
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_linear_smoothing_sigmas(const std::vector<double>& sigmas) {
+  if (sigmas.empty()) {
+    throw std::invalid_argument("linear registration smoothing sigmas must not be empty");
+  }
+  impl_->linear_smoothing_sigmas = sigmas;
+}
+
+//---------------------------------------------------------------------------
+void ImageRegistration::set_correlation_radius(unsigned int radius) { impl_->correlation_radius = radius; }
+
+//---------------------------------------------------------------------------
+void ImageRegistration::run(const Image& fixed, const Image& moving) {
+  if (impl_->iterations.size() != impl_->shrink_factors.size() ||
+      impl_->iterations.size() != impl_->smoothing_sigmas.size()) {
+    throw std::invalid_argument("registration iterations, shrink factors and smoothing sigmas must be the same length");
+  }
+  if (impl_->linear_iterations.size() != impl_->linear_shrink_factors.size() ||
+      impl_->linear_iterations.size() != impl_->linear_smoothing_sigmas.size()) {
+    throw std::invalid_argument(
+        "linear registration iterations, shrink factors and smoothing sigmas must be the same length");
+  }
+
+  impl_->fixed = fixed.getITKImage();
+  impl_->moving = moving.getITKImage();
+  impl_->composite = CompositeTransformType::New();
+  impl_->effective_shrink_factors = clamp_shrink_factors(impl_->shrink_factors, impl_->fixed);
+  impl_->effective_linear_shrink_factors = clamp_shrink_factors(impl_->linear_shrink_factors, impl_->fixed);
+
+  auto run_stage = [](const char* name, const std::function<void()>& stage) {
+    try {
+      stage();
+    } catch (const itk::ExceptionObject& e) {
+      throw std::runtime_error(std::string("image registration failed during the ") + name + " stage: " + e.what());
+    }
+  };
+
+  run_stage("rigid", [this]() { impl_->run_rigid(); });
+
+  if (impl_->transform_type == TransformType::Affine || impl_->transform_type == TransformType::SyN) {
+    run_stage("affine", [this]() { impl_->run_affine(); });
+  }
+
+  if (impl_->transform_type == TransformType::SyN) {
+    run_stage("SyN", [this]() { impl_->run_syn(); });
+  }
+}
+
+//---------------------------------------------------------------------------
+std::vector<Point3> ImageRegistration::transform_points(const std::vector<Point3>& points) const {
+  if (!impl_->composite) {
+    throw std::runtime_error("transform_points called before run()");
+  }
+
+  std::vector<Point3> transformed;
+  transformed.reserve(points.size());
+  for (const auto& point : points) {
+    transformed.push_back(impl_->composite->TransformPoint(point));
+  }
+  return transformed;
+}
+
+//---------------------------------------------------------------------------
+Image ImageRegistration::warped_moving() const {
+  if (!impl_->composite) {
+    throw std::runtime_error("warped_moving called before run()");
+  }
+
+  auto resampler = itk::ResampleImageFilter<ImageType, ImageType>::New();
+  resampler->SetInput(impl_->moving);
+  resampler->SetTransform(impl_->composite);
+  resampler->SetOutputParametersFromImage(impl_->fixed);
+  resampler->SetInterpolator(itk::LinearInterpolateImageFunction<ImageType, double>::New());
+  resampler->SetDefaultPixelValue(0);
+  resampler->Update();
+
+  return Image(resampler->GetOutput());
+}
+
+//---------------------------------------------------------------------------
+ImageRegistration::CompositeTransformType::Pointer ImageRegistration::get_transform() const {
+  if (!impl_->composite) {
+    throw std::runtime_error("get_transform called before run()");
+  }
+  return impl_->composite;
+}
+
+//---------------------------------------------------------------------------
+Image ImageRegistration::make_registration_image(const Image& dt, double band) {
+  if (band <= 0.0) {
+    throw std::invalid_argument("band must be positive");
+  }
+
+  Image result(dt);
+  auto image = result.getITKImage();
+
+  // A distance transform is only meaningful near the surface; far away it grows without bound and
+  // would otherwise dominate the similarity metric.  Clamp to the band and rescale to [0,1].
+  itk::ImageRegionIterator<ImageType> it(image, image->GetRequestedRegion());
+  for (it.GoToBegin(); !it.IsAtEnd(); ++it) {
+    const auto clamped = std::clamp(static_cast<double>(it.Get()), -band, band);
+    it.Set(static_cast<Image::PixelType>((clamped + band) / (2.0 * band)));
+  }
+
+  return result;
+}
+
+}  // namespace shapeworks

--- a/Libs/Image/ImageRegistration.h
+++ b/Libs/Image/ImageRegistration.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <itkCompositeTransform.h>
+
+#include <memory>
+#include <vector>
+
+#include "Image.h"
+#include "Shapeworks.h"
+
+namespace shapeworks {
+
+/**
+ * \class ImageRegistration
+ * \ingroup Group-Image
+ *
+ * Intensity based registration of one image to another, following the same recipe as the ANTs
+ * `SyNRA` pipeline: a multi-resolution rigid stage, then affine, then symmetric normalization
+ * (SyN) with a neighborhood cross correlation metric.
+ *
+ * The resulting transform maps points from the fixed image space into the moving image space.
+ * This is the ITK convention: resampling walks the fixed (output) grid and pulls samples from the
+ * moving image.  So to carry a point set from image A onto image B, register with A as the fixed
+ * image and B as the moving image, then call transform_points().
+ *
+ * Distance transforms rather than binary images are the expected input.  Use make_registration_image()
+ * to clamp a distance transform to a band around the surface; unbounded far-field values otherwise
+ * dominate the metric.
+ */
+class ImageRegistration {
+ public:
+  //! Which stages to run.  Each mode includes the stages before it.
+  enum class TransformType {
+    Rigid,   //!< rigid only
+    Affine,  //!< rigid, then affine
+    SyN      //!< rigid, then affine, then symmetric normalization
+  };
+
+  using CompositeTransformType = itk::CompositeTransform<double, 3>;
+
+  ImageRegistration();
+  ~ImageRegistration();
+
+  //! set which registration stages to run (default SyN)
+  void set_transform_type(TransformType type);
+
+  //! set the SyN gradient step size (default 0.25, ANTs `grad_step`)
+  void set_gradient_step(double step);
+
+  //! set the variance for gaussian smoothing of the SyN update field (default 3.0, ANTs `flow_sigma`)
+  void set_update_field_variance(double variance);
+
+  //! set the variance for gaussian smoothing of the SyN total field (default 0.0, ANTs `total_sigma`)
+  void set_total_field_variance(double variance);
+
+  //! set the deformable stage's per-level iteration counts, coarsest level first (default {40, 20, 0})
+  void set_iterations(const std::vector<unsigned int>& iterations);
+
+  //! set the deformable shrink factors per level, coarsest first (default {4, 2, 1}); must match
+  //! set_iterations() size
+  void set_shrink_factors(const std::vector<unsigned int>& shrink_factors);
+
+  //! set the deformable gaussian smoothing sigmas (in physical units) per level, coarsest first
+  //! (default {2, 1, 0})
+  void set_smoothing_sigmas(const std::vector<double>& sigmas);
+
+  /**
+   * @brief Set the schedule used by the rigid and affine stages.
+   *
+   * These stages need a coarser and much longer schedule than the deformable one.  Their coarse
+   * levels are cheap, and an unconverged linear stage leaves the deformable stage with a starting
+   * point it cannot recover from.  Defaults follow ANTs: iterations {2100, 1200, 1200, 10}, shrink
+   * factors {6, 4, 2, 1}, sigmas {3, 2, 1, 0}.
+   */
+  void set_linear_iterations(const std::vector<unsigned int>& iterations);
+  void set_linear_shrink_factors(const std::vector<unsigned int>& shrink_factors);
+  void set_linear_smoothing_sigmas(const std::vector<double>& sigmas);
+
+  //! set the radius of the neighborhood correlation metric window used by the SyN stage (default 4)
+  void set_correlation_radius(unsigned int radius);
+
+  //! run the registration.  Throws std::runtime_error if any stage fails.
+  void run(const Image& fixed, const Image& moving);
+
+  //! map points from fixed image space into moving image space.  run() must have been called.
+  std::vector<Point3> transform_points(const std::vector<Point3>& points) const;
+
+  //! the moving image resampled onto the fixed image grid.  Useful for inspecting registration quality.
+  Image warped_moving() const;
+
+  //! the composed transform from all stages, mapping fixed space to moving space
+  CompositeTransformType::Pointer get_transform() const;
+
+  /**
+   * @brief Prepare a distance transform for registration by clamping and rescaling it.
+   *
+   * Values are clamped to +/- band and then mapped to [0,1].  This keeps the metric focused on the
+   * region near the surface, where the distance transform is informative, instead of on the
+   * unbounded values far away from it.
+   *
+   * @param dt a distance transform
+   * @param band the half-width of the retained band, in physical units
+   * @return the clamped and rescaled image
+   */
+  static Image make_registration_image(const Image& dt, double band = 5.0);
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace shapeworks

--- a/Libs/Image/ImageRegistration.h
+++ b/Libs/Image/ImageRegistration.h
@@ -92,6 +92,24 @@ class ImageRegistration {
   CompositeTransformType::Pointer get_transform() const;
 
   /**
+   * @brief Write the transform computed by run() so that it can be reused.
+   *
+   * The transform depends only on the two images and the registration settings, so a saved one can
+   * stand in for re-running the registration whenever those are unchanged.
+   */
+  void save_transform(const std::string& filename) const;
+
+  /**
+   * @brief Read a transform written by save_transform(), in place of running the registration.
+   *
+   * transform_points() and get_transform() work afterwards exactly as they would have after run().
+   * warped_moving() does not, since no images were supplied.
+   *
+   * @return whether the transform was read
+   */
+  bool load_transform(const std::string& filename);
+
+  /**
    * @brief Prepare a distance transform for registration by clamping and rescaling it.
    *
    * Values are clamped to +/- band and then mapped to [0,1].  This keeps the metric focused on the

--- a/Libs/Optimize/Matrix/LegacyShapeMatrix.h
+++ b/Libs/Optimize/Matrix/LegacyShapeMatrix.h
@@ -59,6 +59,9 @@ class LegacyShapeMatrix : public vnl_matrix<double>, public Observer {
   }
 
   virtual void PositionAddEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     const int VDimension = 3;
     const ParticlePositionAddEvent& event = dynamic_cast<const ParticlePositionAddEvent&>(e);
     const ParticleSystem* ps = dynamic_cast<const ParticleSystem*>(o);
@@ -92,6 +95,9 @@ class LegacyShapeMatrix : public vnl_matrix<double>, public Observer {
   }
 
   virtual void PositionSetEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     const int VDimension = 3;
     const ParticlePositionSetEvent& event = dynamic_cast<const ParticlePositionSetEvent&>(e);
     const ParticleSystem* ps = dynamic_cast<const ParticleSystem*>(o);

--- a/Libs/Optimize/Matrix/LinearRegressionShapeMatrix.h
+++ b/Libs/Optimize/Matrix/LinearRegressionShapeMatrix.h
@@ -98,6 +98,9 @@ class LinearRegressionShapeMatrix : public LegacyShapeMatrix {
   }
 
   virtual void PositionAddEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     const ParticlePositionAddEvent& event = dynamic_cast<const ParticlePositionAddEvent&>(e);
     const ParticleSystem* ps = dynamic_cast<const ParticleSystem*>(o);
     const int d = event.GetDomainIndex();
@@ -124,6 +127,9 @@ class LinearRegressionShapeMatrix : public LegacyShapeMatrix {
   }
 
   virtual void PositionSetEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     const ParticlePositionSetEvent& event = dynamic_cast<const ParticlePositionSetEvent&>(e);
 
     const ParticleSystem* ps = dynamic_cast<const ParticleSystem*>(o);

--- a/Libs/Optimize/Matrix/MixedEffectsShapeMatrix.h
+++ b/Libs/Optimize/Matrix/MixedEffectsShapeMatrix.h
@@ -108,6 +108,9 @@ class MixedEffectsShapeMatrix : public LegacyShapeMatrix {
   }
 
   virtual void PositionAddEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     const int VDimension = 3;
 
     const ParticlePositionAddEvent& event = dynamic_cast<const ParticlePositionAddEvent&>(e);
@@ -136,6 +139,9 @@ class MixedEffectsShapeMatrix : public LegacyShapeMatrix {
   }
 
   virtual void PositionSetEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     const int VDimension = 3;
 
     const ParticlePositionSetEvent& event = dynamic_cast<const ParticlePositionSetEvent&>(e);

--- a/Libs/Optimize/Matrix/ShapeGradientMatrix.h
+++ b/Libs/Optimize/Matrix/ShapeGradientMatrix.h
@@ -88,6 +88,9 @@ class ShapeGradientMatrix : public vnl_matrix<double>, public Observer {
   }
 
   virtual void PositionAddEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     // update the size of matrix based on xyz, normals and number of attributes being used
     const ParticlePositionAddEvent& event = dynamic_cast<const ParticlePositionAddEvent&>(e);
     const ParticleSystem* ps = dynamic_cast<const ParticleSystem*>(o);
@@ -113,6 +116,9 @@ class ShapeGradientMatrix : public vnl_matrix<double>, public Observer {
   }
 
   virtual void PositionSetEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     // update xyz, normals and number of attributes being used
     const ParticlePositionSetEvent& event = dynamic_cast<const ParticlePositionSetEvent&>(e);
     const ParticleSystem* ps = dynamic_cast<const ParticleSystem*>(o);

--- a/Libs/Optimize/Matrix/ShapeMatrix.h
+++ b/Libs/Optimize/Matrix/ShapeMatrix.h
@@ -154,6 +154,9 @@ class ShapeMatrix : public vnl_matrix<double>, public Observer {
   }
 
   virtual void PositionAddEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     const int VDimension = 3;
 
     // update the size of matrix based on xyz, normals and number of attributes being used
@@ -175,6 +178,9 @@ class ShapeMatrix : public vnl_matrix<double>, public Observer {
   }
 
   virtual void PositionSetEventCallback(Object* o, const itk::EventObject& e) {
+    if (is_suspended()) {
+      return;
+    }
     // update xyz, normals and number of attributes being used
     const ParticlePositionSetEvent& event = dynamic_cast<const ParticlePositionSetEvent&>(e);
     const ParticleSystem* ps = dynamic_cast<const ParticleSystem*>(o);

--- a/Libs/Optimize/Observer.h
+++ b/Libs/Optimize/Observer.h
@@ -59,6 +59,13 @@ class Observer : public itk::DataObject {
   virtual void PositionAddEventCallback(Object*, const itk::EventObject&) {}
   virtual void PositionRemoveEventCallback(Object*, const itk::EventObject&) {}
 
+  /** Stop this observer from reacting to events.  The correspondence matrices lay themselves out
+      assuming every shape holds the same number of particles, which is not true while particles are
+      still being spread over a single reference shape.  Suspending them until every shape has been
+      populated avoids that, and a later SynchronizePositions() brings them back up to date. */
+  void set_suspended(bool suspended) { suspended_ = suspended; }
+  bool is_suspended() const { return suspended_; }
+
  protected:
   Observer() {}
   virtual ~Observer(){};
@@ -68,6 +75,8 @@ class Observer : public itk::DataObject {
  private:
   Observer(const Self&);  // purposely not implemented
   void operator=(const Self&);     // purposely not implemented
+
+  bool suspended_ = false;
 };
 
 }  // namespace shapeworks

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <iostream>
+#include <optional>
 // #include <numeric>
 #include <sstream>
 #include <string>
@@ -956,7 +957,10 @@ void Optimize::TransferParticlesFromReference(int reference_shape) {
       reference_points.push_back(system->GetPosition(k, reference_domain));
     }
 
-    Image reference_image = GetRegistrationImage(reference_domain);
+    // The reference image is only needed to run a registration, so it is built lazily on the first
+    // cache miss.  Rasterizing a large mesh takes several seconds, and when every transfer is a cache
+    // hit (e.g. re-running with different optimization parameters) it is never needed at all.
+    std::optional<Image> reference_image;
 
     for (int s = 0; s < num_subjects && !m_aborted; s++) {
       if (s == reference_shape) {
@@ -965,6 +969,7 @@ void Optimize::TransferParticlesFromReference(int reference_shape) {
       const int domain = s * m_domains_per_shape + d;
 
       UpdateProgress(fmt::format("Registering shape {} of {}", s + 1, num_subjects));
+      RefreshDuringTransfer();
 
       ImageRegistration registration;
       registration.set_transform_type(m_registration_transform_type);
@@ -979,7 +984,14 @@ void Optimize::TransferParticlesFromReference(int reference_shape) {
       if (cached) {
         SW_DEBUG("Reusing cached registration: {}", cache_path);
       } else {
-        registration.run(reference_image, GetRegistrationImage(domain));
+        if (!reference_image) {
+          // only now, on a genuine miss, is the reference image worth building
+          UpdateProgress(m_domains_per_shape > 1 ? fmt::format("Preparing registration (domain {})", d + 1)
+                                                 : std::string("Preparing registration"));
+          RefreshDuringTransfer();
+          reference_image = GetRegistrationImage(reference_domain);
+        }
+        registration.run(*reference_image, GetRegistrationImage(domain));
         if (!cache_path.empty()) {
           try {
             registration.save_transform(cache_path);
@@ -1000,6 +1012,9 @@ void Optimize::TransferParticlesFromReference(int reference_shape) {
       // reserved for them; without this the bar would sit still through the longest phase
       current_particle_iterations_ += m_transfer_iteration_weight;
       UpdateProgress(fmt::format("Registered shape {} of {}", s + 1, num_subjects));
+      // the shape now has its particles; let the GUI redraw them (and the status) between
+      // registrations rather than only when the whole phase ends
+      RefreshDuringTransfer();
     }
   }
 }

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/filesystem.hpp>
+
 #include "Profiling.h"
 
 #ifdef _WIN32
@@ -910,6 +912,38 @@ void Optimize::SpreadParticlesOnReference(int reference_shape) {
 }
 
 //---------------------------------------------------------------------------
+std::string Optimize::GetRegistrationCachePath(int reference_domain, int domain) const {
+  if (m_registration_cache_dir.empty()) {
+    return "";
+  }
+
+  auto describe = [&](int d) {
+    std::string description = d < static_cast<int>(m_domain_paths.size()) ? m_domain_paths[d] : std::to_string(d);
+    // a groomed input that has been rewritten must not read back as a hit
+    if (ShapeWorksUtils::file_exists(description)) {
+      try {
+        description += ":" + std::to_string(boost::filesystem::file_size(description));
+        description += ":" + std::to_string(boost::filesystem::last_write_time(description));
+      } catch (const std::exception&) {
+      }
+    }
+    return description;
+  };
+
+  // everything the transform depends on, and nothing that it does not
+  std::string key = describe(reference_domain) + "->" + describe(domain);
+  key += "|transform=" + std::to_string(static_cast<int>(m_registration_transform_type));
+  key += "|step=" + std::to_string(m_registration_gradient_step);
+  key += "|sigma=" + std::to_string(m_registration_flow_sigma);
+  key += "|band=" + std::to_string(m_registration_band);
+
+  const auto hash = std::hash<std::string>{}(key);
+  std::stringstream name;
+  name << m_registration_cache_dir << "/registration_" << std::hex << hash << ".tfm";
+  return name.str();
+}
+
+//---------------------------------------------------------------------------
 void Optimize::TransferParticlesFromReference(int reference_shape) {
   auto* system = m_sampler->GetParticleSystem();
   const int num_subjects = GetNumberOfSubjects();
@@ -936,7 +970,24 @@ void Optimize::TransferParticlesFromReference(int reference_shape) {
       registration.set_transform_type(m_registration_transform_type);
       registration.set_gradient_step(m_registration_gradient_step);
       registration.set_update_field_variance(m_registration_flow_sigma);
-      registration.run(reference_image, GetRegistrationImage(domain));
+
+      const auto cache_path = GetRegistrationCachePath(reference_domain, domain);
+      // check for the file first: asking the reader for one that is not there is a normal cache
+      // miss, but it makes the HDF5 layer print an alarming block of text
+      const bool cached =
+          !cache_path.empty() && ShapeWorksUtils::file_exists(cache_path) && registration.load_transform(cache_path);
+      if (cached) {
+        SW_DEBUG("Reusing cached registration: {}", cache_path);
+      } else {
+        registration.run(reference_image, GetRegistrationImage(domain));
+        if (!cache_path.empty()) {
+          try {
+            registration.save_transform(cache_path);
+          } catch (const std::exception& e) {
+            SW_WARN("Unable to cache registration: {}", e.what());
+          }
+        }
+      }
 
       auto transferred = registration.transform_points(reference_points);
 
@@ -2174,6 +2225,9 @@ void Optimize::SetRegistrationFlowSigma(double sigma) { m_registration_flow_sigm
 
 //---------------------------------------------------------------------------
 void Optimize::SetRegistrationBand(double band) { m_registration_band = band; }
+
+//---------------------------------------------------------------------------
+void Optimize::SetRegistrationCacheDir(const std::string& path) { m_registration_cache_dir = path; }
 
 //---------------------------------------------------------------------------
 int Optimize::GetNumberOfSubjects() const {

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -28,7 +28,9 @@
 #include <Project/Project.h>
 
 #include "EarlyStoppingConfig.h"
+#include "Libs/Optimize/Domain/MeshDomain.h"
 #include "Libs/Optimize/Domain/Surface.h"
+#include "MeshUtils.h"
 #include "Libs/Optimize/Utils/ObjectReader.h"
 #include "Libs/Optimize/Utils/ObjectWriter.h"
 #include "Libs/Optimize/Utils/ParticleGoodBadAssessment.h"
@@ -44,6 +46,25 @@
 namespace py = pybind11;
 
 namespace shapeworks {
+
+//! Number of voxels across the largest dimension when rasterizing a mesh for registration.  Fixing
+//! the grid size rather than the spacing keeps this working whatever units the data is stored in.
+static constexpr double kRegistrationGridSize = 128.0;
+
+//! Width of the retained band around the surface, in voxels, when it is not set explicitly
+static constexpr double kRegistrationBandVoxels = 4.0;
+
+//! A transferred particle further than this fraction of the shape's size from the surface is
+//! considered mislanded, whatever units the data is in
+static constexpr double kTransferFarFraction = 0.05;
+
+//! Warn that a registration may have failed once this fraction of a shape's particles are mislanded.
+//! Keyed off a fraction rather than the single worst particle so a stray outlier is not a false alarm.
+static constexpr double kTransferFarFractionThreshold = 0.25;
+
+//! Share of the reported progress reserved for the registrations, which dominate the wall clock in
+//! registration based initialization but run no particle iterations of their own
+static constexpr double kTransferProgressShare = 0.85;
 
 #ifdef _WIN32
 static std::string find_in_path(std::string file) {
@@ -111,6 +132,13 @@ bool Optimize::Run() {
   current_particle_iterations_ = 0;
   m_iteration_count = 0;
   m_split_number = 0;
+
+  if (m_initialization_mode == InitializationMode::Registration && m_use_shape_statistics_after > 0) {
+    // registration seeds every shape at the final particle count, so there is nothing left for the
+    // multiscale loop to split up to
+    SW_WARN("Multiscale optimization is not used with registration based initialization; ignoring it");
+    m_use_shape_statistics_after = -1;
+  }
 
   ComputeTotalIterations();
 
@@ -515,6 +543,11 @@ void Optimize::Initialize() {
     SW_LOG("------------------------------");
   }
 
+  if (m_initialization_mode == InitializationMode::Registration) {
+    InitializeFromRegistration();
+    return;
+  }
+
   if (m_procrustes_interval != 0) {  // Initial registration
     for (int i = 0; i < this->m_domains_per_shape; i++) {
       if (m_sampler->GetParticleSystem()->GetNumberOfParticles(i) > 10) {
@@ -700,6 +733,325 @@ void Optimize::Initialize() {
   this->WriteCuttingPlanePoints();
   if (m_verbosity_level > 0) {
     SW_LOG("Finished initialization");
+  }
+}
+
+//---------------------------------------------------------------------------
+Mesh Optimize::GetDomainSurface(int domain) {
+  auto* particle_domain = m_sampler->GetParticleSystem()->GetDomain(domain);
+
+  if (auto* mesh_domain = dynamic_cast<MeshDomain*>(particle_domain)) {
+    return Mesh(mesh_domain->get_surface()->get_polydata());
+  }
+
+  // an image domain keeps only a narrow band of its distance transform, so read the groomed input
+  // back from disk to recover the full surface
+  if (domain >= static_cast<int>(m_domain_paths.size()) || m_domain_paths[domain].empty()) {
+    throw std::runtime_error(
+        "Registration based initialization needs the path of each groomed input, but none was given for domain " +
+        std::to_string(domain));
+  }
+  return Image(m_domain_paths[domain]).toMesh(0.0);
+}
+
+//---------------------------------------------------------------------------
+Image Optimize::GetRegistrationImage(int domain) {
+  auto* particle_domain = m_sampler->GetParticleSystem()->GetDomain(domain);
+
+  if (particle_domain->GetDomainType() == DomainType::Image) {
+    if (domain >= static_cast<int>(m_domain_paths.size()) || m_domain_paths[domain].empty()) {
+      throw std::runtime_error(
+          "Registration based initialization needs the path of each groomed input, but none was given for domain " +
+          std::to_string(domain));
+    }
+    // the groomed input is already a distance transform, so take its resolution as given
+    Image dt(m_domain_paths[domain]);
+    const auto spacing = dt.spacing();
+    const double largest_spacing = std::max({spacing[0], spacing[1], spacing[2]});
+    return ImageRegistration::make_registration_image(dt, GetRegistrationBand(largest_spacing));
+  }
+
+  // A mesh carries no resolution of its own, so pick one from how large it actually is.  Assuming a
+  // spacing (and a band) in millimeters would break on data stored in other units, where a fixed
+  // spacing yields either an unusable grid or one too coarse to register.
+  Mesh mesh = GetDomainSurface(domain);
+  auto region = mesh.boundingBox();
+  const auto extent = region.size();
+  const double largest_extent = std::max({extent[0], extent[1], extent[2]});
+  const double spacing = largest_extent / kRegistrationGridSize;
+  const double band = GetRegistrationBand(spacing);
+
+  // pad far enough that the whole band around the surface stays inside the grid
+  region.pad(band * 2.0);
+  return ImageRegistration::make_registration_image(mesh.toDistanceTransform(region, Point3({spacing, spacing, spacing})),
+                                                    band);
+}
+
+//---------------------------------------------------------------------------
+double Optimize::GetRegistrationBand(double spacing) const {
+  if (m_registration_band > 0.0) {
+    return m_registration_band;
+  }
+  // default to a band a few voxels wide, which keeps the metric focused near the surface without
+  // making it so thin that it spans less than a voxel
+  return kRegistrationBandVoxels * spacing;
+}
+
+//---------------------------------------------------------------------------
+int Optimize::ResolveRegistrationReference() {
+  const int num_subjects = GetNumberOfSubjects();
+  if (num_subjects < 1) {
+    throw std::runtime_error("No shapes to initialize");
+  }
+
+  if (m_registration_reference >= 0) {
+    if (m_registration_reference >= num_subjects) {
+      throw std::runtime_error("Requested registration reference " + std::to_string(m_registration_reference) +
+                               " is out of range, there are only " + std::to_string(num_subjects) + " shapes");
+    }
+    return m_registration_reference;
+  }
+
+  if (num_subjects == 1) {
+    return 0;
+  }
+
+  // combine each subject's domains into one mesh so that the template is representative of the whole
+  // anatomy rather than of a single domain
+  PrintStartMessage("Choosing a registration reference...");
+  std::vector<Mesh> meshes;
+  for (int s = 0; s < num_subjects; s++) {
+    Mesh mesh = GetDomainSurface(s * m_domains_per_shape);
+    for (int d = 1; d < static_cast<int>(m_domains_per_shape); d++) {
+      mesh += GetDomainSurface(s * m_domains_per_shape + d);
+    }
+    meshes.push_back(mesh);
+  }
+
+  const int reference = MeshUtils::findReferenceMesh(meshes);
+  if (reference < 0 || reference >= num_subjects) {
+    throw std::runtime_error("Could not choose a registration reference");
+  }
+  PrintDoneMessage();
+  return reference;
+}
+
+//---------------------------------------------------------------------------
+void Optimize::SpreadParticlesOnReference(int reference_shape) {
+  auto* system = m_sampler->GetParticleSystem();
+  const int first_domain = reference_shape * m_domains_per_shape;
+
+  // only the reference carries particles for the moment, so the correspondence matrices cannot keep
+  // a consistent layout; they are brought back once every shape has been populated
+  m_sampler->SetCorrespondenceMatricesSuspended(true);
+
+  // seed a single particle on each of the reference's domains
+  for (int d = 0; d < static_cast<int>(m_domains_per_shape); d++) {
+    const int domain = first_domain + d;
+    if (system->GetNumberOfParticles(domain) == 0) {
+      auto* particle_domain = system->GetDomain(domain);
+      system->AddPosition(particle_domain->GetValidLocationNear(particle_domain->GetZeroCrossingPoint()), domain);
+    }
+  }
+  system->SynchronizePositions();
+
+  // allocate everything without optimizing, so that turning correspondence off below sticks; Execute
+  // forces it back on the first time it runs
+  m_sampler->Initialize();
+
+  // only one shape carries particles at this point, so there is no correspondence to establish yet
+  m_sampler->SetCorrespondenceOff();
+
+  // report progress against the reference rather than the first shape, which is still empty
+  m_progress_domain_offset = first_domain;
+
+  const double epsilon = m_spacing;
+
+  auto needs_split = [&]() {
+    for (int d = 0; d < static_cast<int>(m_domains_per_shape); d++) {
+      if (system->GetNumberOfParticles(first_domain + d) < m_number_of_particles[d]) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  while (needs_split() && !m_aborted) {
+    OptimizerStop();
+
+    for (int d = 0; d < static_cast<int>(m_domains_per_shape); d++) {
+      const int domain = first_domain + d;
+      if (system->GetNumberOfParticles(domain) < m_number_of_particles[d]) {
+        system->SplitAllParticlesInDomain(epsilon, domain);
+      }
+    }
+    system->SynchronizePositions();
+
+    m_split_number++;
+    if (m_verbosity_level > 0) {
+      std::string counts;
+      for (int d = 0; d < static_cast<int>(m_domains_per_shape); d++) {
+        counts += " " + std::to_string(system->GetNumberOfParticles(first_domain + d));
+      }
+      SW_LOG("Reference split {}, particle count:{}", m_split_number, counts);
+    }
+
+    m_energy_a.clear();
+    m_energy_b.clear();
+    m_total_energy.clear();
+    m_str_energy = "split" + std::to_string(m_split_number) + "pts_init";
+
+    m_sampler->GetOptimizer()->set_maximum_number_of_iterations(m_iterations_per_split);
+    m_sampler->GetOptimizer()->set_number_of_iterations(0);
+    m_sampler->Execute();
+  }
+
+  m_progress_domain_offset = 0;
+}
+
+//---------------------------------------------------------------------------
+void Optimize::TransferParticlesFromReference(int reference_shape) {
+  auto* system = m_sampler->GetParticleSystem();
+  const int num_subjects = GetNumberOfSubjects();
+
+  for (int d = 0; d < static_cast<int>(m_domains_per_shape) && !m_aborted; d++) {
+    const int reference_domain = reference_shape * m_domains_per_shape + d;
+
+    std::vector<Point3> reference_points;
+    for (auto k = 0; k < system->GetNumberOfParticles(reference_domain); k++) {
+      reference_points.push_back(system->GetPosition(k, reference_domain));
+    }
+
+    Image reference_image = GetRegistrationImage(reference_domain);
+
+    for (int s = 0; s < num_subjects && !m_aborted; s++) {
+      if (s == reference_shape) {
+        continue;
+      }
+      const int domain = s * m_domains_per_shape + d;
+
+      UpdateProgress(fmt::format("Registering shape {} of {}", s + 1, num_subjects));
+
+      ImageRegistration registration;
+      registration.set_transform_type(m_registration_transform_type);
+      registration.set_gradient_step(m_registration_gradient_step);
+      registration.set_update_field_variance(m_registration_flow_sigma);
+      registration.run(reference_image, GetRegistrationImage(domain));
+
+      auto transferred = registration.transform_points(reference_points);
+
+      // AddPositionList applies the domain constraints, which pulls each point onto the surface
+      system->AddPositionList(transferred, domain);
+
+      ReportTransferQuality(domain, reference_points, transferred);
+
+      // registrations do not run particle iterations, so charge each one its share of the budget
+      // reserved for them; without this the bar would sit still through the longest phase
+      current_particle_iterations_ += m_transfer_iteration_weight;
+      UpdateProgress(fmt::format("Registered shape {} of {}", s + 1, num_subjects));
+    }
+  }
+}
+
+//---------------------------------------------------------------------------
+void Optimize::ReportTransferQuality(int domain, const std::vector<Point3>& reference_points,
+                                     const std::vector<Point3>& transferred) {
+  if (transferred.empty()) {
+    return;
+  }
+
+  auto* system = m_sampler->GetParticleSystem();
+
+  // Judge the transfer against the size of the shape rather than an absolute distance, so the same
+  // thresholds work whatever units and resolution the data is in.  Take that size from the domain
+  // itself, not from the particles: particles that have collapsed together would otherwise shrink
+  // the scale in step with the distances being judged, and always look acceptable.
+  const auto* particle_domain = system->GetDomain(domain);
+  const double shape_scale = particle_domain->GetLowerBound().EuclideanDistanceTo(particle_domain->GetUpperBound());
+
+  // A particle beyond this fraction of the shape's size is clearly in the wrong place
+  const double far_distance = kTransferFarFraction * shape_scale;
+
+  double total_snap = 0.0;
+  double worst_snap = 0.0;
+  int far = 0;
+  int unmoved = 0;
+
+  for (size_t i = 0; i < transferred.size(); i++) {
+    // how far the point had to travel to reach the surface is how far off the surface it landed
+    const double snap = transferred[i].EuclideanDistanceTo(system->GetPosition(i, domain));
+    total_snap += snap;
+    worst_snap = std::max(worst_snap, snap);
+    if (shape_scale > 0.0 && snap > far_distance) {
+      far++;
+    }
+
+    // a point outside the displacement field is returned unchanged rather than reported as an error,
+    // so an unmoved point means the field did not cover it
+    if (transferred[i] == reference_points[i]) {
+      unmoved++;
+    }
+  }
+
+  const double mean_snap = total_snap / transferred.size();
+  const double far_fraction = static_cast<double>(far) / transferred.size();
+  // a registration that failed leaves many particles far from the surface, not just one outlier
+  const bool suspect = far_fraction > kTransferFarFractionThreshold || unmoved > 0;
+
+  const std::string name = domain < static_cast<int>(m_filenames.size()) ? m_filenames[domain] : std::to_string(domain);
+
+  if (m_verbosity_level > 0 || suspect) {
+    SW_LOG("{}: transferred particles landed {:.3g} from the surface on average (worst {:.3g})", name, mean_snap,
+           worst_snap);
+  }
+
+  if (unmoved > 0) {
+    SW_WARN("{}: {} of {} transferred particles fell outside the registration field and did not move", name, unmoved,
+            transferred.size());
+  }
+
+  if (far_fraction > kTransferFarFractionThreshold) {
+    SW_WARN("{}: {:.0f}% of transferred particles landed far from the surface, the registration may have failed", name,
+            100.0 * far_fraction);
+  }
+}
+
+//---------------------------------------------------------------------------
+void Optimize::InitializeFromRegistration() {
+  m_registration_reference_chosen = ResolveRegistrationReference();
+
+  const std::string name = m_registration_reference_chosen * m_domains_per_shape < m_filenames.size()
+                               ? m_filenames[m_registration_reference_chosen * m_domains_per_shape]
+                               : std::to_string(m_registration_reference_chosen);
+  SW_LOG("Spreading particles on reference shape {} ({})", m_registration_reference_chosen, name);
+
+  SpreadParticlesOnReference(m_registration_reference_chosen);
+
+  // each shape is populated with a full set below, so the matrices can track them again
+  m_sampler->SetCorrespondenceMatricesSuspended(false);
+
+  if (!m_aborted) {
+    TransferParticlesFromReference(m_registration_reference_chosen);
+  }
+
+  // Only now does every shape hold its particles.  The matrices size themselves from the first
+  // shape's domains, so they cannot be brought up to date any earlier: while particles were being
+  // spread, only the reference (which is usually not the first shape) had any.
+  auto* system = m_sampler->GetParticleSystem();
+  system->ResyncObservers();
+  system->SynchronizePositions();
+
+  // every shape now carries a full set of corresponding particles
+  m_sampler->SetCorrespondenceOn();
+
+  this->WritePointFiles();
+  this->WritePointFilesWithFeatures();
+  this->WriteTransformFile();
+  this->WriteTransformFiles();
+  this->WriteCuttingPlanePoints();
+
+  if (m_verbosity_level > 0) {
+    SW_LOG("Finished registration based initialization");
   }
 }
 
@@ -1625,6 +1977,13 @@ void Optimize::UpdateProject() {
     return;
   }
 
+  if (m_initialization_mode == InitializationMode::Registration && m_registration_reference_chosen >= 0) {
+    // record which shape was used as the template, so the run can be understood and reproduced
+    auto params = project_->get_parameters(Parameters::OPTIMIZE_PARAMS);
+    params.set("initialization_reference_chosen", m_registration_reference_chosen);
+    project_->set_parameters(Parameters::OPTIMIZE_PARAMS, params);
+  }
+
   auto transforms = GetProcrustesTransforms();
   auto& subjects = project_->get_subjects();
 
@@ -1794,6 +2153,37 @@ void Optimize::SetInitialPoints(std::vector<std::vector<itk::Point<double>>> ini
 }
 
 //---------------------------------------------------------------------------
+void Optimize::SetDomainPaths(const std::vector<std::string>& paths) { m_domain_paths = paths; }
+
+//---------------------------------------------------------------------------
+void Optimize::SetInitializationMode(InitializationMode mode) { m_initialization_mode = mode; }
+
+//---------------------------------------------------------------------------
+void Optimize::SetRegistrationReference(int shape_index) { m_registration_reference = shape_index; }
+
+//---------------------------------------------------------------------------
+void Optimize::SetRegistrationTransformType(ImageRegistration::TransformType type) {
+  m_registration_transform_type = type;
+}
+
+//---------------------------------------------------------------------------
+void Optimize::SetRegistrationGradientStep(double step) { m_registration_gradient_step = step; }
+
+//---------------------------------------------------------------------------
+void Optimize::SetRegistrationFlowSigma(double sigma) { m_registration_flow_sigma = sigma; }
+
+//---------------------------------------------------------------------------
+void Optimize::SetRegistrationBand(double band) { m_registration_band = band; }
+
+//---------------------------------------------------------------------------
+int Optimize::GetNumberOfSubjects() const {
+  if (m_domains_per_shape < 1) {
+    return 0;
+  }
+  return m_num_shapes / static_cast<int>(m_domains_per_shape);
+}
+
+//---------------------------------------------------------------------------
 int Optimize::GetNumShapes() { return this->m_num_shapes; }
 
 //---------------------------------------------------------------------------
@@ -1882,7 +2272,7 @@ void Optimize::SetIterationCallback() {
     this->m_iteration_count++;
 
     for (int d = 0; d < m_domains_per_shape; d++) {
-      current_particle_iterations_ += m_sampler->GetParticleSystem()->GetNumberOfParticles(d);
+      current_particle_iterations_ += m_sampler->GetParticleSystem()->GetNumberOfParticles(m_progress_domain_offset + d);
     }
 
     if (this->GetShowVisualizer()) {
@@ -2133,6 +2523,20 @@ void Optimize::ComputeTotalIterations() {
     }
   }
 
+  // Registering the reference to every other shape runs no particle iterations at all, yet it
+  // dominates the wall clock.  Reserve a share of the budget for it so that the reported progress
+  // keeps moving, and charge each registration an equal part of that share as it finishes.
+  m_transfer_iteration_weight = 0;
+  if (m_initialization_mode == InitializationMode::Registration) {
+    const int transfers = std::max(0, GetNumberOfSubjects() - 1) * static_cast<int>(m_domains_per_shape);
+    if (transfers > 0) {
+      const double share = kTransferProgressShare / (1.0 - kTransferProgressShare);
+      const auto budget = static_cast<int64_t>(total_particle_iterations_ * share);
+      m_transfer_iteration_weight = static_cast<int>(budget / transfers);
+      total_particle_iterations_ += m_transfer_iteration_weight * transfers;
+    }
+  }
+
   m_total_iterations = (number_of_splits * m_iterations_per_split) + m_optimization_iterations;
 
   if (this->m_verbosity_level > 0) {
@@ -2141,12 +2545,16 @@ void Optimize::ComputeTotalIterations() {
 }
 
 //---------------------------------------------------------------------------
-void Optimize::UpdateProgress() {
+void Optimize::UpdateProgress() { UpdateProgress(""); }
+
+//---------------------------------------------------------------------------
+void Optimize::UpdateProgress(const std::string& stage) {
   auto now = std::chrono::system_clock::now();
 
   bool final = current_particle_iterations_ == total_particle_iterations_;
 
-  if (final || (now - m_last_update_time) > std::chrono::milliseconds(100)) {
+  // a named stage reports whenever it is reached, since those are infrequent by nature
+  if (final || !stage.empty() || (now - m_last_update_time) > std::chrono::milliseconds(100)) {
     m_last_update_time = now;
     std::chrono::duration<double> elapsed_seconds =
         std::chrono::duration_cast<std::chrono::seconds>(now - m_start_time);
@@ -2157,18 +2565,22 @@ void Optimize::UpdateProgress() {
     int seconds = static_cast<int>(seconds_remaining - (hours * 3600) - (minutes * 60));
 
     std::string message;
-    if (m_optimizing) {
-      message = "Optimizing";
+    if (!stage.empty()) {
+      message = stage;
     } else {
-      message = "Initializing";
+      if (m_optimizing) {
+        message = "Optimizing";
+      } else {
+        message = "Initializing";
+      }
+
+      int stage_num_iterations = m_sampler->GetOptimizer()->get_number_of_iterations();
+      int stage_total_iterations = m_sampler->GetOptimizer()->get_maximum_number_of_iterations();
+      int num_particles = m_sampler->GetParticleSystem()->GetNumberOfParticles(0);
+
+      message = fmt::format("{} : Particles: {}, Iteration: {} / {}", message, num_particles, stage_num_iterations,
+                            stage_total_iterations);
     }
-
-    int stage_num_iterations = m_sampler->GetOptimizer()->get_number_of_iterations();
-    int stage_total_iterations = m_sampler->GetOptimizer()->get_maximum_number_of_iterations();
-    int num_particles = m_sampler->GetParticleSystem()->GetNumberOfParticles(0);
-
-    message = fmt::format("{} : Particles: {}, Iteration: {} / {}", message, num_particles, stage_num_iterations,
-                          stage_total_iterations);
 
     if ((now - m_last_remaining_update_time) > std::chrono::seconds(1)) {
       m_remaining_time_message = fmt::format("({:02d}:{:02d}:{:02d} remaining)", hours, minutes, seconds);

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -50,11 +50,16 @@ namespace py = pybind11;
 
 namespace shapeworks {
 
-//! Number of voxels across the largest dimension when rasterizing a mesh for registration.  Fixing
-//! the grid size rather than the spacing keeps this working whatever units the data is stored in.
-static constexpr double kRegistrationGridSize = 128.0;
+//! Width of the retained band around the surface, as a fraction of the shape's largest dimension,
+//! when it is not set explicitly.  The band is what the similarity metric can actually see, so it
+//! must be a physical width independent of the rasterization grid: tying it to the grid would
+//! silently narrow it as the grid is raised and starve the metric of context on dissimilar shapes.
+//! ~5% of the shape size was the best compromise across similar and dissimilar pairs in testing --
+//! wide enough to bridge shape differences, not so wide that it loses surface detail.
+static constexpr double kRegistrationBandFraction = 0.05;
 
-//! Width of the retained band around the surface, in voxels, when it is not set explicitly
+//! Width of the image-domain band, in voxels of the (fixed) distance transform.  Image inputs already
+//! carry their own resolution, so there is no grid to decouple from.
 static constexpr double kRegistrationBandVoxels = 4.0;
 
 //! A transferred particle further than this fraction of the shape's size from the surface is
@@ -781,8 +786,11 @@ Image Optimize::GetRegistrationImage(int domain) {
   auto region = mesh.boundingBox();
   const auto extent = region.size();
   const double largest_extent = std::max({extent[0], extent[1], extent[2]});
-  const double spacing = largest_extent / kRegistrationGridSize;
-  const double band = GetRegistrationBand(spacing);
+  const double spacing = largest_extent / m_registration_grid_size;
+
+  // Band is a physical width derived from the shape's size, independent of the chosen grid, so the
+  // grid controls only resolution and the two do not confound each other.
+  const double band = m_registration_band > 0.0 ? m_registration_band : kRegistrationBandFraction * largest_extent;
 
   // pad far enough that the whole band around the surface stays inside the grid
   region.pad(band * 2.0);
@@ -937,6 +945,7 @@ std::string Optimize::GetRegistrationCachePath(int reference_domain, int domain)
   key += "|step=" + std::to_string(m_registration_gradient_step);
   key += "|sigma=" + std::to_string(m_registration_flow_sigma);
   key += "|band=" + std::to_string(m_registration_band);
+  key += "|grid=" + std::to_string(m_registration_grid_size);
 
   const auto hash = std::hash<std::string>{}(key);
   std::stringstream name;
@@ -2240,6 +2249,12 @@ void Optimize::SetRegistrationFlowSigma(double sigma) { m_registration_flow_sigm
 
 //---------------------------------------------------------------------------
 void Optimize::SetRegistrationBand(double band) { m_registration_band = band; }
+
+//---------------------------------------------------------------------------
+void Optimize::SetRegistrationGridSize(int voxels) {
+  // a grid finer than the metric window is meaningless, so keep a small floor
+  m_registration_grid_size = std::max(16, voxels);
+}
 
 //---------------------------------------------------------------------------
 void Optimize::SetRegistrationCacheDir(const std::string& path) { m_registration_cache_dir = path; }

--- a/Libs/Optimize/Optimize.cpp
+++ b/Libs/Optimize/Optimize.cpp
@@ -1049,7 +1049,7 @@ void Optimize::ReportTransferQuality(int domain, const std::vector<Point3>& refe
 
   double total_snap = 0.0;
   double worst_snap = 0.0;
-  int far = 0;
+  int far_count = 0;
   int unmoved = 0;
 
   for (size_t i = 0; i < transferred.size(); i++) {
@@ -1058,7 +1058,7 @@ void Optimize::ReportTransferQuality(int domain, const std::vector<Point3>& refe
     total_snap += snap;
     worst_snap = std::max(worst_snap, snap);
     if (shape_scale > 0.0 && snap > far_distance) {
-      far++;
+      far_count++;
     }
 
     // a point outside the displacement field is returned unchanged rather than reported as an error,
@@ -1069,7 +1069,7 @@ void Optimize::ReportTransferQuality(int domain, const std::vector<Point3>& refe
   }
 
   const double mean_snap = total_snap / transferred.size();
-  const double far_fraction = static_cast<double>(far) / transferred.size();
+  const double far_fraction = static_cast<double>(far_count) / transferred.size();
   // a registration that failed leaves many particles far from the surface, not just one outlier
   const bool suspect = far_fraction > kTransferFarFractionThreshold || unmoved > 0;
 

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -263,6 +263,15 @@ class Optimize {
   //! automatically from the resolution of the data
   void SetRegistrationBand(double band);
 
+  /**
+   * @brief Set where computed registration transforms are cached, or "" to not cache them.
+   *
+   * A transform depends only on the pair of shapes and the registration settings, none of which the
+   * optimization parameters affect.  Caching them lets the particle count, iterations and weightings
+   * be changed and the model rebuilt without paying for the registrations again.
+   */
+  void SetRegistrationCacheDir(const std::string& path);
+
   //! Get number of shapes
   int GetNumShapes();
   //! Set attribute scales (TODO: details)
@@ -396,6 +405,10 @@ class Optimize {
   void ReportTransferQuality(int domain, const std::vector<Point3>& reference_points,
                              const std::vector<Point3>& transferred);
 
+  //! Path a registration's transform is cached at, or "" when caching is off.  The name covers
+  //! everything the transform depends on, so a stale one is never mistaken for a hit.
+  std::string GetRegistrationCachePath(int reference_domain, int domain) const;
+
   //! Build the image used to register the given domain.  Mesh domains are rasterized to a distance
   //! transform; image domains are read back from their groomed path.
   Image GetRegistrationImage(int domain);
@@ -527,6 +540,7 @@ class Optimize {
   double m_registration_gradient_step = 0.25;
   double m_registration_flow_sigma = 3.0;
   double m_registration_band = 0.0;  // 0 means scale it from the data
+  std::string m_registration_cache_dir;
 
   // progress budget charged for each registration, since they run no particle iterations
   int m_transfer_iteration_weight = 0;

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -263,6 +263,11 @@ class Optimize {
   //! automatically from the resolution of the data
   void SetRegistrationBand(double band);
 
+  //! Set the number of voxels across the largest dimension used when rasterizing a mesh for
+  //! registration.  Lower is faster and coarser, higher is finer; only affects mesh domains (image
+  //! domains already have a resolution).  Defaults to 128.
+  void SetRegistrationGridSize(int voxels);
+
   /**
    * @brief Set where computed registration transforms are cached, or "" to not cache them.
    *
@@ -545,6 +550,7 @@ class Optimize {
   double m_registration_gradient_step = 0.25;
   double m_registration_flow_sigma = 3.0;
   double m_registration_band = 0.0;  // 0 means scale it from the data
+  double m_registration_grid_size = 128.0;  // voxels across the largest dimension when rasterizing a mesh
   std::string m_registration_cache_dir;
 
   // progress budget charged for each registration, since they run no particle iterations

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -16,6 +16,7 @@
 #include <Eigen/Eigen>
 
 // shapeworks
+#include <Image/ImageRegistration.h>
 #include <Project/Project.h>
 
 #include "Libs/Optimize/Domain/DomainType.h"
@@ -52,6 +53,13 @@ class Optimize {
   using ImageType = itk::Image<float, 3>;
   using VectorType = VectorFunction::VectorType;
   using MatrixType = Eigen::MatrixXd;
+
+  //! How the initial particle correspondence is established
+  enum class InitializationMode {
+    Split,       //!< particles are split and optimized on every shape at once (the historical behavior)
+    Registration //!< particles are spread over a single reference shape, then carried onto the other
+                 //!< shapes by deformably registering the reference to each of them
+  };
 
   //! Constructor
   Optimize();
@@ -226,6 +234,35 @@ class Optimize {
   //! Set initial particle positions (e.g. for fixed subjects)
   void SetInitialPoints(std::vector<std::vector<itk::Point<double>>> initial_points);
 
+  //! Set the full path of each domain's groomed input, indexed by global domain number.  Image
+  //! domains discard their image once it has been converted to a narrow band, so the path is needed
+  //! to recover the distance transform for registration based initialization.
+  void SetDomainPaths(const std::vector<std::string>& paths);
+
+  //! Set how the initial correspondence is established (default Split)
+  void SetInitializationMode(InitializationMode mode);
+  InitializationMode GetInitializationMode() const { return m_initialization_mode; }
+
+  //! Set the shape used as the registration template, or -1 to choose the most representative shape
+  //! automatically.  Only used when the initialization mode is Registration.
+  void SetRegistrationReference(int shape_index);
+
+  //! Return the shape used as the registration template.  Valid once initialization has run.
+  int GetRegistrationReference() const { return m_registration_reference_chosen; }
+
+  //! Set which registration stages to run when transferring particles (default SyN)
+  void SetRegistrationTransformType(ImageRegistration::TransformType type);
+
+  //! Set the SyN gradient step used when transferring particles
+  void SetRegistrationGradientStep(double step);
+
+  //! Set the variance used to smooth the SyN update field when transferring particles
+  void SetRegistrationFlowSigma(double sigma);
+
+  //! Set the half-width of the distance transform band retained for registration, or 0 to scale it
+  //! automatically from the resolution of the data
+  void SetRegistrationBand(double band);
+
   //! Get number of shapes
   int GetNumShapes();
   //! Set attribute scales (TODO: details)
@@ -314,6 +351,9 @@ class Optimize {
 
   void UpdateProgress();
 
+  //! Report progress with an explicit stage message, for phases that run no particle iterations
+  void UpdateProgress(const std::string& stage);
+
   //! Return the estimated total number of particle-iterations used for progress reporting
   int GetTotalParticleIterations() const { return total_particle_iterations_; }
 
@@ -338,6 +378,36 @@ class Optimize {
   void AddSinglePoint();
   void Initialize();
   void RunOptimize();
+
+  //! Establish the initial correspondence by spreading particles over a single reference shape and
+  //! then registering that shape to each of the others
+  void InitializeFromRegistration();
+
+  //! Pick the shape used as the registration template, honoring an explicitly requested one
+  int ResolveRegistrationReference();
+
+  //! Split and optimize particles on the reference shape alone, until it holds the requested counts
+  void SpreadParticlesOnReference(int reference_shape);
+
+  //! Register the reference to every other shape and carry its particles across
+  void TransferParticlesFromReference(int reference_shape);
+
+  //! Log how well a shape's transferred particles landed on its surface
+  void ReportTransferQuality(int domain, const std::vector<Point3>& reference_points,
+                             const std::vector<Point3>& transferred);
+
+  //! Build the image used to register the given domain.  Mesh domains are rasterized to a distance
+  //! transform; image domains are read back from their groomed path.
+  Image GetRegistrationImage(int domain);
+
+  //! Return the band to retain around the surface, defaulting to a few voxels of the given spacing
+  double GetRegistrationBand(double spacing) const;
+
+  //! Return the surface of the given domain, reading it back from disk for image domains
+  Mesh GetDomainSurface(int domain);
+
+  //! Return the number of shapes (subjects), as opposed to the total number of domains
+  int GetNumberOfSubjects() const;
 
   void ComputeEnergyAfterIteration();
 
@@ -446,7 +516,20 @@ class Optimize {
   double m_spacing = 0;
 
   std::vector<std::string> m_filenames;
+  std::vector<std::string> m_domain_paths;
   int m_num_shapes = 0;
+
+  // Registration based initialization
+  InitializationMode m_initialization_mode = InitializationMode::Split;
+  int m_registration_reference = -1;         // -1 means choose automatically
+  int m_registration_reference_chosen = -1;  // the shape actually used
+  ImageRegistration::TransformType m_registration_transform_type = ImageRegistration::TransformType::SyN;
+  double m_registration_gradient_step = 0.25;
+  double m_registration_flow_sigma = 3.0;
+  double m_registration_band = 0.0;  // 0 means scale it from the data
+
+  // progress budget charged for each registration, since they run no particle iterations
+  int m_transfer_iteration_weight = 0;
 
   std::vector<double> m_energy_a;
   std::vector<double> m_energy_b;
@@ -472,6 +555,10 @@ class Optimize {
 
   int current_particle_iterations_ = 0;
   int total_particle_iterations_ = 0;
+
+  // Progress accrues over one shape's domains.  This shifts that accounting onto the reference while
+  // it is the only shape holding particles.
+  int m_progress_domain_offset = 0;
 
   std::function<void(void)> iteration_callback_;
   bool show_visualizer_ = false;

--- a/Libs/Optimize/Optimize.h
+++ b/Libs/Optimize/Optimize.h
@@ -401,6 +401,11 @@ class Optimize {
   //! Register the reference to every other shape and carry its particles across
   void TransferParticlesFromReference(int reference_shape);
 
+  //! Give the host a chance to refresh during the transfer phase, which runs no optimizer iterations
+  //! and so would otherwise not drive any of the normal per-iteration UI updates.  The base
+  //! implementation does nothing; Studio overrides it to redraw the particles and status.
+  virtual void RefreshDuringTransfer() {}
+
   //! Log how well a shape's transferred particles landed on its surface
   void ReportTransferQuality(int domain, const std::vector<Point3>& reference_points,
                              const std::vector<Point3>& transferred);

--- a/Libs/Optimize/OptimizeParameterFile.cpp
+++ b/Libs/Optimize/OptimizeParameterFile.cpp
@@ -492,6 +492,8 @@ bool OptimizeParameterFile::read_image_inputs(TiXmlHandle* docHandle, Optimize* 
   inputsBuffer.str("");
 
   optimize->SetFilenames(StringUtils::getFileNamesFromPaths(imageFiles));
+  // registration based initialization reads image domains back from disk, so keep the full paths too
+  optimize->SetDomainPaths(imageFiles);
   return true;
 }
 
@@ -582,6 +584,8 @@ bool OptimizeParameterFile::read_mesh_inputs(TiXmlHandle* docHandle, Optimize* o
   }
 
   optimize->SetFilenames(StringUtils::getFileNamesFromPaths(meshFiles));
+  // registration based initialization reads image domains back from disk, so keep the full paths too
+  optimize->SetDomainPaths(meshFiles);
 
   return true;
 }

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -43,6 +43,12 @@ const std::string narrow_band = "narrow_band";
 const std::string verbosity = "verbosity";
 const std::string mesh_ffc_mode = "mesh_ffc_mode";
 const std::string use_landmarks = "use_landmarks";
+const std::string initialization_mode = "initialization_mode";
+const std::string initialization_reference = "initialization_reference";
+const std::string registration_transform_type = "registration_transform_type";
+const std::string registration_grad_step = "registration_grad_step";
+const std::string registration_flow_sigma = "registration_flow_sigma";
+const std::string registration_band = "registration_band";
 const std::string use_fixed_subjects = "use_fixed_subjects";
 const std::string fixed_subjects_column = "fixed_subjects_column";
 const std::string fixed_subjects_choice = "fixed_subjects_choice";
@@ -97,6 +103,12 @@ OptimizeParameters::OptimizeParameters(ProjectHandle project) {
                                          Keys::verbosity,
                                          Keys::mesh_ffc_mode,
                                          Keys::use_landmarks,
+                                         Keys::initialization_mode,
+                                         Keys::initialization_reference,
+                                         Keys::registration_transform_type,
+                                         Keys::registration_grad_step,
+                                         Keys::registration_flow_sigma,
+                                         Keys::registration_band,
                                          Keys::use_fixed_subjects,
                                          Keys::fixed_subjects_column,
                                          Keys::fixed_subjects_choice,
@@ -319,6 +331,83 @@ std::string OptimizeParameters::get_output_prefix() {
 }
 
 //---------------------------------------------------------------------------
+int OptimizeParameters::resolve_registration_reference() {
+  int requested = get_initialization_reference();
+  auto subjects = project_->get_subjects();
+
+  if (requested < 0) {
+    // grooming already picked a representative shape when it aligned the cohort, so reuse that
+    // choice rather than paying for the search a second time.  Groom records it per domain, so ask
+    // the first domain and fall back to the project wide parameters.
+    const std::string key = "alignment_reference_chosen";
+    auto domain_names = project_->get_domain_names();
+    if (!domain_names.empty()) {
+      requested = project_->get_parameters(Parameters::GROOM_PARAMS, domain_names[0]).get(key, -1);
+    }
+    if (requested < 0) {
+      requested = project_->get_parameters(Parameters::GROOM_PARAMS).get(key, -1);
+    }
+  }
+
+  if (requested < 0 || requested >= static_cast<int>(subjects.size()) || subjects[requested]->is_excluded()) {
+    return -1;  // no usable choice, let the optimizer find one
+  }
+
+  // the optimizer only ever sees the subjects that were not excluded, so shift the index to match
+  int shape_index = 0;
+  for (int i = 0; i < requested; i++) {
+    if (!subjects[i]->is_excluded()) {
+      shape_index++;
+    }
+  }
+  return shape_index;
+}
+
+//---------------------------------------------------------------------------
+void OptimizeParameters::apply_initialization_parameters(Optimize* optimize) {
+  const auto mode = get_initialization_mode();
+
+  if (mode == "split") {
+    return;
+  }
+  if (mode != "registration") {
+    throw std::invalid_argument("Unknown initialization mode: \"" + mode + "\", expected \"split\" or \"registration\"");
+  }
+
+  // these all supply their own initial particles, so they cannot also be seeded by registration
+  if (project_->get_fixed_subjects_present()) {
+    throw std::invalid_argument("Registration based initialization cannot be used with fixed subjects");
+  }
+  if (get_use_landmarks()) {
+    throw std::invalid_argument("Registration based initialization cannot be used with landmark initial points");
+  }
+  for (const auto& domain_type : project_->get_groomed_domain_types()) {
+    if (domain_type == DomainType::Contour) {
+      throw std::invalid_argument("Registration based initialization does not support contour domains");
+    }
+  }
+
+  optimize->SetInitializationMode(Optimize::InitializationMode::Registration);
+  optimize->SetRegistrationReference(resolve_registration_reference());
+
+  const auto transform_type = get_registration_transform_type();
+  if (transform_type == "Rigid") {
+    optimize->SetRegistrationTransformType(ImageRegistration::TransformType::Rigid);
+  } else if (transform_type == "Affine") {
+    optimize->SetRegistrationTransformType(ImageRegistration::TransformType::Affine);
+  } else if (transform_type == "SyN") {
+    optimize->SetRegistrationTransformType(ImageRegistration::TransformType::SyN);
+  } else {
+    throw std::invalid_argument("Unknown registration transform type: \"" + transform_type +
+                                "\", expected \"Rigid\", \"Affine\" or \"SyN\"");
+  }
+
+  optimize->SetRegistrationGradientStep(get_registration_grad_step());
+  optimize->SetRegistrationFlowSigma(get_registration_flow_sigma());
+  optimize->SetRegistrationBand(get_registration_band());
+}
+
+//---------------------------------------------------------------------------
 std::vector<std::vector<itk::Point<double>>> OptimizeParameters::get_initial_points() {
   int domains_per_shape = project_->get_number_of_domains_per_subject();
 
@@ -422,6 +511,54 @@ bool OptimizeParameters::get_use_landmarks() { return params_.get(Keys::use_land
 
 //---------------------------------------------------------------------------
 void OptimizeParameters::set_use_landmarks(bool value) { params_.set(Keys::use_landmarks, value); }
+
+//---------------------------------------------------------------------------
+std::string OptimizeParameters::get_initialization_mode() {
+  return params_.get(Keys::initialization_mode, std::string("split"));
+}
+
+//---------------------------------------------------------------------------
+void OptimizeParameters::set_initialization_mode(std::string value) { params_.set(Keys::initialization_mode, value); }
+
+//---------------------------------------------------------------------------
+int OptimizeParameters::get_initialization_reference() { return params_.get(Keys::initialization_reference, -1); }
+
+//---------------------------------------------------------------------------
+void OptimizeParameters::set_initialization_reference(int value) {
+  params_.set(Keys::initialization_reference, value);
+}
+
+//---------------------------------------------------------------------------
+std::string OptimizeParameters::get_registration_transform_type() {
+  return params_.get(Keys::registration_transform_type, std::string("SyN"));
+}
+
+//---------------------------------------------------------------------------
+void OptimizeParameters::set_registration_transform_type(std::string value) {
+  params_.set(Keys::registration_transform_type, value);
+}
+
+//---------------------------------------------------------------------------
+double OptimizeParameters::get_registration_grad_step() { return params_.get(Keys::registration_grad_step, 0.25); }
+
+//---------------------------------------------------------------------------
+void OptimizeParameters::set_registration_grad_step(double value) {
+  params_.set(Keys::registration_grad_step, value);
+}
+
+//---------------------------------------------------------------------------
+double OptimizeParameters::get_registration_flow_sigma() { return params_.get(Keys::registration_flow_sigma, 3.0); }
+
+//---------------------------------------------------------------------------
+void OptimizeParameters::set_registration_flow_sigma(double value) {
+  params_.set(Keys::registration_flow_sigma, value);
+}
+
+//---------------------------------------------------------------------------
+double OptimizeParameters::get_registration_band() { return params_.get(Keys::registration_band, 0.0); }
+
+//---------------------------------------------------------------------------
+void OptimizeParameters::set_registration_band(double value) { params_.set(Keys::registration_band, value); }
 
 //---------------------------------------------------------------------------
 bool OptimizeParameters::get_use_fixed_subjects() { return params_.get(Keys::use_fixed_subjects, false); }
@@ -1011,7 +1148,11 @@ bool OptimizeParameters::set_up_optimize(Optimize* optimize) {
   optimize->SetKeepCheckpoints(get_keep_checkpoints() ? 1 : 0);
 
   optimize->SetFilenames(StringUtils::getFileNamesFromPaths(filenames));
+  // registration based initialization reads image domains back from disk, so keep the full paths too
+  optimize->SetDomainPaths(filenames);
   optimize->SetOutputTransformFile("transform");
+
+  apply_initialization_parameters(optimize);
 
   return true;
 }

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -49,6 +49,7 @@ const std::string registration_transform_type = "registration_transform_type";
 const std::string registration_grad_step = "registration_grad_step";
 const std::string registration_flow_sigma = "registration_flow_sigma";
 const std::string registration_band = "registration_band";
+const std::string registration_grid_size = "registration_grid_size";
 const std::string registration_cache = "registration_cache";
 const std::string use_fixed_subjects = "use_fixed_subjects";
 const std::string fixed_subjects_column = "fixed_subjects_column";
@@ -110,6 +111,7 @@ OptimizeParameters::OptimizeParameters(ProjectHandle project) {
                                          Keys::registration_grad_step,
                                          Keys::registration_flow_sigma,
                                          Keys::registration_band,
+                                         Keys::registration_grid_size,
                                          Keys::registration_cache,
                                          Keys::use_fixed_subjects,
                                          Keys::fixed_subjects_column,
@@ -407,6 +409,7 @@ void OptimizeParameters::apply_initialization_parameters(Optimize* optimize) {
   optimize->SetRegistrationGradientStep(get_registration_grad_step());
   optimize->SetRegistrationFlowSigma(get_registration_flow_sigma());
   optimize->SetRegistrationBand(get_registration_band());
+  optimize->SetRegistrationGridSize(get_registration_grid_size());
 
   if (get_registration_cache()) {
     // Keep the cache beside the project, not under the particle output: that output path carries the
@@ -581,6 +584,12 @@ double OptimizeParameters::get_registration_band() { return params_.get(Keys::re
 
 //---------------------------------------------------------------------------
 void OptimizeParameters::set_registration_band(double value) { params_.set(Keys::registration_band, value); }
+
+//---------------------------------------------------------------------------
+int OptimizeParameters::get_registration_grid_size() { return params_.get(Keys::registration_grid_size, 128); }
+
+//---------------------------------------------------------------------------
+void OptimizeParameters::set_registration_grid_size(int value) { params_.set(Keys::registration_grid_size, value); }
 
 //---------------------------------------------------------------------------
 bool OptimizeParameters::get_registration_cache() { return params_.get(Keys::registration_cache, true); }

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -45,6 +45,7 @@ const std::string mesh_ffc_mode = "mesh_ffc_mode";
 const std::string use_landmarks = "use_landmarks";
 const std::string initialization_mode = "initialization_mode";
 const std::string initialization_reference = "initialization_reference";
+const std::string initialization_reference_chosen = "initialization_reference_chosen";
 const std::string registration_transform_type = "registration_transform_type";
 const std::string registration_grad_step = "registration_grad_step";
 const std::string registration_flow_sigma = "registration_flow_sigma";
@@ -107,6 +108,7 @@ OptimizeParameters::OptimizeParameters(ProjectHandle project) {
                                          Keys::use_landmarks,
                                          Keys::initialization_mode,
                                          Keys::initialization_reference,
+                                         Keys::initialization_reference_chosen,
                                          Keys::registration_transform_type,
                                          Keys::registration_grad_step,
                                          Keys::registration_flow_sigma,

--- a/Libs/Optimize/OptimizeParameters.cpp
+++ b/Libs/Optimize/OptimizeParameters.cpp
@@ -49,6 +49,7 @@ const std::string registration_transform_type = "registration_transform_type";
 const std::string registration_grad_step = "registration_grad_step";
 const std::string registration_flow_sigma = "registration_flow_sigma";
 const std::string registration_band = "registration_band";
+const std::string registration_cache = "registration_cache";
 const std::string use_fixed_subjects = "use_fixed_subjects";
 const std::string fixed_subjects_column = "fixed_subjects_column";
 const std::string fixed_subjects_choice = "fixed_subjects_choice";
@@ -109,6 +110,7 @@ OptimizeParameters::OptimizeParameters(ProjectHandle project) {
                                          Keys::registration_grad_step,
                                          Keys::registration_flow_sigma,
                                          Keys::registration_band,
+                                         Keys::registration_cache,
                                          Keys::use_fixed_subjects,
                                          Keys::fixed_subjects_column,
                                          Keys::fixed_subjects_choice,
@@ -405,6 +407,26 @@ void OptimizeParameters::apply_initialization_parameters(Optimize* optimize) {
   optimize->SetRegistrationGradientStep(get_registration_grad_step());
   optimize->SetRegistrationFlowSigma(get_registration_flow_sigma());
   optimize->SetRegistrationBand(get_registration_band());
+
+  if (get_registration_cache()) {
+    // Keep the cache beside the project, not under the particle output: that output path carries the
+    // optimize prefix, so a run with different parameters would look in a different place and pay
+    // for every registration again, which is the opposite of the point.
+    // note StringUtils::getPath is not usable here: it returns the whole string when there is no
+    // directory component, which would put the cache inside the project file itself
+    auto base = boost::filesystem::path(project_->get_filename()).parent_path();
+    if (base.empty()) {
+      base = ".";  // a project named without any directory sits in the working directory
+    }
+    const auto directory = (base / "registration_cache").string();
+    try {
+      boost::filesystem::create_directories(directory);
+      optimize->SetRegistrationCacheDir(directory);
+      SW_DEBUG("Caching registrations in {}", directory);
+    } catch (const std::exception& e) {
+      SW_WARN("Unable to create registration cache directory \"{}\": {}", directory, e.what());
+    }
+  }
 }
 
 //---------------------------------------------------------------------------
@@ -559,6 +581,12 @@ double OptimizeParameters::get_registration_band() { return params_.get(Keys::re
 
 //---------------------------------------------------------------------------
 void OptimizeParameters::set_registration_band(double value) { params_.set(Keys::registration_band, value); }
+
+//---------------------------------------------------------------------------
+bool OptimizeParameters::get_registration_cache() { return params_.get(Keys::registration_cache, true); }
+
+//---------------------------------------------------------------------------
+void OptimizeParameters::set_registration_cache(bool value) { params_.set(Keys::registration_cache, value); }
 
 //---------------------------------------------------------------------------
 bool OptimizeParameters::get_use_fixed_subjects() { return params_.get(Keys::use_fixed_subjects, false); }

--- a/Libs/Optimize/OptimizeParameters.h
+++ b/Libs/Optimize/OptimizeParameters.h
@@ -24,6 +24,9 @@ class OptimizeParameters {
   //! Return whether the project supplied any optimize parameters (otherwise defaults are used).
   bool has_optimize_parameters();
 
+  //! Apply the initialization settings, if registration based initialization was requested
+  void apply_initialization_parameters(Optimize* optimize);
+
   std::string get_optimize_output_prefix();
   void set_optimize_output_prefix(std::string prefix);
 
@@ -92,6 +95,33 @@ class OptimizeParameters {
 
   bool get_use_landmarks();
   void set_use_landmarks(bool value);
+
+  //! "split" spreads particles on every shape at once, "registration" spreads them on one reference
+  //! shape and carries them onto the others by deformable registration
+  std::string get_initialization_mode();
+  void set_initialization_mode(std::string value);
+
+  //! index of the shape used as the registration template, or -1 to choose it automatically
+  int get_initialization_reference();
+  void set_initialization_reference(int value);
+
+  //! which registration stages to run: "Rigid", "Affine" or "SyN"
+  std::string get_registration_transform_type();
+  void set_registration_transform_type(std::string value);
+
+  double get_registration_grad_step();
+  void set_registration_grad_step(double value);
+
+  double get_registration_flow_sigma();
+  void set_registration_flow_sigma(double value);
+
+  //! half-width of the retained band around the surface, or 0 to scale it from the data resolution
+  double get_registration_band();
+  void set_registration_band(double value);
+
+  //! Resolve which shape should be the registration template, mapping a project subject index onto
+  //! the shape index the optimizer uses.  Returns -1 to let the optimizer choose for itself.
+  int resolve_registration_reference();
 
   bool get_use_fixed_subjects();
   void set_use_fixed_subjects(bool value);

--- a/Libs/Optimize/OptimizeParameters.h
+++ b/Libs/Optimize/OptimizeParameters.h
@@ -119,6 +119,10 @@ class OptimizeParameters {
   double get_registration_band();
   void set_registration_band(double value);
 
+  //! voxels across the largest dimension when rasterizing a mesh for registration (mesh domains only)
+  int get_registration_grid_size();
+  void set_registration_grid_size(int value);
+
   //! whether to reuse registrations across runs; they do not depend on any optimization parameter
   bool get_registration_cache();
   void set_registration_cache(bool value);

--- a/Libs/Optimize/OptimizeParameters.h
+++ b/Libs/Optimize/OptimizeParameters.h
@@ -119,6 +119,10 @@ class OptimizeParameters {
   double get_registration_band();
   void set_registration_band(double value);
 
+  //! whether to reuse registrations across runs; they do not depend on any optimization parameter
+  bool get_registration_cache();
+  void set_registration_cache(bool value);
+
   //! Resolve which shape should be the registration template, mapping a project subject index onto
   //! the shape index the optimizer uses.  Returns -1 to let the optimizer choose for itself.
   int resolve_registration_reference();

--- a/Libs/Optimize/ParticleSystem.cpp
+++ b/Libs/Optimize/ParticleSystem.cpp
@@ -320,6 +320,52 @@ void ParticleSystem::AdvancedAllParticleSplitting(double epsilon, unsigned int d
   }      // if end
 }
 
+void ParticleSystem::ResyncObservers() {
+  for (unsigned int d = 0; d < GetNumberOfDomains(); d++) {
+    const auto count = GetNumberOfParticles(d);
+    if (count == 0) {
+      continue;
+    }
+    // observers size themselves from the particle counts when a position is added, so announcing the
+    // last position of each domain is enough to bring them up to date
+    ParticlePositionAddEvent e;
+    e.SetDomainIndex(d);
+    e.SetPositionIndex(count - 1);
+    InvokeEvent(e);
+  }
+}
+
+void ParticleSystem::SplitAllParticlesInDomain(double epsilon, unsigned int domain) {
+  std::vector<PointType> positions;
+  for (auto k = 0; k < GetPositions(domain)->GetSize(); k++) {
+    positions.push_back(GetPositions(domain)->Get(k));
+  }
+
+  std::vector<double> zeros(positions.size() * 2, 0.0);
+  GetDomain(domain)->GetConstraints()->InitializeLagrangianParameters(zeros);
+
+  std::uniform_real_distribution<double> distribution(-1000., 1000.);
+
+  for (const auto& position : positions) {
+    // generate a random unit vector and offset the particle along it, then pull the result back onto
+    // the surface
+    vnl_vector_fixed<double, 3> random;
+    for (int i = 0; i < 3; i++) {
+      random[i] = distribution(m_rand);
+    }
+    random /= random.magnitude();
+
+    auto transformed_vector = TransformVector(random, GetInversePrefixTransform(domain) * GetInverseTransform(domain));
+    PointType new_position = GetDomain(domain)->GetPositionAfterSplit(position, transformed_vector, random, epsilon);
+
+    if (!m_DomainFlags[domain] && !GetDomain(domain)->GetConstraints()->isAnyViolated(new_position)) {
+      GetDomain(domain)->ApplyConstraints(new_position, -1);
+    }
+
+    AddPosition(new_position, domain);
+  }
+}
+
 double ParticleSystem::ComputeMaxDistNearestNeighbors(size_t dom) {
   std::vector<PointType> list;
   for (auto k = 0; k < GetPositions(dom)->GetSize(); k++) {

--- a/Libs/Optimize/ParticleSystem.h
+++ b/Libs/Optimize/ParticleSystem.h
@@ -138,6 +138,18 @@ class ParticleSystem : public itk::DataObject {
   void SplitAllParticles(double epsilon);
   void SplitParticle(double epsilon, unsigned int idx, unsigned int d = 0);
   void AdvancedAllParticleSplitting(double epsilon, unsigned int domains_per_shape, unsigned int dom_to_process);
+
+  /** Doubles the number of particles in a single domain.  Unlike
+      AdvancedAllParticleSplitting, which splits one domain across every shape at once and therefore
+      requires all shapes to hold the same number of particles, this splits one domain on its own.
+      It is used to spread particles over a single reference shape. */
+  void SplitAllParticlesInDomain(double epsilon, unsigned int domain);
+
+  /** Re-announce the current particle count of every domain, so that observers which were not
+      listening while the positions were added (the correspondence matrices are suspended while
+      particles are spread over a single reference shape) resize themselves to match.  Without this
+      they keep their original size and later position updates index out of bounds. */
+  void ResyncObservers();
   // Debug function
   void PrintParticleSystem();
 

--- a/Libs/Optimize/Sampler.h
+++ b/Libs/Optimize/Sampler.h
@@ -146,6 +146,18 @@ class Sampler {
 
   bool GetSamplingOn() const { return m_LinkingFunction->get_a_on(); }
 
+  /** Stop the correspondence matrices from tracking particle changes.  They index themselves
+      assuming every shape holds the same number of particles, so they cannot be kept up to date
+      while particles are being spread over a single reference shape.  Resume and then call
+      SynchronizePositions() once every shape has been populated. */
+  void SetCorrespondenceMatricesSuspended(bool suspended) {
+    m_LegacyShapeMatrix->set_suspended(suspended);
+    m_LinearRegressionShapeMatrix->set_suspended(suspended);
+    m_MixedEffectsShapeMatrix->set_suspended(suspended);
+    m_GeneralShapeMatrix->set_suspended(suspended);
+    m_GeneralShapeGradMatrix->set_suspended(suspended);
+  }
+
   /** This method sets the optimization function for correspondences between surfaces (domains). */
   void SetCorrespondenceMode(shapeworks::CorrespondenceMode mode);
 

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -858,6 +858,14 @@ PYBIND11_MODULE(shapeworks_py, m) {
       .def("warped_moving", &ImageRegistration::warped_moving,
            "returns the moving image resampled onto the fixed image grid")
 
+      .def("save_transform", &ImageRegistration::save_transform,
+           "writes the computed transform so that it can be reused in place of registering again",
+           "filename"_a)
+
+      .def("load_transform", &ImageRegistration::load_transform,
+           "reads a transform written by save_transform, in place of running the registration",
+           "filename"_a)
+
       .def_static("make_registration_image", &ImageRegistration::make_registration_image,
                   "clamps a distance transform to a band around the surface and rescales it to [0,1], which keeps the "
                   "similarity metric focused on the region near the surface",

--- a/Libs/Python/ShapeworksPython.cpp
+++ b/Libs/Python/ShapeworksPython.cpp
@@ -32,6 +32,7 @@ using namespace pybind11::literals;
 
 #include "EigenUtils.h"
 #include "Image.h"
+#include "ImageRegistration.h"
 #include "ImageUtils.h"
 #include "Mesh.h"
 #include "MeshUtils.h"
@@ -790,6 +791,79 @@ PYBIND11_MODULE(shapeworks_py, m) {
                   "computes a warp transform from the source to the target landmarks (in the given files) using every "
                   "stride points",
                   "source_landmarks"_a, "target_landmarks"_a, "stride"_a = 1);
+
+  // ImageRegistration
+  py::class_<ImageRegistration> image_registration(m, "ImageRegistration");
+
+  // ImageRegistration::TransformType
+  py::enum_<ImageRegistration::TransformType>(image_registration, "TransformType")
+      .value("Rigid", ImageRegistration::TransformType::Rigid)
+      .value("Affine", ImageRegistration::TransformType::Affine)
+      .value("SyN", ImageRegistration::TransformType::SyN)
+      .export_values();
+
+  image_registration
+
+      .def(py::init<>())
+
+      .def("set_transform_type", &ImageRegistration::set_transform_type,
+           "sets which registration stages to run: Rigid, Affine or SyN", "type"_a)
+
+      .def("set_gradient_step", &ImageRegistration::set_gradient_step, "sets the SyN gradient step size", "step"_a)
+
+      .def("set_update_field_variance", &ImageRegistration::set_update_field_variance,
+           "sets the variance used to smooth the SyN update field", "variance"_a)
+
+      .def("set_total_field_variance", &ImageRegistration::set_total_field_variance,
+           "sets the variance used to smooth the SyN total field", "variance"_a)
+
+      .def("set_iterations", &ImageRegistration::set_iterations,
+           "sets the per-level iteration counts, coarsest level first", "iterations"_a)
+
+      .def("set_shrink_factors", &ImageRegistration::set_shrink_factors,
+           "sets the shrink factors per level, coarsest level first", "shrink_factors"_a)
+
+      .def("set_smoothing_sigmas", &ImageRegistration::set_smoothing_sigmas,
+           "sets the smoothing sigmas (in physical units) per level, coarsest level first", "sigmas"_a)
+
+      .def("set_correlation_radius", &ImageRegistration::set_correlation_radius,
+           "sets the neighborhood radius of the correlation metric used by the SyN stage", "radius"_a)
+
+      .def("run", &ImageRegistration::run,
+           "registers the moving image to the fixed image; the resulting transform maps points from fixed space into "
+           "moving space, so pass the shape holding the particles as the fixed image",
+           "fixed"_a, "moving"_a)
+
+      .def(
+          "transform_points",
+          [](const ImageRegistration& registration, const std::vector<std::vector<double>>& points) {
+            std::vector<Point3> input;
+            input.reserve(points.size());
+            for (const auto& point : points) {
+              if (point.size() != 3) {
+                throw std::invalid_argument("each point must have three coordinates");
+              }
+              input.push_back(Point3({point[0], point[1], point[2]}));
+            }
+
+            std::vector<std::vector<double>> output;
+            output.reserve(input.size());
+            for (const auto& point : registration.transform_points(input)) {
+              output.push_back({point[0], point[1], point[2]});
+            }
+            return output;
+          },
+          "maps points from fixed image space into moving image space", "points"_a)
+
+      .def("warped_moving", &ImageRegistration::warped_moving,
+           "returns the moving image resampled onto the fixed image grid")
+
+      .def_static("make_registration_image", &ImageRegistration::make_registration_image,
+                  "clamps a distance transform to a band around the surface and rescales it to [0,1], which keeps the "
+                  "similarity metric focused on the region near the surface",
+                  "dt"_a, "band"_a = 5.0)
+
+      ;
 
   // Mesh
   py::class_<Mesh> mesh(m, "Mesh");

--- a/Studio/Analysis/AnalysisTool.ui
+++ b/Studio/Analysis/AnalysisTool.ui
@@ -1275,6 +1275,187 @@ QWidget#particles_panel {
                 </item>
                </layout>
               </widget>
+              <widget class="QWidget" name="regression_tab">
+               <attribute name="title">
+                <string>Regression</string>
+               </attribute>
+               <layout class="QVBoxLayout" name="regression_tab_layout">
+                <item>
+                 <layout class="QHBoxLayout" name="regression_combo_layout">
+                  <item>
+                   <widget class="QLabel" name="regression_explanatory_label">
+                    <property name="text">
+                     <string>Explanatory Variable</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="regression_combo">
+                    <property name="toolTip">
+                     <string>Select the numeric per-subject column to regress shape against</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <widget class="QLabel" name="regression_hint_label">
+                  <property name="text">
+                   <string>No numeric per-subject columns are available for regression.  Add a numeric column (e.g. age or time) to the project spreadsheet.</string>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <layout class="QGridLayout" name="regression_grid_layout">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="regression_min_label">
+                    <property name="text">
+                     <string>0</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="CustomSlider" name="regressionSlider">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="toolTip">
+                     <string>Explanatory variable value</string>
+                    </property>
+                    <property name="maximum">
+                     <number>100</number>
+                    </property>
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="tickPosition">
+                     <enum>QSlider::TicksBelow</enum>
+                    </property>
+                    <property name="tickInterval">
+                     <number>25</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QLabel" name="regression_max_label">
+                    <property name="text">
+                     <string>1</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="regression_value_layout">
+                  <item>
+                   <spacer name="regression_spacer_left">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="regression_value_caption">
+                    <property name="text">
+                     <string>Value:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QLabel" name="regressionLabel">
+                    <property name="minimumSize">
+                     <size>
+                      <width>50</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="regression_spacer_right">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QHBoxLayout" name="regression_animate_layout">
+                  <item>
+                   <spacer name="regression_animate_spacer_left">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="regressionAnimateCheckBox">
+                    <property name="enabled">
+                     <bool>false</bool>
+                    </property>
+                    <property name="toolTip">
+                     <string>Animate across the explanatory variable range</string>
+                    </property>
+                    <property name="text">
+                     <string>Animate</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="regression_animate_spacer_right">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>40</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <spacer name="regression_vertical_spacer">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>40</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </widget>
               <widget class="QWidget" name="pca_tab">
                <attribute name="title">
                 <string>PCA</string>
@@ -1750,187 +1931,6 @@ QWidget#particles_panel {
                    </item>
                   </layout>
                  </widget>
-                </item>
-               </layout>
-              </widget>
-              <widget class="QWidget" name="regression_tab">
-               <attribute name="title">
-                <string>Regression</string>
-               </attribute>
-               <layout class="QVBoxLayout" name="regression_tab_layout">
-                <item>
-                 <layout class="QHBoxLayout" name="regression_combo_layout">
-                  <item>
-                   <widget class="QLabel" name="regression_explanatory_label">
-                    <property name="text">
-                     <string>Explanatory Variable</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="regression_combo">
-                    <property name="toolTip">
-                     <string>Select the numeric per-subject column to regress shape against</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <widget class="QLabel" name="regression_hint_label">
-                  <property name="text">
-                   <string>No numeric per-subject columns are available for regression.  Add a numeric column (e.g. age or time) to the project spreadsheet.</string>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <layout class="QGridLayout" name="regression_grid_layout">
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="regression_min_label">
-                    <property name="text">
-                     <string>0</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="CustomSlider" name="regressionSlider">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                    <property name="toolTip">
-                     <string>Explanatory variable value</string>
-                    </property>
-                    <property name="maximum">
-                     <number>100</number>
-                    </property>
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="tickPosition">
-                     <enum>QSlider::TicksBelow</enum>
-                    </property>
-                    <property name="tickInterval">
-                     <number>25</number>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <widget class="QLabel" name="regression_max_label">
-                    <property name="text">
-                     <string>1</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout" name="regression_value_layout">
-                  <item>
-                   <spacer name="regression_spacer_left">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item>
-                   <widget class="QLabel" name="regression_value_caption">
-                    <property name="text">
-                     <string>Value:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QLabel" name="regressionLabel">
-                    <property name="minimumSize">
-                     <size>
-                      <width>50</width>
-                      <height>0</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <spacer name="regression_spacer_right">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout" name="regression_animate_layout">
-                  <item>
-                   <spacer name="regression_animate_spacer_left">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item>
-                   <widget class="QCheckBox" name="regressionAnimateCheckBox">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                    <property name="toolTip">
-                     <string>Animate across the explanatory variable range</string>
-                    </property>
-                    <property name="text">
-                     <string>Animate</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <spacer name="regression_animate_spacer_right">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <spacer name="regression_vertical_spacer">
-                  <property name="orientation">
-                   <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>40</height>
-                   </size>
-                  </property>
-                 </spacer>
                 </item>
                </layout>
               </widget>

--- a/Studio/Optimize/OptimizeTool.cpp
+++ b/Studio/Optimize/OptimizeTool.cpp
@@ -80,6 +80,7 @@ OptimizeTool::OptimizeTool(Preferences& prefs, Telemetry& telemetry) : preferenc
   connect(ui_->use_geodesics_from_landmarks, &QCheckBox::toggled, this, &OptimizeTool::update_ui_elements);
   connect(ui_->use_geodesic_distance, &QCheckBox::toggled, this, &OptimizeTool::update_ui_elements);
   connect(ui_->sampling_scale, &QCheckBox::toggled, this, &OptimizeTool::update_ui_elements);
+  connect(ui_->registration_initialization, &QCheckBox::toggled, this, &OptimizeTool::update_ui_elements);
 
   ui_->number_of_particles->setToolTip("Number of correspondence points to generate");
   ui_->initial_relative_weighting->setToolTip("Relative weighting of correspondence term during initialization");
@@ -101,6 +102,16 @@ OptimizeTool::OptimizeTool(Preferences& prefs, Telemetry& telemetry) : preferenc
   ui_->multiscale->setToolTip("Use multiscale optimization mode");
   ui_->multiscale_particles->setToolTip("Start multiscale optimization after this many particles");
   ui_->use_landmarks->setToolTip("Use landmarks as initial particles");
+  ui_->registration_initialization->setToolTip(
+      "Spread particles over a single automatically chosen reference shape, then carry them onto every "
+      "other shape by deformably registering the reference to it, instead of splitting particles on all "
+      "shapes at once. Cannot be combined with landmarks or fixed subjects");
+  ui_->registration_transform_type->setToolTip(
+      "Registration stages to run when transferring particles. SyN runs rigid, then affine, then "
+      "symmetric normalization");
+  ui_->registration_band->setToolTip(
+      "Half-width, in physical units, of the band around the surface that registration considers. "
+      "Should span several voxels of the groomed inputs");
   ui_->narrow_band->setToolTip(
       "Narrow band around distance transforms.  "
       "This value should only be changed if an error occurs "
@@ -136,6 +147,7 @@ OptimizeTool::OptimizeTool(Preferences& prefs, Telemetry& telemetry) : preferenc
   ui_->geodesics_to_landmarks_weight->setValidator(double_validator);
   ui_->shared_boundary_weight->setValidator(double_validator);
   ui_->sampling_scale_value->setValidator(double_validator);
+  ui_->registration_band->setValidator(double_validator);
 
   line_edits_.push_back(ui_->number_of_particles);
   line_edits_.push_back(ui_->initial_relative_weighting);
@@ -151,6 +163,7 @@ OptimizeTool::OptimizeTool(Preferences& prefs, Telemetry& telemetry) : preferenc
   line_edits_.push_back(ui_->narrow_band);
   line_edits_.push_back(ui_->shared_boundary_weight);
   line_edits_.push_back(ui_->sampling_scale_value);
+  line_edits_.push_back(ui_->registration_band);
 
   for (QLineEdit* line_edit : line_edits_) {
     connect(line_edit, &QLineEdit::textChanged, this, &OptimizeTool::update_run_button);
@@ -351,6 +364,10 @@ void OptimizeTool::load_params() {
   ui_->multiscale->setChecked(params.get_use_multiscale());
   ui_->multiscale_particles->setText(QString::number(params.get_multiscale_particles()));
   ui_->use_landmarks->setChecked(params.get_use_landmarks());
+  ui_->registration_initialization->setChecked(params.get_initialization_mode() == "registration");
+  ui_->registration_transform_type->setCurrentText(
+      QString::fromStdString(params.get_registration_transform_type()));
+  ui_->registration_band->setText(QString::number(params.get_registration_band()));
   ui_->narrow_band->setText(QString::number(params.get_narrow_band()));
   ui_->shared_boundary->setChecked(params.get_shared_boundary());
   ui_->shared_boundary_weight->setText(QString::number(params.get_shared_boundary_weight()));
@@ -397,6 +414,9 @@ void OptimizeTool::store_params() {
   params.set_use_multiscale(ui_->multiscale->isChecked());
   params.set_multiscale_particles(ui_->multiscale_particles->text().toDouble());
   params.set_use_landmarks(ui_->use_landmarks->isChecked());
+  params.set_initialization_mode(ui_->registration_initialization->isChecked() ? "registration" : "split");
+  params.set_registration_transform_type(ui_->registration_transform_type->currentText().toStdString());
+  params.set_registration_band(ui_->registration_band->text().toDouble());
 
   // always use preference value
   params.set_geodesic_cache_multiplier(preferences_.get_geodesic_cache_multiplier());
@@ -449,6 +469,14 @@ void OptimizeTool::update_ui_elements() {
 
   ui_->sampling_auto_scale->setEnabled(ui_->sampling_scale->isChecked());
   ui_->sampling_scale_value->setEnabled(ui_->sampling_scale->isChecked());
+
+  const bool registration = ui_->registration_initialization->isChecked();
+  ui_->registration_transform_type->setEnabled(registration);
+  ui_->registration_band->setEnabled(registration);
+  // registration seeds every shape at the final particle count, so these have nothing left to do
+  ui_->multiscale->setEnabled(!registration);
+  ui_->multiscale_particles->setEnabled(!registration && ui_->multiscale->isChecked());
+  ui_->use_landmarks->setEnabled(!registration);
 }
 
 //---------------------------------------------------------------------------
@@ -568,7 +596,10 @@ void OptimizeTool::setup_domain_boxes() {
   QWidget::setTabOrder(ui_->multiscale_particles, ui_->shared_boundary);
   QWidget::setTabOrder(ui_->shared_boundary, ui_->shared_boundary_weight);
   QWidget::setTabOrder(ui_->shared_boundary_weight, ui_->use_landmarks);
-  QWidget::setTabOrder(ui_->use_landmarks, ui_->procrustes);
+  QWidget::setTabOrder(ui_->use_landmarks, ui_->registration_initialization);
+  QWidget::setTabOrder(ui_->registration_initialization, ui_->registration_transform_type);
+  QWidget::setTabOrder(ui_->registration_transform_type, ui_->registration_band);
+  QWidget::setTabOrder(ui_->registration_band, ui_->procrustes);
   QWidget::setTabOrder(ui_->procrustes, ui_->procrustes_interval);
   QWidget::setTabOrder(ui_->procrustes_interval, ui_->procrustes_scaling);
   QWidget::setTabOrder(ui_->procrustes_scaling, ui_->procrustes_rotation_translation);

--- a/Studio/Optimize/OptimizeTool.cpp
+++ b/Studio/Optimize/OptimizeTool.cpp
@@ -114,6 +114,10 @@ OptimizeTool::OptimizeTool(Preferences& prefs, Telemetry& telemetry) : preferenc
       "Leave empty to scale it automatically from the resolution of the groomed inputs (a few voxels), "
       "which is the recommended default");
   ui_->registration_band->setPlaceholderText("auto");
+  ui_->registration_grid_size->setToolTip(
+      "Rasterization resolution for mesh registration: voxels across the largest dimension. Lower is "
+      "faster and coarser, higher is finer; 128 is the default. Above ~192 gives little benefit at "
+      "much higher time and cache cost. Ignored for image (distance-transform) inputs");
   ui_->narrow_band->setToolTip(
       "Narrow band around distance transforms.  "
       "This value should only be changed if an error occurs "
@@ -150,6 +154,7 @@ OptimizeTool::OptimizeTool(Preferences& prefs, Telemetry& telemetry) : preferenc
   ui_->shared_boundary_weight->setValidator(double_validator);
   ui_->sampling_scale_value->setValidator(double_validator);
   ui_->registration_band->setValidator(double_validator);
+  ui_->registration_grid_size->setValidator(new QIntValidator(16, 1024, this));
 
   line_edits_.push_back(ui_->number_of_particles);
   line_edits_.push_back(ui_->initial_relative_weighting);
@@ -166,6 +171,7 @@ OptimizeTool::OptimizeTool(Preferences& prefs, Telemetry& telemetry) : preferenc
   line_edits_.push_back(ui_->shared_boundary_weight);
   line_edits_.push_back(ui_->sampling_scale_value);
   line_edits_.push_back(ui_->registration_band);
+  line_edits_.push_back(ui_->registration_grid_size);
 
   for (QLineEdit* line_edit : line_edits_) {
     connect(line_edit, &QLineEdit::textChanged, this, &OptimizeTool::update_run_button);
@@ -373,6 +379,7 @@ void OptimizeTool::load_params() {
   // rather than a literal 0, which reads as a zero-width band
   const double band = params.get_registration_band();
   ui_->registration_band->setText(band > 0.0 ? QString::number(band) : QString());
+  ui_->registration_grid_size->setText(QString::number(params.get_registration_grid_size()));
   ui_->narrow_band->setText(QString::number(params.get_narrow_band()));
   ui_->shared_boundary->setChecked(params.get_shared_boundary());
   ui_->shared_boundary_weight->setText(QString::number(params.get_shared_boundary_weight()));
@@ -422,6 +429,7 @@ void OptimizeTool::store_params() {
   params.set_initialization_mode(ui_->registration_initialization->isChecked() ? "registration" : "split");
   params.set_registration_transform_type(ui_->registration_transform_type->currentText().toStdString());
   params.set_registration_band(ui_->registration_band->text().toDouble());
+  params.set_registration_grid_size(ui_->registration_grid_size->text().toInt());
 
   // always use preference value
   params.set_geodesic_cache_multiplier(preferences_.get_geodesic_cache_multiplier());
@@ -478,6 +486,7 @@ void OptimizeTool::update_ui_elements() {
   const bool registration = ui_->registration_initialization->isChecked();
   ui_->registration_transform_type->setEnabled(registration);
   ui_->registration_band->setEnabled(registration);
+  ui_->registration_grid_size->setEnabled(registration);
   // registration seeds every shape at the final particle count, so these have nothing left to do
   ui_->multiscale->setEnabled(!registration);
   ui_->multiscale_particles->setEnabled(!registration && ui_->multiscale->isChecked());
@@ -607,7 +616,8 @@ void OptimizeTool::setup_domain_boxes() {
   QWidget::setTabOrder(ui_->use_landmarks, ui_->registration_initialization);
   QWidget::setTabOrder(ui_->registration_initialization, ui_->registration_transform_type);
   QWidget::setTabOrder(ui_->registration_transform_type, ui_->registration_band);
-  QWidget::setTabOrder(ui_->registration_band, ui_->procrustes);
+  QWidget::setTabOrder(ui_->registration_band, ui_->registration_grid_size);
+  QWidget::setTabOrder(ui_->registration_grid_size, ui_->procrustes);
   QWidget::setTabOrder(ui_->procrustes, ui_->procrustes_interval);
   QWidget::setTabOrder(ui_->procrustes_interval, ui_->procrustes_scaling);
   QWidget::setTabOrder(ui_->procrustes_scaling, ui_->procrustes_rotation_translation);

--- a/Studio/Optimize/OptimizeTool.cpp
+++ b/Studio/Optimize/OptimizeTool.cpp
@@ -111,7 +111,9 @@ OptimizeTool::OptimizeTool(Preferences& prefs, Telemetry& telemetry) : preferenc
       "symmetric normalization");
   ui_->registration_band->setToolTip(
       "Half-width, in physical units, of the band around the surface that registration considers. "
-      "Should span several voxels of the groomed inputs");
+      "Leave empty to scale it automatically from the resolution of the groomed inputs (a few voxels), "
+      "which is the recommended default");
+  ui_->registration_band->setPlaceholderText("auto");
   ui_->narrow_band->setToolTip(
       "Narrow band around distance transforms.  "
       "This value should only be changed if an error occurs "
@@ -367,7 +369,10 @@ void OptimizeTool::load_params() {
   ui_->registration_initialization->setChecked(params.get_initialization_mode() == "registration");
   ui_->registration_transform_type->setCurrentText(
       QString::fromStdString(params.get_registration_transform_type()));
-  ui_->registration_band->setText(QString::number(params.get_registration_band()));
+  // a band of 0 means "scale automatically"; show that as an empty field with an "auto" placeholder
+  // rather than a literal 0, which reads as a zero-width band
+  const double band = params.get_registration_band();
+  ui_->registration_band->setText(band > 0.0 ? QString::number(band) : QString());
   ui_->narrow_band->setText(QString::number(params.get_narrow_band()));
   ui_->shared_boundary->setChecked(params.get_shared_boundary());
   ui_->shared_boundary_weight->setText(QString::number(params.get_shared_boundary_weight()));
@@ -506,7 +511,10 @@ bool OptimizeTool::validate_inputs() {
     QString text = line_edit->text();
     int pos;
     QString ss;
-    if (QValidator::Acceptable != line_edit->validator()->validate(text, pos)) {
+    // an empty registration band is valid: it means "scale the band automatically from the data".
+    // The field's own validator still rejects non-numeric input, so this only accepts truly empty.
+    const bool empty_band_is_ok = line_edit == ui_->registration_band && text.isEmpty();
+    if (!empty_band_is_ok && QValidator::Acceptable != line_edit->validator()->validate(text, pos)) {
       ss = "QLineEdit {background-color: rgb(255,204,203);}";
       all_valid = false;
     }

--- a/Studio/Optimize/OptimizeTool.ui
+++ b/Studio/Optimize/OptimizeTool.ui
@@ -815,23 +815,56 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
+               <!-- Row 26: Registration grid size -->
+               <item row="26" column="1">
+                <widget class="QLabel" name="registration_grid_label">
+                 <property name="text">
+                  <string>Grid:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="26" column="2">
+                <widget class="QLineEdit" name="registration_grid_size">
+                 <property name="text">
+                  <string>128</string>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>50</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>100</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
                <!-- Divider: after Geodesic/Options group -->
-               <item row="26" column="0" colspan="4">
+               <item row="27" column="0" colspan="4">
                 <widget class="Line" name="line_opt_2">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
                  </property>
                 </widget>
                </item>
-               <!-- Row 27: Procrustes (combined checkbox + interval) -->
-               <item row="27" column="0">
+               <!-- Row 28: Procrustes (combined checkbox + interval) -->
+               <item row="28" column="0">
                 <widget class="QCheckBox" name="procrustes">
                  <property name="text">
                   <string>Procrustes</string>
                  </property>
                 </widget>
                </item>
-               <item row="27" column="1">
+               <item row="28" column="1">
                 <widget class="QLabel" name="procrustes_interval_label">
                  <property name="text">
                   <string>Interval:</string>
@@ -841,7 +874,7 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-              <item row="27" column="2">
+              <item row="28" column="2">
                 <widget class="QLineEdit" name="procrustes_interval">
                  <property name="text">
                   <string>10</string>
@@ -863,8 +896,8 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-               <!-- Row 28: Procrustes sub-options (Scaling + Rot/Trans) -->
-               <item row="28" column="0" colspan="3">
+               <!-- Row 29: Procrustes sub-options (Scaling + Rot/Trans) -->
+               <item row="29" column="0" colspan="3">
                 <widget class="QWidget" name="procrustes_sub_widget" native="true">
                  <layout class="QHBoxLayout" name="procrustes_sub_layout">
                   <property name="leftMargin">
@@ -910,15 +943,15 @@ QWidget#optimize_panel {
                 </widget>
                </item>
                <!-- Divider: after Procrustes group -->
-               <item row="29" column="0" colspan="4">
+               <item row="30" column="0" colspan="4">
                 <widget class="Line" name="line_opt_3">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
                  </property>
                 </widget>
                </item>
-               <!-- Row 30: Sampling Scale (combined checkbox + multiplier) -->
-               <item row="30" column="0">
+               <!-- Row 31: Sampling Scale (combined checkbox + multiplier) -->
+               <item row="31" column="0">
                 <widget class="QCheckBox" name="sampling_scale">
                  <property name="text">
                   <string>Sampling Scale</string>
@@ -928,7 +961,7 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-               <item row="30" column="1">
+               <item row="31" column="1">
                 <widget class="QLabel" name="sampling_scale_label">
                  <property name="text">
                   <string>Multiplier:</string>
@@ -938,7 +971,7 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-              <item row="30" column="2">
+              <item row="31" column="2">
                 <widget class="QLineEdit" name="sampling_scale_value">
                  <property name="text">
                   <string>1.0</string>
@@ -960,8 +993,8 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-               <!-- Row 31: Auto Scale (sub-checkbox) -->
-               <item row="31" column="0" colspan="3">
+               <!-- Row 32: Auto Scale (sub-checkbox) -->
+               <item row="32" column="0" colspan="3">
                 <widget class="QWidget" name="sampling_auto_scale_sub_widget" native="true">
                  <layout class="QHBoxLayout" name="sampling_auto_scale_sub_layout">
                   <property name="leftMargin">
@@ -1002,8 +1035,8 @@ QWidget#optimize_panel {
                  </layout>
                 </widget>
                </item>
-               <!-- Row 32: Disentangled SSM (checkbox only, hidden) -->
-               <item row="32" column="0">
+               <!-- Row 33: Disentangled SSM (checkbox only, hidden) -->
+               <item row="33" column="0">
                 <widget class="QCheckBox" name="use_disentangled_ssm">
                  <property name="text">
                   <string>Disentangled SSM</string>
@@ -1118,6 +1151,7 @@ QWidget#optimize_panel {
   <tabstop>registration_initialization</tabstop>
   <tabstop>registration_transform_type</tabstop>
   <tabstop>registration_band</tabstop>
+  <tabstop>registration_grid_size</tabstop>
   <tabstop>narrow_band</tabstop>
   <tabstop>sampling_scale</tabstop>
   <tabstop>sampling_scale_value</tabstop>

--- a/Studio/Optimize/OptimizeTool.ui
+++ b/Studio/Optimize/OptimizeTool.ui
@@ -795,8 +795,8 @@ QWidget#optimize_panel {
                </item>
                <item row="25" column="2">
                 <widget class="QLineEdit" name="registration_band">
-                 <property name="text">
-                  <string>5.0</string>
+                 <property name="placeholderText">
+                  <string>auto</string>
                  </property>
                  <property name="minimumSize">
                   <size>

--- a/Studio/Optimize/OptimizeTool.ui
+++ b/Studio/Optimize/OptimizeTool.ui
@@ -733,23 +733,105 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
+               <!-- Row 24: Registration Initialization (combined checkbox + transform type) -->
+               <item row="24" column="0">
+                <widget class="QCheckBox" name="registration_initialization">
+                 <property name="text">
+                  <string>Registration Initialization</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="24" column="1">
+                <widget class="QLabel" name="registration_transform_label">
+                 <property name="text">
+                  <string>Transform:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="24" column="2">
+                <widget class="QComboBox" name="registration_transform_type">
+                 <property name="minimumSize">
+                  <size>
+                   <width>50</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>100</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <item>
+                  <property name="text">
+                   <string>Rigid</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Affine</string>
+                  </property>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>SyN</string>
+                  </property>
+                 </item>
+                </widget>
+               </item>
+               <!-- Row 25: Registration band -->
+               <item row="25" column="1">
+                <widget class="QLabel" name="registration_band_label">
+                 <property name="text">
+                  <string>Band:</string>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignVCenter</set>
+                 </property>
+                </widget>
+               </item>
+               <item row="25" column="2">
+                <widget class="QLineEdit" name="registration_band">
+                 <property name="text">
+                  <string>5.0</string>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>50</width>
+                   <height>0</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>100</width>
+                   <height>16777215</height>
+                  </size>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                </widget>
+               </item>
                <!-- Divider: after Geodesic/Options group -->
-               <item row="24" column="0" colspan="4">
+               <item row="26" column="0" colspan="4">
                 <widget class="Line" name="line_opt_2">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
                  </property>
                 </widget>
                </item>
-               <!-- Row 25: Procrustes (combined checkbox + interval) -->
-               <item row="25" column="0">
+               <!-- Row 27: Procrustes (combined checkbox + interval) -->
+               <item row="27" column="0">
                 <widget class="QCheckBox" name="procrustes">
                  <property name="text">
                   <string>Procrustes</string>
                  </property>
                 </widget>
                </item>
-               <item row="25" column="1">
+               <item row="27" column="1">
                 <widget class="QLabel" name="procrustes_interval_label">
                  <property name="text">
                   <string>Interval:</string>
@@ -759,7 +841,7 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-              <item row="25" column="2">
+              <item row="27" column="2">
                 <widget class="QLineEdit" name="procrustes_interval">
                  <property name="text">
                   <string>10</string>
@@ -781,8 +863,8 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-               <!-- Row 26: Procrustes sub-options (Scaling + Rot/Trans) -->
-               <item row="26" column="0" colspan="3">
+               <!-- Row 28: Procrustes sub-options (Scaling + Rot/Trans) -->
+               <item row="28" column="0" colspan="3">
                 <widget class="QWidget" name="procrustes_sub_widget" native="true">
                  <layout class="QHBoxLayout" name="procrustes_sub_layout">
                   <property name="leftMargin">
@@ -828,15 +910,15 @@ QWidget#optimize_panel {
                 </widget>
                </item>
                <!-- Divider: after Procrustes group -->
-               <item row="27" column="0" colspan="4">
+               <item row="29" column="0" colspan="4">
                 <widget class="Line" name="line_opt_3">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
                  </property>
                 </widget>
                </item>
-               <!-- Row 28: Sampling Scale (combined checkbox + multiplier) -->
-               <item row="28" column="0">
+               <!-- Row 30: Sampling Scale (combined checkbox + multiplier) -->
+               <item row="30" column="0">
                 <widget class="QCheckBox" name="sampling_scale">
                  <property name="text">
                   <string>Sampling Scale</string>
@@ -846,7 +928,7 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-               <item row="28" column="1">
+               <item row="30" column="1">
                 <widget class="QLabel" name="sampling_scale_label">
                  <property name="text">
                   <string>Multiplier:</string>
@@ -856,7 +938,7 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-              <item row="28" column="2">
+              <item row="30" column="2">
                 <widget class="QLineEdit" name="sampling_scale_value">
                  <property name="text">
                   <string>1.0</string>
@@ -878,8 +960,8 @@ QWidget#optimize_panel {
                  </property>
                 </widget>
                </item>
-               <!-- Row 29: Auto Scale (sub-checkbox) -->
-               <item row="29" column="0" colspan="3">
+               <!-- Row 31: Auto Scale (sub-checkbox) -->
+               <item row="31" column="0" colspan="3">
                 <widget class="QWidget" name="sampling_auto_scale_sub_widget" native="true">
                  <layout class="QHBoxLayout" name="sampling_auto_scale_sub_layout">
                   <property name="leftMargin">
@@ -920,8 +1002,8 @@ QWidget#optimize_panel {
                  </layout>
                 </widget>
                </item>
-               <!-- Row 30: Disentangled SSM (checkbox only, hidden) -->
-               <item row="30" column="0">
+               <!-- Row 32: Disentangled SSM (checkbox only, hidden) -->
+               <item row="32" column="0">
                 <widget class="QCheckBox" name="use_disentangled_ssm">
                  <property name="text">
                   <string>Disentangled SSM</string>
@@ -1033,6 +1115,9 @@ QWidget#optimize_panel {
   <tabstop>multiscale</tabstop>
   <tabstop>multiscale_particles</tabstop>
   <tabstop>use_landmarks</tabstop>
+  <tabstop>registration_initialization</tabstop>
+  <tabstop>registration_transform_type</tabstop>
+  <tabstop>registration_band</tabstop>
   <tabstop>narrow_band</tabstop>
   <tabstop>sampling_scale</tabstop>
   <tabstop>sampling_scale_value</tabstop>

--- a/Studio/Optimize/QOptimize.h
+++ b/Studio/Optimize/QOptimize.h
@@ -31,6 +31,10 @@ class QOptimize : public QObject, public Optimize {
   virtual void SetIterationCallback() override;
   void IterateCallbackInternal();
 
+  //! Registration based initialization runs no optimizer iterations, so reuse the per-iteration
+  //! refresh to redraw particles and flush the status during the transfer phase.
+  void RefreshDuringTransfer() override { IterateCallbackInternal(); }
+
  Q_SIGNALS:
   void progress(int, QString);
 

--- a/Testing/ImageTests/ImageTests.cpp
+++ b/Testing/ImageTests/ImageTests.cpp
@@ -1,4 +1,7 @@
+#include <fstream>
+
 #include "Image.h"
+#include "ImageRegistration.h"
 #include "ImageUtils.h"
 #include "Mesh.h"
 #include "Testing.h"
@@ -1169,4 +1172,86 @@ TEST(ImageTests, evaluateTest) {
   EXPECT_TRUE(epsEqual(image.evaluate(pt3), -1.236827493, 1e-6));
   EXPECT_TRUE(epsEqual(image.evaluate(pt4), -50.785587311, 1e-6));
   EXPECT_TRUE(epsEqual(image.evaluate(pt5), -69.377281189, 1e-6));
+}
+
+//---------------------------------------------------------------------------
+// Registration tests
+//---------------------------------------------------------------------------
+
+/// read a .particles file (three whitespace separated coordinates per line)
+static std::vector<Point3> read_particles(const std::string& filename) {
+  std::ifstream in(filename);
+  std::vector<Point3> points;
+  double x, y, z;
+  while (in >> x >> y >> z) {
+    points.push_back(Point3({x, y, z}));
+  }
+  return points;
+}
+
+/// mean absolute distance transform value at the given points, i.e. how far they sit off the surface
+static double mean_surface_distance(Image& dt, const std::vector<Point3>& points) {
+  double total = 0.0;
+  for (auto point : points) {
+    total += std::abs(dt.evaluate(point));
+  }
+  return total / points.size();
+}
+
+TEST(ImageTests, registrationClampTest) {
+  Image dt(std::string(TEST_DATA_DIR) + "/ellipsoid_00.DT.nrrd");
+  auto clamped = ImageRegistration::make_registration_image(dt, 5.0);
+
+  // the band maps to [0,1], with the surface landing at the midpoint
+  ASSERT_GE(clamped.min(), 0.0f);
+  ASSERT_LE(clamped.max(), 1.0f);
+  ASSERT_TRUE(epsEqual(clamped.evaluate(Point({0.0, 0.0, 0.0})), 1.0f, 1e-4));  // deep inside
+}
+
+TEST(ImageTests, registrationTranslationTest) {
+  Image fixed_dt(std::string(TEST_DATA_DIR) + "/ellipsoid_00.DT.nrrd");
+  const Vector3 offset({3.0, -2.0, 4.0});
+
+  Image moving_dt(fixed_dt);
+  moving_dt.translate(offset);
+
+  ImageRegistration registration;
+  registration.set_transform_type(ImageRegistration::TransformType::Rigid);
+  registration.run(ImageRegistration::make_registration_image(fixed_dt),
+                   ImageRegistration::make_registration_image(moving_dt));
+
+  // the transform maps fixed space to moving space, so it must reproduce the known offset
+  const std::vector<Point3> points = {Point3({0.0, 0.0, 0.0}), Point3({10.0, 5.0, -15.0}),
+                                      Point3({-8.0, -6.0, 12.0})};
+  auto transformed = registration.transform_points(points);
+
+  for (size_t i = 0; i < points.size(); i++) {
+    for (unsigned int d = 0; d < 3; d++) {
+      ASSERT_NEAR(transformed[i][d], points[i][d] + offset[d], 0.5);
+    }
+  }
+}
+
+TEST(ImageTests, registrationParticleTransferTest) {
+  Image reference_dt(std::string(TEST_DATA_DIR) + "/ellipsoid_00.DT.nrrd");
+  Image target_dt(std::string(TEST_DATA_DIR) + "/ellipsoid_01.DT.nrrd");
+
+  auto reference_particles = read_particles(std::string(TEST_DATA_DIR) + "/ellipsoid_00.local.particles");
+  ASSERT_FALSE(reference_particles.empty());
+
+  // the reference particles lie on the reference surface, but not on the target's
+  ASSERT_LT(mean_surface_distance(reference_dt, reference_particles), 0.5);
+  const double before = mean_surface_distance(target_dt, reference_particles);
+
+  ImageRegistration registration;
+  registration.run(ImageRegistration::make_registration_image(reference_dt),
+                   ImageRegistration::make_registration_image(target_dt));
+
+  auto transferred = registration.transform_points(reference_particles);
+  ASSERT_EQ(transferred.size(), reference_particles.size());
+
+  // after transfer they should land on the target surface
+  const double after = mean_surface_distance(target_dt, transferred);
+  ASSERT_LT(after, before);
+  ASSERT_LT(after, 0.25);  // measured ~0.03, well under the 1mm voxel size
 }

--- a/Testing/ImageTests/ImageTests.cpp
+++ b/Testing/ImageTests/ImageTests.cpp
@@ -1255,3 +1255,35 @@ TEST(ImageTests, registrationParticleTransferTest) {
   ASSERT_LT(after, before);
   ASSERT_LT(after, 0.25);  // measured ~0.03, well under the 1mm voxel size
 }
+
+TEST(ImageTests, registrationTransformCacheTest) {
+  Image reference_dt(std::string(TEST_DATA_DIR) + "/ellipsoid_00.DT.nrrd");
+  Image target_dt(std::string(TEST_DATA_DIR) + "/ellipsoid_01.DT.nrrd");
+
+  auto reference_particles = read_particles(std::string(TEST_DATA_DIR) + "/ellipsoid_00.local.particles");
+
+  ImageRegistration registration;
+  registration.run(ImageRegistration::make_registration_image(reference_dt),
+                   ImageRegistration::make_registration_image(target_dt));
+  auto expected = registration.transform_points(reference_particles);
+
+  const std::string cache = std::string(TEST_DATA_DIR) + "/registration_cache_test.tfm";
+  registration.save_transform(cache);
+
+  // a saved transform must stand in for the registration exactly
+  ImageRegistration restored;
+  ASSERT_TRUE(restored.load_transform(cache));
+  auto actual = restored.transform_points(reference_particles);
+
+  ASSERT_EQ(actual.size(), expected.size());
+  for (size_t i = 0; i < actual.size(); i++) {
+    ASSERT_LT(actual[i].EuclideanDistanceTo(expected[i]), 1e-4);
+  }
+
+  // reading something that is not a transform is a miss, not a crash
+  ImageRegistration missing;
+  ASSERT_FALSE(missing.load_transform(std::string(TEST_DATA_DIR) + "/does_not_exist.tfm"));
+
+  std::remove(cache.c_str());
+  std::remove((cache + ".field.nrrd").c_str());
+}

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -1043,8 +1043,17 @@ TEST(OptimizeTests, registration_initialization_parameters) {
     Optimize app;
     OptimizeParameters params(project);
     ASSERT_EQ(params.get_initialization_mode(), "split");
+    ASSERT_EQ(params.get_registration_grid_size(), 128);  // default preserved
     ASSERT_TRUE(params.set_up_optimize(&app));
     ASSERT_EQ(app.GetInitializationMode(), Optimize::InitializationMode::Split);
+  }
+
+  // the grid size round-trips through the project
+  {
+    OptimizeParameters params(project);
+    params.set_registration_grid_size(96);
+    ASSERT_EQ(params.get_registration_grid_size(), 96);
+    params.set_registration_grid_size(128);  // restore for the checks below
   }
 
   // asking for registration in the project turns it on for the optimizer

--- a/Testing/OptimizeTests/OptimizeTests.cpp
+++ b/Testing/OptimizeTests/OptimizeTests.cpp
@@ -13,6 +13,7 @@
 #include "Optimize.h"
 #include "OptimizeParameterFile.h"
 #include "ParticleShapeStatistics.h"
+#include "StringUtils.h"
 
 using namespace shapeworks;
 
@@ -979,4 +980,126 @@ TEST(OptimizeTests, vtk_output) {
   // Otherwise it is quite large (>4000).
   double value = values[values.size() - 1];
   ASSERT_LT(value, 100);
+}
+
+//---------------------------------------------------------------------------
+TEST(OptimizeTests, registration_initialization) {
+  const std::vector<std::string> shapes = {"ellipsoid_00.DT.nrrd", "ellipsoid_01.DT.nrrd", "ellipsoid_02.DT.nrrd"};
+  const int num_particles = 32;
+
+  std::vector<std::string> paths;
+  for (const auto& shape : shapes) {
+    paths.push_back(std::string(TEST_DATA_DIR) + "/" + shape);
+  }
+
+  Optimize app;
+  app.SetDomainsPerShape(1);
+  app.SetNumberOfParticles({num_particles});
+  app.SetOptimizationIterations(50);
+  app.SetIterationsPerSplit(50);
+  app.SetFileOutputEnabled(false);
+  app.SetInitializationMode(Optimize::InitializationMode::Registration);
+
+  for (const auto& path : paths) {
+    app.AddImage(Image(path).getITKImage(), StringUtils::getFilename(path));
+  }
+  app.SetDomainPaths(paths);
+
+  ASSERT_TRUE(app.Run());
+
+  // a reference must have been chosen from the shapes provided
+  const int reference = app.GetRegistrationReference();
+  ASSERT_GE(reference, 0);
+  ASSERT_LT(reference, static_cast<int>(shapes.size()));
+
+  // every shape must end up with the full, matching set of particles
+  auto* system = app.GetSampler()->GetParticleSystem();
+  ASSERT_EQ(system->GetNumberOfDomains(), shapes.size());
+  for (unsigned int domain = 0; domain < system->GetNumberOfDomains(); domain++) {
+    ASSERT_EQ(system->GetNumberOfParticles(domain), num_particles);
+  }
+
+  // and those particles must lie on their own shape's surface
+  for (unsigned int domain = 0; domain < shapes.size(); domain++) {
+    Image dt(paths[domain]);
+    double worst = 0.0;
+    for (auto k = 0; k < system->GetNumberOfParticles(domain); k++) {
+      auto position = system->GetPosition(k, domain);
+      worst = std::max(worst, std::abs(static_cast<double>(dt.evaluate(Point({position[0], position[1], position[2]})))));
+    }
+    ASSERT_LT(worst, 1.0) << "domain " << domain << " has particles off its surface";
+  }
+}
+
+//---------------------------------------------------------------------------
+TEST(OptimizeTests, registration_initialization_parameters) {
+  prep_temp("/optimize/sphere", "registration_initialization_parameters");
+
+  ProjectHandle project = std::make_shared<Project>();
+  ASSERT_TRUE(project->load("optimize.swproj"));
+
+  // the historical behavior stays the default
+  {
+    Optimize app;
+    OptimizeParameters params(project);
+    ASSERT_EQ(params.get_initialization_mode(), "split");
+    ASSERT_TRUE(params.set_up_optimize(&app));
+    ASSERT_EQ(app.GetInitializationMode(), Optimize::InitializationMode::Split);
+  }
+
+  // asking for registration in the project turns it on for the optimizer
+  {
+    Optimize app;
+    OptimizeParameters params(project);
+    params.set_initialization_mode("registration");
+    params.set_registration_transform_type("Affine");
+    params.set_registration_band(7.5);
+    ASSERT_TRUE(params.set_up_optimize(&app));
+    ASSERT_EQ(app.GetInitializationMode(), Optimize::InitializationMode::Registration);
+  }
+
+  // registration supplies the initial particles, so it cannot be combined with landmarks
+  {
+    Optimize app;
+    OptimizeParameters params(project);
+    params.set_initialization_mode("registration");
+    params.set_use_landmarks(true);
+    ASSERT_THROW(params.set_up_optimize(&app), std::invalid_argument);
+  }
+
+  // an unrecognized mode is rejected rather than silently falling back
+  {
+    Optimize app;
+    OptimizeParameters params(project);
+    params.set_initialization_mode("nonsense");
+    ASSERT_THROW(params.set_up_optimize(&app), std::invalid_argument);
+  }
+}
+
+//---------------------------------------------------------------------------
+// A single shape is its own registration reference, so no particles are ever transferred.  The
+// correspondence matrices are suspended while particles are spread over the reference, and nothing
+// else would size them afterwards, so this used to index out of bounds (see ResyncObservers).
+TEST(OptimizeTests, registration_initialization_single_shape) {
+  const std::string path = std::string(TEST_DATA_DIR) + "/ellipsoid_00.DT.nrrd";
+  const int num_particles = 16;
+
+  Optimize app;
+  app.SetDomainsPerShape(1);
+  app.SetNumberOfParticles({num_particles});
+  app.SetOptimizationIterations(10);
+  app.SetIterationsPerSplit(10);
+  app.SetFileOutputEnabled(false);
+  app.SetInitializationMode(Optimize::InitializationMode::Registration);
+  app.AddImage(Image(path).getITKImage(), StringUtils::getFilename(path));
+  app.SetDomainPaths({path});
+
+  ASSERT_TRUE(app.Run());
+
+  auto* system = app.GetSampler()->GetParticleSystem();
+  ASSERT_EQ(system->GetNumberOfDomains(), 1);
+  ASSERT_EQ(system->GetNumberOfParticles(0), num_particles);
+
+  // the single shape is the reference, so it must be the one chosen
+  ASSERT_EQ(app.GetRegistrationReference(), 0);
 }

--- a/docs/tools/ShapeWorksCommands.md
+++ b/docs/tools/ShapeWorksCommands.md
@@ -992,6 +992,50 @@ shapeworks  tp-levelset [args]...
 <a href="#top">Back to Top</a>
   
 [Back to Image Commands](#image-commands)
+### transfer-particles
+
+
+**Usage:**
+
+```
+shapeworks  transfer-particles [args]...
+```  
+
+
+**Description:** transfers a particle set from the current image, used as the registration reference, onto a target image by deformably registering the two  
+
+
+**Options:**
+
+**-h, --help:** show this help message and exit
+
+**--target=STRING:** Distance transform of the target image.
+
+**--particles=STRING:** Particle file holding the reference particles.
+
+**--output=STRING:** Particle file to write the transferred particles to.
+
+**--transform=STRING:** Registration stages to run: Rigid, Affine or SyN [default: SyN].
+
+**--band=DOUBLE:** Half-width of the distance transform band retained for registration [default: 5].
+
+**--gradstep=DOUBLE:** SyN gradient step size [default: 0.25].
+
+**--flowsigma=DOUBLE:** Variance for smoothing the SyN update field [default: 3].
+
+**--totalsigma=DOUBLE:** Variance for smoothing the SyN total field [default: 0].
+
+**--warped=STRING:** Optional path to write the warped target image for inspection.  
+
+**Example:** transfer the particles of a reference shape onto a target shape
+
+```
+shapeworks read-image --name ref_dt.nrrd transfer-particles --target target_dt.nrrd --particles ref.particles --output target.particles
+```  
+  
+<a href="#top">Back to Top</a>
+  
+[Back to Image Commands](#image-commands)
 ### translate-image
 
 

--- a/docs/workflow/optimize.md
+++ b/docs/workflow/optimize.md
@@ -109,6 +109,14 @@ deformable stage with a starting point it cannot recover from. Transferred parti
 projected back onto the target surface, and the optimization step then refines both their spacing and
 their correspondence as usual.
 
+**Reusing registrations between runs.** A registration depends only on the pair of shapes and the
+registration settings, never on the particle count, iteration counts or weightings. Computed
+transforms are therefore cached in a `registration_cache` directory beside the project, so that the
+optimization parameters can be changed and the model rebuilt without paying for the registrations a
+second time. Regrooming an input invalidates its entries automatically. Set the `registration_cache`
+parameter to `false` to turn this off. The cache holds a displacement field per pair of shapes, on the
+order of tens of megabytes each, so delete the directory when finished with a cohort.
+
 Notes and limitations:
 
 - It cannot be combined with fixed subjects or with landmark initial particles, since those also

--- a/docs/workflow/optimize.md
+++ b/docs/workflow/optimize.md
@@ -64,6 +64,63 @@ For both, the initialization and optimization steps, the weighting to the shape 
 **The first particle:** The particle system is initialized with a single particle on each shape. The first particle is found by raster-scanning the signed distance map and finding the first zero crossing. The particle system can also be initialized using user-defined sparse corresponding landmarks across all shapes.
 
 
+### Registration Based Initialization
+
+The splitting scheme described above spreads and optimizes particles on every shape at once. As an
+alternative, particles can be spread over a **single reference shape** and then carried onto every
+other shape by deformably registering the reference to it. Each shape then starts the optimization
+already holding a full set of corresponding particles, so no splitting is needed.
+
+**This is not a general replacement for splitting.** It exists for anatomy complex enough that
+splitting fails to converge to a usable correspondence — highly convoluted surfaces, or shapes with
+many separate lobes or appendages. Registering one shape to another costs far more than splitting
+does, so on anatomy where splitting already works, this is slower with nothing to show for it. Reach
+for it when a split-based model comes out poorly, not by default.
+
+In Studio, tick **Registration Initialization** in the Optimize panel. Outside Studio, set
+`initialization_mode` to `registration` in the project file's `optimize` parameters, alongside
+`number_of_particles` and the rest:
+
+```
+"optimize": {
+    "number_of_particles": "128",
+    "initialization_mode": "registration",
+    ...
+}
+```
+
+or from Python:
+
+```python
+params = project.get_parameters("optimize")
+params.set("initialization_mode", "registration")
+project.set_parameters("optimize", params)
+```
+
+The reference shape is chosen automatically. If grooming already picked an alignment reference, that
+choice is reused; otherwise the most representative shape (the medoid of the cohort) is found. To
+pick one yourself, set `initialization_reference` to its subject index.
+
+Registration runs the same sequence of stages as the ANTs `SyNRA` pipeline — rigid, then affine, then
+symmetric normalization (SyN) — over distance transforms of the two shapes, using the same
+multi-resolution schedule ANTs does. The linear stages deliberately run far longer and start coarser
+than the deformable one: their coarse levels are cheap, and an unconverged linear stage leaves the
+deformable stage with a starting point it cannot recover from. Transferred particles are
+projected back onto the target surface, and the optimization step then refines both their spacing and
+their correspondence as usual.
+
+Notes and limitations:
+
+- It cannot be combined with fixed subjects or with landmark initial particles, since those also
+  supply the initial correspondence. Contour domains are not supported.
+- Multiscale optimization does not apply, because every shape starts at the final particle count.
+- Every shape inherits the reference's particle layout. For cohorts with large shape variation this
+  can produce a worse model than splitting; compare compactness and generalization before adopting it.
+- Registration dominates the run time, taking far longer than splitting the same cohort would.  The
+  cost scales with the number of shapes and the size of the images, not with the particle count.
+- ShapeWorks reports how far the transferred particles landed from each target surface, and warns when
+  a registration looks like it failed. Very small or very coarsely sampled inputs are the usual cause.
+
 
 ## On Algorithmic Parameters
 

--- a/docs/workflow/optimize.md
+++ b/docs/workflow/optimize.md
@@ -129,6 +129,16 @@ Notes and limitations:
 - ShapeWorks reports how far the transferred particles landed from each target surface, and warns when
   a registration looks like it failed. Very small or very coarsely sampled inputs are the usual cause.
 
+**Tuning speed vs. detail (mesh inputs).** A mesh is rasterized to a distance transform before
+registering; `registration_grid_size` sets that resolution, in voxels across the largest dimension
+(default 128). Lowering it (e.g. 96 or 64) is markedly faster and coarser — useful for a quick pass
+or a large cohort — while raising it is finer at cubic cost in both time and the size of each cached
+transform. In practice 128 is a good default and gains above ~192 are small; this only affects mesh
+inputs, since image (distance-transform) inputs already have a resolution. The `registration_band`
+(the width of the surface collar the similarity metric sees) is scaled automatically from the shape
+size and does not shrink as the grid is raised; set it explicitly only to widen the context for
+cohorts whose shapes differ substantially.
+
 
 ## On Algorithmic Parameters
 


### PR DESCRIPTION
* #2374 

Resolves #2374 

Alternative to particle splitting: spread particles over a single reference shape, then carry them onto every other shape by deformably registering the reference to it (ANTs SyNRA stages: rigid -> affine -> SyN  over distance transforms). Each shape starts optimization already holding a full set of corresponding particles.
