### PR TITLE
Fix mesh warp failure on patches joined to the surface at a single vertex

### DIFF
--- a/Libs/Mesh/MeshUtils.cpp
+++ b/Libs/Mesh/MeshUtils.cpp
@@ -37,6 +37,7 @@
 #include <igl/AABB.h>
 #include <igl/remove_unreferenced.h>
 
+#include <numeric>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -1164,6 +1165,114 @@ vtkSmartPointer<vtkPolyData> MeshUtils::recreate_mesh(vtkSmartPointer<vtkPolyDat
 }
 
 //---------------------------------------------------------------------------
+vtkSmartPointer<vtkPolyData> MeshUtils::extract_largest_edge_connected_component(vtkSmartPointer<vtkPolyData> mesh) {
+  const vtkIdType num_cells = mesh->GetNumberOfCells();
+  if (num_cells == 0) {
+    return mesh;
+  }
+
+  // Group the faces with a union-find, joining any two that share an edge.
+  std::vector<vtkIdType> parent(num_cells);
+  std::iota(parent.begin(), parent.end(), 0);
+
+  auto find = [&parent](vtkIdType cell) {
+    while (parent[cell] != cell) {
+      parent[cell] = parent[parent[cell]];
+      cell = parent[cell];
+    }
+    return cell;
+  };
+
+  // The first face to claim an edge owns it; every later face sharing that edge joins its group.
+  // Hashed rather than ordered: repair_mesh runs this over every mesh in a project, and the meshes
+  // can carry hundreds of thousands of faces.
+  struct EdgeHash {
+    size_t operator()(const std::pair<vtkIdType, vtkIdType>& edge) const {
+      const size_t first = std::hash<vtkIdType>{}(edge.first);
+      const size_t second = std::hash<vtkIdType>{}(edge.second);
+      return first ^ (second + 0x9e3779b9 + (first << 6) + (first >> 2));
+    }
+  };
+  std::unordered_map<std::pair<vtkIdType, vtkIdType>, vtkIdType, EdgeHash> edge_owner;
+  edge_owner.reserve(num_cells * 3);
+  auto cell_points = vtkSmartPointer<vtkIdList>::New();
+
+  for (vtkIdType cell_id = 0; cell_id < num_cells; cell_id++) {
+    mesh->GetCellPoints(cell_id, cell_points);
+    const vtkIdType num_points = cell_points->GetNumberOfIds();
+    for (vtkIdType i = 0; i < num_points; i++) {
+      const vtkIdType a = cell_points->GetId(i);
+      const vtkIdType b = cell_points->GetId((i + 1) % num_points);
+      const auto edge = std::make_pair(std::min(a, b), std::max(a, b));
+      const auto result = edge_owner.insert({edge, cell_id});
+      if (!result.second) {
+        const vtkIdType root_a = find(result.first->second);
+        const vtkIdType root_b = find(cell_id);
+        if (root_a != root_b) {
+          parent[root_a] = root_b;
+        }
+      }
+    }
+  }
+
+  std::unordered_map<vtkIdType, vtkIdType> group_sizes;
+  for (vtkIdType cell_id = 0; cell_id < num_cells; cell_id++) {
+    group_sizes[find(cell_id)]++;
+  }
+
+  vtkIdType largest_group = 0;
+  vtkIdType largest_size = 0;
+  for (const auto& [root, size] : group_sizes) {
+    if (size > largest_size) {
+      largest_size = size;
+      largest_group = root;
+    }
+  }
+
+  if (largest_size == num_cells) {
+    // already a single piece, nothing to drop and no need to renumber
+    return mesh;
+  }
+
+  SW_DEBUG("Dropping {} of {} faces not connected by an edge to the main surface", num_cells - largest_size, num_cells);
+
+  auto result = vtkSmartPointer<vtkPolyData>::New();
+  auto points = vtkSmartPointer<vtkPoints>::New();
+  if (mesh->GetPoints()) {
+    points->SetDataType(mesh->GetPoints()->GetDataType());
+  }
+  auto polys = vtkSmartPointer<vtkCellArray>::New();
+
+  // points are copied as they are first used, which also drops any the surviving faces do not
+  // reference: an unreferenced point is an empty row in the Laplacian downstream
+  std::vector<vtkIdType> point_map(mesh->GetNumberOfPoints(), -1);
+  std::vector<vtkIdType> new_ids;
+
+  for (vtkIdType cell_id = 0; cell_id < num_cells; cell_id++) {
+    if (find(cell_id) != largest_group) {
+      continue;
+    }
+    mesh->GetCellPoints(cell_id, cell_points);
+    if (cell_points->GetNumberOfIds() < 3) {
+      continue;
+    }
+    new_ids.clear();
+    for (vtkIdType i = 0; i < cell_points->GetNumberOfIds(); i++) {
+      const vtkIdType old_id = cell_points->GetId(i);
+      if (point_map[old_id] < 0) {
+        point_map[old_id] = points->InsertNextPoint(mesh->GetPoint(old_id));
+      }
+      new_ids.push_back(point_map[old_id]);
+    }
+    polys->InsertNextCell(static_cast<int>(new_ids.size()), new_ids.data());
+  }
+
+  result->SetPoints(points);
+  result->SetPolys(polys);
+  return result;
+}
+
+//---------------------------------------------------------------------------
 vtkSmartPointer<vtkPolyData> MeshUtils::repair_mesh(vtkSmartPointer<vtkPolyData> mesh, bool extract_largest) {
   // Line-only / vertex-only polydata (e.g. contours) has no polygons to repair;
   // the triangulation and cleanup steps below would discard its cells.
@@ -1194,6 +1303,13 @@ vtkSmartPointer<vtkPolyData> MeshUtils::repair_mesh(vtkSmartPointer<vtkPolyData>
   auto recreated = MeshUtils::recreate_mesh(fixed.getVTKMesh());
 
   auto final = MeshUtils::remove_zero_area_triangles(recreated);
+
+  if (extract_largest) {
+    // Again, and only now that the mesh has stopped changing.  Removing the zero-area triangles
+    // above can strand a patch that touches the surface at a single vertex, which the connectivity
+    // filter at the top cannot see because it treats a shared corner as a connection.
+    final = MeshUtils::extract_largest_edge_connected_component(final);
+  }
 
   return final;
 }

--- a/Libs/Mesh/MeshUtils.h
+++ b/Libs/Mesh/MeshUtils.h
@@ -81,6 +81,12 @@ class MeshUtils {
   /// Recreate mesh, dropping deleted cells
   static vtkSmartPointer<vtkPolyData> recreate_mesh(vtkSmartPointer<vtkPolyData> mesh);
 
+  /// Keep only the largest group of faces joined edge-to-edge, dropping any point left unused.
+  /// vtkPolyDataConnectivityFilter joins faces that merely share a corner, so it cannot separate a
+  /// scrap that hangs off the surface by a single vertex.  Solvers that walk the mesh by its edges
+  /// -- igl::biharmonic_coordinates among them -- see such a scrap as its own component and fail.
+  static vtkSmartPointer<vtkPolyData> extract_largest_edge_connected_component(vtkSmartPointer<vtkPolyData> mesh);
+
   /// Repair mesh: triangulate, optionally extract largest component, clean, fix non-manifold, remove zero-area
   /// triangles
   static vtkSmartPointer<vtkPolyData> repair_mesh(vtkSmartPointer<vtkPolyData> mesh, bool extract_largest = true);

--- a/Libs/Mesh/MeshWarper.cpp
+++ b/Libs/Mesh/MeshWarper.cpp
@@ -105,6 +105,14 @@ bool MeshWarper::get_warp_available() { return warp_available_; }
 bool MeshWarper::check_warp_ready() {
   std::scoped_lock lock(mutex);
 
+  // A warp that has already failed stays failed until a new reference mesh arrives.  build_mesh()
+  // reads warp_available_ before taking this lock, so every mesh that queued up behind a long
+  // generation is already past that test: without this each one would repeat the same failing
+  // generation, once per shape, with the GUI blocked behind them the whole time.
+  if (!warp_available_) {
+    return false;
+  }
+
   if (!needs_warp_) {
     // warp already done
     return true;

--- a/Testing/MeshTests/MeshTests.cpp
+++ b/Testing/MeshTests/MeshTests.cpp
@@ -1096,6 +1096,58 @@ TEST(MeshTests, extractLargestComponentTest) {
   ASSERT_TRUE(multi_component == baseline);
 }
 
+TEST(MeshTests, extractLargestEdgeConnectedComponentTest) {
+  // Two triangles meeting at a single shared vertex.  They are one component to anything that
+  // walks the mesh by its points, but two to anything that walks it by its edges, which is what
+  // igl::biharmonic_coordinates does.
+  auto points = vtkSmartPointer<vtkPoints>::New();
+  points->InsertNextPoint(0, 0, 0);  // 0: the shared corner
+  points->InsertNextPoint(1, 0, 0);  // 1
+  points->InsertNextPoint(0, 1, 0);  // 2  -- big triangle: 0,1,2
+  points->InsertNextPoint(-1, 0, 0);
+  points->InsertNextPoint(0, -1, 0);  // scrap triangle: 0,3,4
+
+  auto polys = vtkSmartPointer<vtkCellArray>::New();
+  vtkIdType big[3] = {0, 1, 2};
+  vtkIdType scrap[3] = {0, 3, 4};
+  polys->InsertNextCell(3, big);
+  polys->InsertNextCell(3, scrap);
+
+  auto mesh = vtkSmartPointer<vtkPolyData>::New();
+  mesh->SetPoints(points);
+  mesh->SetPolys(polys);
+
+  auto result = MeshUtils::extract_largest_edge_connected_component(mesh);
+
+  // the scrap goes, and so do the two points only it referenced
+  ASSERT_EQ(result->GetNumberOfCells(), 1);
+  ASSERT_EQ(result->GetNumberOfPoints(), 3);
+}
+
+TEST(MeshTests, extractLargestEdgeConnectedComponentSingleComponentTest) {
+  // Two triangles sharing a whole edge are a single component and must come back untouched
+  auto points = vtkSmartPointer<vtkPoints>::New();
+  points->InsertNextPoint(0, 0, 0);
+  points->InsertNextPoint(1, 0, 0);
+  points->InsertNextPoint(0, 1, 0);
+  points->InsertNextPoint(1, 1, 0);
+
+  auto polys = vtkSmartPointer<vtkCellArray>::New();
+  vtkIdType lower[3] = {0, 1, 2};
+  vtkIdType upper[3] = {1, 3, 2};  // shares edge 1-2
+  polys->InsertNextCell(3, lower);
+  polys->InsertNextCell(3, upper);
+
+  auto mesh = vtkSmartPointer<vtkPolyData>::New();
+  mesh->SetPoints(points);
+  mesh->SetPolys(polys);
+
+  auto result = MeshUtils::extract_largest_edge_connected_component(mesh);
+
+  ASSERT_EQ(result->GetNumberOfPoints(), 4);
+  ASSERT_EQ(result->GetNumberOfCells(), 2);
+}
+
 TEST(MeshTests, extractLargestComponentSingleComponentTest) {
   // Test that extracting from a mesh with only one component preserves count
   Mesh femur(std::string(TEST_DATA_DIR) + "/femur.vtk");


### PR DESCRIPTION
Fixes #2619

`repair_mesh` extracted the largest component using point connectivity and did so before `remove_zero_area_triangles`, so patches joined to the surface at a single vertex survived and `igl::biharmonic_coordinates` failed on them. Adds an edge-connected extraction at the end of `repair_mesh`, and stops an already-failed warp being regenerated once per queued mesh.

Two new MeshTests cases. Mesh, Groom, Optimize, Image, Particles and Project suites pass.
