### PR TITLE
Remove the polyfill.io script from the docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,7 +182,6 @@ extra_css:
 
 extra_javascript:
   - assets/mathjaxhelper.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:


### PR DESCRIPTION
The `polyfill.io` domain changed hands in 2024 and now serves hostile responses to anyone still loading it. Browsers surface that as a spurious username/password dialog on our docs pages, which is what visitors have been reporting on https://sciinstitute.github.io/ShapeWorks/latest/. Nothing of ours was compromised — the behavior is entirely on their end.

The tag came from the old MkDocs-Material MathJax snippet. MathJax 3 needs no ES6 polyfill on any browser it still supports, so it is dropped rather than repointed at the Cloudflare mirror.

Removing it here only affects newly built docs — the tag is baked into every generated page — so the published HTML on `gh-pages` was swept separately (3519 files across 6.2–6.7, one identical line removed from each) and is already live.