### PR TITLE
Fail DeepSSM jobs instead of reporting success

### DIFF
--- a/Applications/shapeworks/Commands.cpp
+++ b/Applications/shapeworks/Commands.cpp
@@ -616,7 +616,7 @@ bool DeepSSMCommand::execute(const optparse::Values& options, SharedCommandData&
         return false;
       }
     }
-    return true;
+    return !job->is_failed();
   };
 
   if (do_prep) {

--- a/Libs/Application/DeepSSM/DeepSSMJob.cpp
+++ b/Libs/Application/DeepSSM/DeepSSMJob.cpp
@@ -48,6 +48,7 @@ void DeepSSMJob::run() {
     }
   } catch (const std::exception& e) {
     SW_ERROR("Exception Caught: {}", e.what());
+    set_failed();
   }
 }
 

--- a/Libs/Application/Job/Job.cpp
+++ b/Libs/Application/Job/Job.cpp
@@ -21,6 +21,12 @@ QString Job::get_abort_message() {
 }
 
 //---------------------------------------------------------------------------
+QString Job::get_failure_message() {
+  QString duration = QString::number(timer_.elapsed() / 1000.0, 'f', 1);
+  return name() + " failed.  Duration: " + duration + " seconds";
+}
+
+//---------------------------------------------------------------------------
 void Job::execute() {
   TIME_SCOPE(name());
   run();

--- a/Libs/Application/Job/Job.h
+++ b/Libs/Application/Job/Job.h
@@ -27,6 +27,9 @@ class Job : public QObject {
   //! get a message to display when the job is aborted
   virtual QString get_abort_message();
 
+  //! get a message to display when the job has failed
+  virtual QString get_failure_message();
+
   //! start the timer
   void start_timer();
 
@@ -45,6 +48,12 @@ class Job : public QObject {
   //! was the job aborted?
   bool is_aborted() const { return abort_; }
 
+  //! mark the job as failed (the error itself should be logged by the caller)
+  void set_failed() { failed_ = true; }
+
+  //! did the job fail?
+  bool is_failed() const { return failed_; }
+
   //! set to quiet mode (no progress messages)
   void set_quiet_mode(bool quiet) { quiet_mode_ = quiet; }
 
@@ -61,6 +70,7 @@ class Job : public QObject {
  private:
   std::atomic<bool> complete_ = false;
   std::atomic<bool> abort_ = false;
+  std::atomic<bool> failed_ = false;
   std::atomic<bool> quiet_mode_ = false;
 
   QElapsedTimer timer_;

--- a/Libs/Application/Job/PythonWorker.cpp
+++ b/Libs/Application/Job/PythonWorker.cpp
@@ -99,6 +99,7 @@ void PythonWorker::set_cli_mode(bool cli_mode) { python_logger_->set_cli_mode(cl
 //---------------------------------------------------------------------------
 void PythonWorker::start_job(QSharedPointer<Job> job) {
   if (init()) {
+    current_job_ = job;
     try {
       // Invalidate import caches in case packages were installed since init()
       // (e.g. PyTorch on-demand install)
@@ -109,14 +110,21 @@ void PythonWorker::start_job(QSharedPointer<Job> job) {
         SW_LOG("Running Task: " + job->name().toStdString());
       }
       Q_EMIT job->progress(0);
-      current_job_ = job;
-      current_job_->execute();
-      current_job_->set_complete(true);
-      if (!job->get_quiet_mode()) {
-        SW_LOG(current_job_->get_completion_message().toStdString());
-      }
+      job->execute();
     } catch (py::error_already_set& e) {
       SW_ERROR("{}", e.what());
+      job->set_failed();
+    }
+    // mark complete even on failure, otherwise anything waiting on the job waits forever
+    job->set_complete(true);
+    if (!job->get_quiet_mode()) {
+      if (job->is_failed()) {
+        SW_LOG(job->get_failure_message().toStdString());
+      } else if (job->is_aborted()) {
+        SW_LOG(job->get_abort_message().toStdString());
+      } else {
+        SW_LOG(job->get_completion_message().toStdString());
+      }
     }
   }
 

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/__init__.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/__init__.py
@@ -191,10 +191,10 @@ def get_image_registration_transform(
 
 def testPytorch() -> None:
     """Check if PyTorch is using GPU and print a warning if not."""
-    # net_utils.gpu_available() explains itself when a GPU is present but unusable
+    # gpu_available() raises if a GPU is present but cannot run this PyTorch build
     if net_utils.gpu_available():
         print("Running on GPU.")
-    elif not torch.cuda.is_available():
+    else:
         print("********************* WARNING ****************************")
         print("Pytorch is running on your CPU!")
         print("This will be very slow. If your machine has a GPU,")

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/__init__.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/__init__.py
@@ -191,12 +191,13 @@ def get_image_registration_transform(
 
 def testPytorch() -> None:
     """Check if PyTorch is using GPU and print a warning if not."""
-    if torch.cuda.is_available():
+    # net_utils.gpu_available() explains itself when a GPU is present but unusable
+    if net_utils.gpu_available():
         print("Running on GPU.")
-    else:
+    elif not torch.cuda.is_available():
         print("********************* WARNING ****************************")
         print("Pytorch is running on your CPU!")
         print("This will be very slow. If your machine has a GPU,")
-        print("please reinstall Pytorch to your shapeworks conda ")
-        print("environment with the correct CUDA version.")
+        print("please install a PyTorch build with the correct CUDA version:")
+        print("  swpip install torch --index-url https://download.pytorch.org/whl/cu128")
         print("**********************************************************")

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/loaders.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/loaders.py
@@ -10,6 +10,7 @@ from torch.utils.data import DataLoader, Dataset
 import shapeworks as sw
 from shapeworks.utils import sw_message
 from DeepSSMUtils import constants as C
+from DeepSSMUtils import net_utils
 random.seed(1)
 
 # Use streaming data loading to avoid loading all images into memory
@@ -53,7 +54,7 @@ def load_data_loader(loader_path, loader_type='train'):
 				batch_size=data.get('batch_size', 1),
 				shuffle=True,
 				num_workers=data.get('num_workers', 0),
-				pin_memory=torch.cuda.is_available()
+				pin_memory=net_utils.gpu_available()
 			)
 		else:
 			# Validation or test
@@ -70,7 +71,7 @@ def load_data_loader(loader_path, loader_type='train'):
 				batch_size=1,
 				shuffle=False,
 				num_workers=data.get('num_workers', 0),
-				pin_memory=torch.cuda.is_available()
+				pin_memory=net_utils.gpu_available()
 			)
 	else:
 		# Legacy format - data is already a DataLoader
@@ -128,7 +129,7 @@ def get_train_val_loaders(loader_dir, data_csv, batch_size=1, down_factor=1, dow
 			batch_size=batch_size,
 			shuffle=True,
 			num_workers=num_workers,
-			pin_memory=torch.cuda.is_available()
+			pin_memory=net_utils.gpu_available()
 		)
 	train_path = loader_dir + C.TRAIN_LOADER
 	torch.save(trainloader, train_path)
@@ -138,7 +139,7 @@ def get_train_val_loaders(loader_dir, data_csv, batch_size=1, down_factor=1, dow
 			batch_size=1,
 			shuffle=True,
 			num_workers=num_workers,
-			pin_memory=torch.cuda.is_available()
+			pin_memory=net_utils.gpu_available()
 		)
 	val_path = loader_dir + C.VALIDATION_LOADER
 	torch.save(validationloader, val_path)
@@ -175,7 +176,7 @@ def get_train_loader(loader_dir, data_csv, batch_size=1, down_factor=1, down_dir
 			batch_size=batch_size,
 			shuffle=True,
 			num_workers=num_workers,
-			pin_memory=torch.cuda.is_available()
+			pin_memory=net_utils.gpu_available()
 		)
 
 		# Save metadata for reconstruction
@@ -204,7 +205,7 @@ def get_train_loader(loader_dir, data_csv, batch_size=1, down_factor=1, down_dir
 			batch_size=batch_size,
 			shuffle=True,
 			num_workers=num_workers,
-			pin_memory=torch.cuda.is_available()
+			pin_memory=net_utils.gpu_available()
 		)
 		train_path = loader_dir + C.TRAIN_LOADER
 		torch.save(trainloader, train_path)
@@ -260,7 +261,7 @@ def get_validation_loader(loader_dir, val_img_list, val_particles, down_factor=1
 			batch_size=1,
 			shuffle=False,
 			num_workers=num_workers,
-			pin_memory=torch.cuda.is_available()
+			pin_memory=net_utils.gpu_available()
 		)
 
 		# Save metadata
@@ -287,7 +288,7 @@ def get_validation_loader(loader_dir, val_img_list, val_particles, down_factor=1
 			batch_size=1,
 			shuffle=False,
 			num_workers=num_workers,
-			pin_memory=torch.cuda.is_available()
+			pin_memory=net_utils.gpu_available()
 		)
 		val_path = loader_dir + C.VALIDATION_LOADER
 		torch.save(val_loader, val_path)
@@ -336,7 +337,7 @@ def get_test_loader(loader_dir, test_img_list, down_factor=1, down_dir=None, num
 			batch_size=1,
 			shuffle=False,
 			num_workers=num_workers,
-			pin_memory=torch.cuda.is_available()
+			pin_memory=net_utils.gpu_available()
 		)
 
 		# Save metadata
@@ -363,7 +364,7 @@ def get_test_loader(loader_dir, test_img_list, down_factor=1, down_dir=None, num
 			batch_size=1,
 			shuffle=False,
 			num_workers=num_workers,
-			pin_memory=torch.cuda.is_available()
+			pin_memory=net_utils.gpu_available()
 		)
 		test_path = loader_dir + C.TEST_LOADER
 		torch.save(testloader, test_path)

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/model.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/model.py
@@ -1,4 +1,3 @@
-import torch
 from torch import nn
 import sys
 import json
@@ -62,11 +61,7 @@ class ConvolutionalBackbone(nn.Module):
 class DeterministicEncoder(nn.Module):
 	def __init__(self, num_latent, img_dims, loader_dir):
 		super(DeterministicEncoder, self).__init__()
-		if torch.cuda.is_available():
-			device = C.DEVICE_CUDA
-		else:
-			device = C.DEVICE_CPU
-		self.device = device
+		self.device = net_utils.get_device()
 		self.num_latent = num_latent
 		self.img_dims = img_dims
 		self.loader_dir = loader_dir
@@ -98,11 +93,7 @@ Supervised DeepSSM Model
 class DeepSSMNet(nn.Module):
 	def __init__(self, config_file):
 		super(DeepSSMNet, self).__init__()
-		if torch.cuda.is_available():
-			device = C.DEVICE_CUDA
-		else:
-			device = C.DEVICE_CPU
-		self.device = device
+		self.device = net_utils.get_device()
 		with open(config_file) as json_file:
 			parameters = json.load(json_file)
 		self.num_latent = parameters['num_latent_dim']
@@ -169,11 +160,7 @@ DeepSSM TL-Net Model
 class DeepSSMNet_TLNet(nn.Module):
 	def __init__(self, conflict_file):
 		super(DeepSSMNet_TLNet, self).__init__()
-		if torch.cuda.is_available():
-			device = C.DEVICE_CUDA
-		else:
-			device = C.DEVICE_CPU
-		self.device = device
+		self.device = net_utils.get_device()
 		with open(conflict_file) as json_file:
 			parameters = json.load(json_file)
 		self.num_latent = parameters['num_latent_dim']

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/net_utils.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/net_utils.py
@@ -2,11 +2,15 @@ import random
 import torch
 from torch import nn
 import numpy as np
-from shapeworks.utils import sw_message
 from DeepSSMUtils import constants as C
 
-# cached result of get_device(), the GPU probe only needs to run once
+# cached results of get_device(), the GPU probe only needs to run once
 _device = None
+_device_error = None
+
+
+class UnusableGPUError(RuntimeError):
+	"""Raised when a GPU is present but cannot run the installed PyTorch build."""
 
 
 def get_device() -> str:
@@ -17,23 +21,42 @@ def get_device() -> str:
 	only ship kernels for a fixed set of GPU architectures, so a card that is
 	newer or older than the installed wheel supports fails at the first kernel
 	launch with "no kernel image is available for execution on the device".
-	Probe the GPU once with a small kernel and fall back to the CPU if it fails.
+	Probe the GPU once with a small kernel so that case is reported up front
+	rather than crashing partway through a run.
 
 	Returns:
-		'cuda:0' if a GPU is present and usable, 'cpu' otherwise
+		'cuda:0' if a GPU is present and usable, 'cpu' if there is no GPU at all
+
+	Raises:
+		UnusableGPUError: if a GPU is present but cannot run this PyTorch build
 	"""
-	global _device
+	global _device, _device_error
+	if _device_error is not None:
+		raise UnusableGPUError(_device_error)
 	if _device is None:
-		_device = C.DEVICE_CUDA if _probe_gpu() else C.DEVICE_CPU
+		if not torch.cuda.is_available():
+			_device = C.DEVICE_CPU
+		else:
+			try:
+				probe = torch.zeros(8, 8, device=C.DEVICE_CUDA)
+				torch.matmul(probe, probe)
+				torch.cuda.synchronize()
+			except Exception as e:
+				_device_error = _unusable_gpu_message(e)
+				raise UnusableGPUError(_device_error) from e
+			_device = C.DEVICE_CUDA
 	return _device
 
 
 def gpu_available() -> bool:
 	"""
-	Check whether a GPU is present and able to run this PyTorch build.
+	Check whether DeepSSM will run on the GPU.
 
 	Returns:
-		True if DeepSSM will run on the GPU
+		True if a GPU is present and usable, False if there is no GPU at all
+
+	Raises:
+		UnusableGPUError: if a GPU is present but cannot run this PyTorch build
 	"""
 	return get_device() == C.DEVICE_CUDA
 
@@ -44,21 +67,7 @@ def empty_gpu_cache() -> None:
 		torch.cuda.empty_cache()
 
 
-def _probe_gpu() -> bool:
-	"""Run a small kernel on the GPU, warning and returning False if it cannot run."""
-	if not torch.cuda.is_available():
-		return False
-	try:
-		probe = torch.zeros(8, 8, device=C.DEVICE_CUDA)
-		torch.matmul(probe, probe)
-		torch.cuda.synchronize()
-		return True
-	except Exception as e:
-		_warn_gpu_unusable(e)
-		return False
-
-
-def _warn_gpu_unusable(error: Exception) -> None:
+def _unusable_gpu_message(error: Exception) -> str:
 	"""Explain why the GPU was rejected and how to install a PyTorch build that supports it."""
 	try:
 		name = torch.cuda.get_device_name(0)
@@ -68,15 +77,15 @@ def _warn_gpu_unusable(error: Exception) -> None:
 		# the device is unusable enough that even querying it fails
 		name = "unknown"
 		capability = "unknown"
-	sw_message("********************* WARNING ****************************")
-	sw_message(f"Your GPU ({name}, compute capability {capability}) cannot run this PyTorch build:")
-	sw_message(f"  {str(error).splitlines()[0]}")
-	sw_message(f"PyTorch {torch.__version__} (CUDA {torch.version.cuda}) only has kernels for: "
-	           f"{', '.join(torch.cuda.get_arch_list())}")
-	sw_message("Falling back to the CPU.  This will be very slow.")
-	sw_message("To use the GPU, install a PyTorch build that supports it, for example:")
-	sw_message("  swpip install torch --index-url https://download.pytorch.org/whl/cu128")
-	sw_message("**********************************************************")
+	return "\n".join([
+		f"Your GPU ({name}, compute capability {capability}) cannot run this PyTorch build:",
+		f"  {str(error).splitlines()[0]}",
+		f"PyTorch {torch.__version__} (CUDA {torch.version.cuda}) only has kernels for: "
+		f"{', '.join(torch.cuda.get_arch_list())}",
+		"Install a PyTorch build that supports your GPU, for example:",
+		"  swpip install torch --index-url https://download.pytorch.org/whl/cu128",
+		"See http://sciinstitute.github.io/ShapeWorks/latest/deep-learning/pytorch-gpu.html",
+	])
 
 
 def set_seed(seed: int = 42) -> None:

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/net_utils.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/net_utils.py
@@ -2,7 +2,81 @@ import random
 import torch
 from torch import nn
 import numpy as np
+from shapeworks.utils import sw_message
 from DeepSSMUtils import constants as C
+
+# cached result of get_device(), the GPU probe only needs to run once
+_device = None
+
+
+def get_device() -> str:
+	"""
+	Get the device DeepSSM should run on.
+
+	A GPU can be visible to torch and still be unable to run it: PyTorch wheels
+	only ship kernels for a fixed set of GPU architectures, so a card that is
+	newer or older than the installed wheel supports fails at the first kernel
+	launch with "no kernel image is available for execution on the device".
+	Probe the GPU once with a small kernel and fall back to the CPU if it fails.
+
+	Returns:
+		'cuda:0' if a GPU is present and usable, 'cpu' otherwise
+	"""
+	global _device
+	if _device is None:
+		_device = C.DEVICE_CUDA if _probe_gpu() else C.DEVICE_CPU
+	return _device
+
+
+def gpu_available() -> bool:
+	"""
+	Check whether a GPU is present and able to run this PyTorch build.
+
+	Returns:
+		True if DeepSSM will run on the GPU
+	"""
+	return get_device() == C.DEVICE_CUDA
+
+
+def empty_gpu_cache() -> None:
+	"""Free cached GPU memory, a no-op when not running on the GPU."""
+	if gpu_available():
+		torch.cuda.empty_cache()
+
+
+def _probe_gpu() -> bool:
+	"""Run a small kernel on the GPU, warning and returning False if it cannot run."""
+	if not torch.cuda.is_available():
+		return False
+	try:
+		probe = torch.zeros(8, 8, device=C.DEVICE_CUDA)
+		torch.matmul(probe, probe)
+		torch.cuda.synchronize()
+		return True
+	except Exception as e:
+		_warn_gpu_unusable(e)
+		return False
+
+
+def _warn_gpu_unusable(error: Exception) -> None:
+	"""Explain why the GPU was rejected and how to install a PyTorch build that supports it."""
+	try:
+		name = torch.cuda.get_device_name(0)
+		major, minor = torch.cuda.get_device_capability(0)
+		capability = f"{major}.{minor}"
+	except Exception:
+		# the device is unusable enough that even querying it fails
+		name = "unknown"
+		capability = "unknown"
+	sw_message("********************* WARNING ****************************")
+	sw_message(f"Your GPU ({name}, compute capability {capability}) cannot run this PyTorch build:")
+	sw_message(f"  {str(error).splitlines()[0]}")
+	sw_message(f"PyTorch {torch.__version__} (CUDA {torch.version.cuda}) only has kernels for: "
+	           f"{', '.join(torch.cuda.get_arch_list())}")
+	sw_message("Falling back to the CPU.  This will be very slow.")
+	sw_message("To use the GPU, install a PyTorch build that supports it, for example:")
+	sw_message("  swpip install torch --index-url https://download.pytorch.org/whl/cu128")
+	sw_message("**********************************************************")
 
 
 def set_seed(seed: int = 42) -> None:

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/trainer.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/trainer.py
@@ -177,7 +177,7 @@ def supervised_train(config_file):
             sw_message(f"Epoch {e}/{num_epochs}")
         sw_progress(e / (num_epochs + 1))
 
-        torch.cuda.empty_cache()
+        net_utils.empty_gpu_cache()
         # train
         net.train()
         train_losses = []
@@ -312,7 +312,7 @@ def supervised_train(config_file):
             sw_message(f"Fine Tuning, Epoch {e}/{ft_epochs}")
             sw_progress(e / (num_epochs + 1))
 
-            torch.cuda.empty_cache()
+            net_utils.empty_gpu_cache()
             # train
             net.train()
             train_losses = []
@@ -472,7 +472,7 @@ def supervised_train_tl(config_file):
         sw_message(f"Autoencoder Epoch {e}/{ae_epochs}")
         sw_progress(e / (ae_epochs + 1))
 
-        torch.cuda.empty_cache()
+        net_utils.empty_gpu_cache()
         # train
         net.train()
         ae_train_losses = []
@@ -580,7 +580,7 @@ def supervised_train_tl(config_file):
         sw_message(f"T-Flank Epoch {e}/{tf_epochs}")
         sw_progress(e / (tf_epochs + 1))
 
-        torch.cuda.empty_cache()
+        net_utils.empty_gpu_cache()
         # train
         net.train()
         tf_train_losses = []

--- a/Studio/DeepSSM/DeepSSMTool.cpp
+++ b/Studio/DeepSSM/DeepSSMTool.cpp
@@ -268,7 +268,8 @@ void DeepSSMTool::run_prep_clicked(int step) {
 //---------------------------------------------------------------------------
 void DeepSSMTool::handle_thread_complete() {
   try {
-    if (!deep_ssm_->is_aborted()) {
+    bool succeeded = !deep_ssm_->is_aborted() && !deep_ssm_->is_failed();
+    if (succeeded) {
       if (current_tool_ == DeepSSMJob::JobType::DeepSSM_PrepType) {
         auto params = DeepSSMParameters(session_->get_project());
         params.set_prep_stage(static_cast<int>(prep_step_));
@@ -287,7 +288,7 @@ void DeepSSMTool::handle_thread_complete() {
     update_panels();
     session_->reload_particles();
 
-    if (!deep_ssm_->is_aborted()) {
+    if (succeeded) {
       if (ui_->run_all->isChecked()) {
         if (current_tool_ == DeepSSMJob::JobType::DeepSSM_PrepType) {
           run_tool(DeepSSMJob::JobType::DeepSSM_AugmentationType);

--- a/docs/deep-learning/pytorch-gpu.md
+++ b/docs/deep-learning/pytorch-gpu.md
@@ -44,8 +44,8 @@ swpython -c "from shapeworks import ensure_torch; ensure_torch()"
 PyTorch wheels only ship kernels for a fixed set of GPU architectures, so a card
 that is newer or older than the installed wheel supports is detected by
 `torch.cuda.is_available()` but fails at the first kernel launch. ShapeWorks
-probes the GPU before using it and falls back to the CPU with a message naming
-your GPU's compute capability and the architectures the wheel supports:
+probes the GPU before using it and stops with a message naming your GPU's
+compute capability and the architectures the wheel supports:
 
 ```
 Your GPU (NVIDIA GeForce GTX 1080, compute capability 6.1) cannot run this PyTorch build:
@@ -53,9 +53,11 @@ Your GPU (NVIDIA GeForce GTX 1080, compute capability 6.1) cannot run this PyTor
 PyTorch 2.9.1 (CUDA 12.8) only has kernels for: sm_75, sm_80, sm_86, sm_90, sm_100, sm_120
 ```
 
-To use the GPU, install a build that covers your card (see below): older cards
-(Maxwell, Pascal) need an older PyTorch with a CUDA 12.6 or earlier wheel, while
-Blackwell cards (RTX 50-series) need CUDA 12.8 or newer.
+Install a build that covers your card (see below): older cards (Maxwell, Pascal)
+need an older PyTorch with a CUDA 12.6 or earlier wheel, while Blackwell cards
+(RTX 50-series) need CUDA 12.8 or newer. DeepSSM does not fall back to the CPU
+in this case — a machine with a GPU it cannot use is a setup problem worth
+fixing, not a reason to start a run that would take days.
 
 ## Reinstalling a different PyTorch version
 

--- a/docs/deep-learning/pytorch-gpu.md
+++ b/docs/deep-learning/pytorch-gpu.md
@@ -39,6 +39,24 @@ installed — kick one off and try again, or trigger the install manually:
 swpython -c "from shapeworks import ensure_torch; ensure_torch()"
 ```
 
+## "No kernel image is available for execution on the device"
+
+PyTorch wheels only ship kernels for a fixed set of GPU architectures, so a card
+that is newer or older than the installed wheel supports is detected by
+`torch.cuda.is_available()` but fails at the first kernel launch. ShapeWorks
+probes the GPU before using it and falls back to the CPU with a message naming
+your GPU's compute capability and the architectures the wheel supports:
+
+```
+Your GPU (NVIDIA GeForce GTX 1080, compute capability 6.1) cannot run this PyTorch build:
+  CUDA error: no kernel image is available for execution on the device
+PyTorch 2.9.1 (CUDA 12.8) only has kernels for: sm_75, sm_80, sm_86, sm_90, sm_100, sm_120
+```
+
+To use the GPU, install a build that covers your card (see below): older cards
+(Maxwell, Pascal) need an older PyTorch with a CUDA 12.6 or earlier wheel, while
+Blackwell cards (RTX 50-series) need CUDA 12.8 or newer.
+
 ## Reinstalling a different PyTorch version
 
 If you need a different PyTorch version than `light-the-torch` selected:


### PR DESCRIPTION
Fixes #2621

`DeepSSMJob::run()` caught exceptions and returned normally, so a failed job was still marked complete: training that died at model initialization logged "Training complete", `Run All` chained into testing (which then failed on the missing `best_model.torch`), and the CLI exited zero. `Job` now carries a failed state that `PythonWorker` reports instead of the completion message, so Studio does not advance to the next step and `shapeworks deepssm` stops and exits non-zero. `PythonWorker` also marks the job complete on failure now, which it previously did not do, leaving the CLI's wait loop spinning forever.

The underlying failure is that light-the-torch 0.8.0's driver table stops at CUDA 12.6, so it can never select a cu128 wheel — every RTX 50-series user gets a PyTorch with no `sm_120` kernels and DeepSSM cannot train at all. Bumped to 0.8.1, which knows CUDA 12.8 through 13.1. `net_utils.get_device()` now also probes the GPU with a small kernel launch and raises `UnusableGPUError` naming the device capability, the architectures the wheel supports, and whether a newer or older PyTorch is needed. It does not fall back to the CPU — that would silently turn a fixable setup problem into a run of several days. Machines with no GPU at all still run on the CPU as before.

`swpip install` now passes `--upgrade`, without which pip skips files that already exist under `--target` and reports success while leaving the old build in place — so the reinstall command in the error message and docs actually replaces PyTorch.

Both DeepSSM tests pass on CPU. The failure path was checked by forcing the unusable-GPU branch: the run stops at data loader preparation with the full message in the log, testing does not run, and the CLI exits 1.
