### PR TITLE
Derive the docs version from CMakeLists.txt

### DIFF
--- a/.github/workflows/build-mac-arm64.yml
+++ b/.github/workflows/build-mac-arm64.yml
@@ -9,6 +9,17 @@ on:
     - '*'
   pull_request:
   workflow_dispatch:
+    inputs:
+      deploy_docs:
+        description: 'Deploy the docs for the selected ref (use with a release tag to rebuild a released version)'
+        type: boolean
+        required: false
+        default: false
+      docs_alias:
+        description: 'mike alias to move to this version (e.g. latest).  Leave blank for the default.'
+        type: string
+        required: false
+        default: ''
   schedule:
     - cron: '0 0 * * 0'
 
@@ -176,10 +187,12 @@ jobs:
              ${{runner.workspace}}/ShapeWorks/artifacts/*.pkg
 
     - name: Deploy Docs
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' || inputs.deploy_docs
       shell: bash -l {0}
       run: conda activate shapeworks && source ./devenv.sh ./build/bin && ./Support/deploy_docs.sh ${GITHUB_WORKSPACE}/build
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCS_REF: ${{ github.ref_name }}
+          DOCS_ALIAS: ${{ inputs.docs_alias }}
       

--- a/Examples/Python/VerifyUseCases.py
+++ b/Examples/Python/VerifyUseCases.py
@@ -67,13 +67,16 @@ async def run_command(args):
 
 
 def run_case(use_case):
-    command = f"python -u RunUseCase.py {use_case}"
+    # use sys.executable rather than "python" so the use cases run under the same
+    # interpreter as this script; PYTHONHOME is set for that interpreter and a
+    # different "python" from PATH would load a mismatched stdlib.
+    argv = [sys.executable, "-u", "RunUseCase.py"] + use_case.split()
     print(f"\n----------------------------------------------------------------")
-    print(f"* Running : {command}")
+    print(f"* Running : {' '.join(argv)}")
     print(f"----------------------------------------------------------------")
     start = time.time()
 
-    success = asyncio.run(run_command(command.split()))
+    success = asyncio.run(run_command(argv))
 
     end = time.time()
     duration = f"{end - start:6.0f} seconds"

--- a/Examples/Python/ellipsoid_fd.py
+++ b/Examples/Python/ellipsoid_fd.py
@@ -27,7 +27,7 @@ def Run_Pipeline(args):
     output_directory = "Output/ellipsoid_fd/"
     if not os.path.exists(output_directory):
         os.makedirs(output_directory)
-    sw.portal.download_dataset(dataset_name, output_directory)
+    sw.download_dataset(dataset_name, output_directory)
     dataset_name = "ellipsoid_1mode_aligned"
     file_list_segs = sorted(glob.glob(output_directory + dataset_name + "/segmentations/fd_*.nrrd"))
     file_list_dts = sorted(glob.glob(output_directory + dataset_name + "/groomed/distance_transforms/*.nrrd"))

--- a/Examples/Python/ellipsoid_multiple_domain.py
+++ b/Examples/Python/ellipsoid_multiple_domain.py
@@ -40,7 +40,9 @@ def Run_Pipeline(args):
     else:
         dataset_name = "ellipsoid_multiple_domain"
         sw.download_dataset(dataset_name, output_directory)
-        file_list = sorted(glob.glob(output_directory + "/segmentations/*.nrrd"))
+        dataset_name = "ellipsoid_joint_rotation"
+        file_list = sorted(glob.glob(output_directory +
+                                     dataset_name + "/segmentations/*.nrrd"))
 
         if args.use_subsample:
             inputImages =[sw.Image(filename) for filename in file_list]

--- a/Examples/Python/ellipsoid_multiple_domain_mesh.py
+++ b/Examples/Python/ellipsoid_multiple_domain_mesh.py
@@ -40,7 +40,9 @@ def Run_Pipeline(args):
     else:
         dataset_name = "ellipsoid_multiple_domain_mesh"
         sw.download_dataset(dataset_name, output_directory)
-        mesh_files = sorted(glob.glob(output_directory + "/meshes/*.vtk"))
+        dataset_name = "ellipsoid_joint_rotation"
+        mesh_files = sorted(glob.glob(output_directory +
+                                      dataset_name + "/meshes/*.vtk"))
 
         if args.use_subsample:
             inputMeshes = [sw.Mesh(filename) for filename in mesh_files]

--- a/Examples/Python/notebooks/tutorials/getting-started-with-data-augmentation.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-data-augmentation.ipynb
@@ -80,15 +80,36 @@
     "\n",
     "### Defining dataset location\n",
     "\n",
-    "You can download exemplar datasets from [ShapeWorks data portal](https://girder.shapeworks-cloud.org) after you login. For new users, you can [register](https://girder.shapeworks-cloud.org/#?dialog=register) an account for free. Please do not use an important password.\n",
+    "The tutorial datasets are published on the ShapeWorks data server and are downloaded directly over HTTPS. No account, login, or registration is needed.\n",
     "\n",
-    "After you login, click `Collections` on the left panel and then `use-case-data-v2`. Select the dataset you would like to download by clicking on the checkbox on the left of the dataset name. See the video below.\n",
-    "After you download the dataset zip file, make sure you unzip/extract the contents in the appropriate location.\n",
+    "The cell below downloads [`femur-v0`](https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/femur-v0.zip) (4.3 GB) into `Examples/Python/Data/` and extracts it, unless it is already there. This notebook uses the groomed images and the shape model under that folder. Feel free to use your own dataset instead.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib.request\n",
+    "import zipfile\n",
     "\n",
-    "**This notebook assumes that you have downloaded `femur-v0` and you have placed the unzipped folder `femur-v0` in `Examples/Python/Data`.** Feel free to use your own dataset. \n",
+    "datasetName = 'femur-v0'\n",
+    "dataDir = '../../Data/'\n",
+    "url = 'https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/' + datasetName + '.zip'\n",
     "\n",
+    "if not os.path.isdir(dataDir + datasetName):\n",
+    "    os.makedirs(dataDir, exist_ok=True)\n",
+    "    archive = dataDir + datasetName + '.zip'\n",
+    "    print('Downloading ' + url)\n",
+    "    urllib.request.urlretrieve(url, archive)\n",
+    "    print('Extracting to ' + dataDir)\n",
+    "    with zipfile.ZipFile(archive) as zipHandle:\n",
+    "        zipHandle.extractall(dataDir)\n",
+    "    os.remove(archive)\n",
     "\n",
-    "<p><video src=\"https://sci.utah.edu/~shapeworks/doc-resources/mp4s/portal_data_download.mp4\" autoplay muted loop controls style=\"width:100%\"></p>"
+    "print('Dataset ready: ' + dataDir + datasetName)"
    ]
   },
   {

--- a/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-exploring-segmentations.ipynb
@@ -42,15 +42,36 @@
     "\n",
     "### Defining dataset location\n",
     "\n",
-    "You can download exemplar datasets from [ShapeWorks data portal](https://girder.shapeworks-cloud.org) after you login. For new users, you can [register](https://girder.shapeworks-cloud.org/#?dialog=register) an account for free. Please do not use an important password.\n",
+    "The tutorial datasets are published on the ShapeWorks data server and are downloaded directly over HTTPS. No account, login, or registration is needed.\n",
     "\n",
-    "After you login, click `Collections` on the left panel and then `use-case-data-v2`. Select the dataset you would like to download by clicking on the checkbox on the left of the dataset name. See the video below.\n",
-    "After you download the dataset zip file, make sure you unzip/extract the contents in the appropriate location.\n",
+    "The cell below downloads [`ellipsoid_1mode`](https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/ellipsoid_1mode.zip) (85 MB) into `Examples/Python/Data/` and extracts it, unless it is already there. This notebook uses the `segmentations` folder inside it. Feel free to use your own dataset instead.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib.request\n",
+    "import zipfile\n",
     "\n",
-    "**This notebook assumes that you have downloaded `ellipsoid_1mode` and you have placed the unzipped folder `ellipsoid_1mode` in `Examples/Python/Data`.** Feel free to use your own dataset.  \n",
+    "datasetName = 'ellipsoid_1mode'\n",
+    "dataDir = '../../Data/'\n",
+    "url = 'https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/' + datasetName + '.zip'\n",
     "\n",
+    "if not os.path.isdir(dataDir + datasetName):\n",
+    "    os.makedirs(dataDir, exist_ok=True)\n",
+    "    archive = dataDir + datasetName + '.zip'\n",
+    "    print('Downloading ' + url)\n",
+    "    urllib.request.urlretrieve(url, archive)\n",
+    "    print('Extracting to ' + dataDir)\n",
+    "    with zipfile.ZipFile(archive) as zipHandle:\n",
+    "        zipHandle.extractall(dataDir)\n",
+    "    os.remove(archive)\n",
     "\n",
-    "<p><video src=\"https://sci.utah.edu/~shapeworks/doc-resources/mp4s/portal_data_download.mp4\" autoplay muted loop controls style=\"width:100%\"></p>"
+    "print('Dataset ready: ' + dataDir + datasetName)"
    ]
   },
   {

--- a/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-meshes.ipynb
@@ -50,15 +50,36 @@
     "\n",
     "### Defining dataset location\n",
     "\n",
-    "You can download exemplar datasets from [ShapeWorks data portal](https://girder.shapeworks-cloud.org) after you login. For new users, you can [register](https://girder.shapeworks-cloud.org/#?dialog=register) an account for free. Please do not use an important password.\n",
+    "The tutorial datasets are published on the ShapeWorks data server and are downloaded directly over HTTPS. No account, login, or registration is needed.\n",
     "\n",
-    "After you login, click `Collections` on the left panel and then `use-case-data-v2`. Select the dataset you would like to download by clicking on the checkbox on the left of the dataset name. See the video below.\n",
+    "The cell below downloads [`ellipsoid_1mode`](https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/ellipsoid_1mode.zip) (85 MB) into `Examples/Python/Data/` and extracts it, unless it is already there. This notebook uses the `meshes` folder inside it. Feel free to use your own dataset instead.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib.request\n",
+    "import zipfile\n",
     "\n",
-    "**This notebook assumes that you have downloaded `ellipsoid_1mode` and you have placed the unzipped folder`ellipsoid_1mode`in `Examples/Python/Data`.** Feel free to use your own dataset. \n",
+    "datasetName = 'ellipsoid_1mode'\n",
+    "dataDir = '../../Data/'\n",
+    "url = 'https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/' + datasetName + '.zip'\n",
     "\n",
+    "if not os.path.isdir(dataDir + datasetName):\n",
+    "    os.makedirs(dataDir, exist_ok=True)\n",
+    "    archive = dataDir + datasetName + '.zip'\n",
+    "    print('Downloading ' + url)\n",
+    "    urllib.request.urlretrieve(url, archive)\n",
+    "    print('Extracting to ' + dataDir)\n",
+    "    with zipfile.ZipFile(archive) as zipHandle:\n",
+    "        zipHandle.extractall(dataDir)\n",
+    "    os.remove(archive)\n",
     "\n",
-    "<p><video src=\"https://sci.utah.edu/~shapeworks/doc-resources/mp4s/portal_data_download.mp4\" autoplay muted loop controls style=\"width:100%\"></p>\n",
-    "\n"
+    "print('Dataset ready: ' + dataDir + datasetName)"
    ]
   },
   {

--- a/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
+++ b/Examples/Python/notebooks/tutorials/getting-started-with-segmentations.ipynb
@@ -43,15 +43,36 @@
     "\n",
     "### Defining dataset location\n",
     "\n",
-    "You can download exemplar datasets from [ShapeWorks data portal](https://girder.shapeworks-cloud.org) after you login. For new users, you can [register](https://girder.shapeworks-cloud.org/#?dialog=register) an account for free. Please do not use an important password.\n",
+    "The tutorial datasets are published on the ShapeWorks data server and are downloaded directly over HTTPS. No account, login, or registration is needed.\n",
     "\n",
-    "After you login, click `Collections` on the left panel and then `use-case-data-v2`. Select the dataset you would like to download by clicking on the checkbox on the left of the dataset name. See the video below.\n",
-    "After you download the dataset zip file, make sure you unzip/extract the contents in the appropriate location.\n",
+    "The cell below downloads [`ellipsoid_1mode`](https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/ellipsoid_1mode.zip) (85 MB) into `Examples/Python/Data/` and extracts it, unless it is already there. This notebook uses the `segmentations` folder inside it. Feel free to use your own dataset instead.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib.request\n",
+    "import zipfile\n",
     "\n",
-    "**This notebook assumes that you have downloaded `ellipsoid_1mode` and you have placed the unzipped folder `ellipsoid_1mode` in `Examples/Python/Data`.** Feel free to use your own dataset.  \n",
+    "datasetName = 'ellipsoid_1mode'\n",
+    "dataDir = '../../Data/'\n",
+    "url = 'https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/' + datasetName + '.zip'\n",
     "\n",
+    "if not os.path.isdir(dataDir + datasetName):\n",
+    "    os.makedirs(dataDir, exist_ok=True)\n",
+    "    archive = dataDir + datasetName + '.zip'\n",
+    "    print('Downloading ' + url)\n",
+    "    urllib.request.urlretrieve(url, archive)\n",
+    "    print('Extracting to ' + dataDir)\n",
+    "    with zipfile.ZipFile(archive) as zipHandle:\n",
+    "        zipHandle.extractall(dataDir)\n",
+    "    os.remove(archive)\n",
     "\n",
-    "<p><video src=\"https://sci.utah.edu/~shapeworks/doc-resources/mp4s/portal_data_download.mp4\" autoplay muted loop controls style=\"width:100%\"></p>\n"
+    "print('Dataset ready: ' + dataDir + datasetName)"
    ]
   },
   {

--- a/Python/DeepSSMUtilsPackage/DeepSSMUtils/trainer.py
+++ b/Python/DeepSSMUtilsPackage/DeepSSMUtils/trainer.py
@@ -56,6 +56,19 @@ def log_print(logger, values):
     logger.write(log_string + '\n')
 
 
+# The TL-net stages report different terms, so every stage gets its own columns and leaves the
+# columns it does not compute blank.  Keep this in sync with log_tl_net().
+TL_NET_LOG_HEADER = ["Training_Stage", "Epoch", "LR",
+                     "Train_Err_AE", "Train_Rel_Err_AE", "Val_Err_AE", "Val_Rel_Err_AE",
+                     "Train_Err_TF", "Train_Rel_Err_TF", "Val_Err_TF", "Val_Rel_Err_TF",
+                     "Train_Err_Joint", "Val_Err_Joint", "Sec"]
+
+
+def log_tl_net(logger, stage, epoch, lr, seconds, ae=("", "", "", ""), tf=("", "", "", ""), joint=("", "")):
+    # ae and tf are (train_err, train_rel_err, val_err, val_rel_err), joint is (train_err, val_err)
+    log_print(logger, [stage, epoch, lr, *ae, *tf, *joint, seconds])
+
+
 def set_scheduler(opt, sched_params):
     if sched_params["type"] == "Step":
         step_size = sched_params['parameters']['step_size']
@@ -68,6 +81,16 @@ def set_scheduler(opt, sched_params):
     else:
         print("Error: Learning rate scheduler not recognized or implemented.")
     return scheduler
+
+
+def restart_scheduler(opt, sched_params, learning_rate):
+    # The TL-net stages train in sequence on one optimizer and each anneals from the base rate, so
+    # the schedule restarts at every stage boundary.  StepLR.get_lr() is relative to the current
+    # rate, so the group rates have to be restored explicitly; a new scheduler is not enough.
+    for group in opt.param_groups:
+        group['lr'] = learning_rate
+        group['initial_lr'] = learning_rate
+    return set_scheduler(opt, sched_params)
 
 
 def train(project, config_file):
@@ -410,6 +433,7 @@ def supervised_train_tl(config_file):
     learning_rate = parameters['trainer']['learning_rate']
     eval_freq = parameters['trainer']['val_freq']
     decay_lr = parameters['trainer']['decay_lr']['enabled']
+    decay_lr_params = parameters['trainer']['decay_lr']
     a_ae = parameters["tl_net"]["a_ae"]
     c_ae = parameters["tl_net"]["c_ae"]
     a_lat = parameters["tl_net"]["a_lat"]
@@ -432,8 +456,6 @@ def supervised_train_tl(config_file):
     train_params = net.parameters()
     opt = torch.optim.Adam(train_params, learning_rate)
     opt.zero_grad()
-    if decay_lr:
-        scheduler = set_scheduler(opt, parameters['trainer']['decay_lr'])
     print("Done.")
     # train
     print("Beginning training on device = " + device + '\n')
@@ -461,10 +483,12 @@ def supervised_train_tl(config_file):
 
     # train the AE first
 
-    log_print(logger, ["Training_Stage", "Epoch", "LR", "Train_Err", "Train_Rel_Err", "Val_Err", "Val_Rel_Err", "Sec"])
+    log_print(logger, TL_NET_LOG_HEADER)
 
     mean_mdl = torch.mean(train_loader.dataset.mdl_target, 0).to(device)
 
+    if decay_lr:
+        scheduler = restart_scheduler(opt, decay_lr_params, learning_rate)
     for e in range(1, ae_epochs + 1):
         if sw_check_abort():
             sw_message("Aborted")
@@ -533,9 +557,8 @@ def supervised_train_tl(config_file):
             last_learning_rate = learning_rate
             if decay_lr:
                 last_learning_rate = scheduler.get_last_lr()[0]
-            log_print(logger,
-                      ["AE", e, last_learning_rate, train_ae_err, train_rel_ae_err, val_ae_err, val_rel_ae_err,
-                       time.time() - t0])
+            log_tl_net(logger, "AE", e, last_learning_rate, time.time() - t0,
+                       ae=(train_ae_err, train_rel_ae_err, val_ae_err, val_rel_ae_err))
             # plot
             epochs.append(e)
             plot_train_losses.append(train_ae_err)
@@ -546,6 +569,8 @@ def supervised_train_tl(config_file):
             train_plot.canvas.draw()
             train_plot.savefig(model_dir + C.TRAINING_PLOT_AE_FILE)
             t0 = time.time()
+        if decay_lr:
+            scheduler.step()
     # save
     torch.save(net.state_dict(), os.path.join(model_dir, C.FINAL_MODEL_AE_FILE))
     # fix the autoencoder and train the TL-net
@@ -573,6 +598,8 @@ def supervised_train_tl(config_file):
     epochs = []
     plot_train_losses = []
     plot_val_losses = []
+    if decay_lr:
+        scheduler = restart_scheduler(opt, decay_lr_params, learning_rate)
     for e in range(1, tf_epochs + 1):
         if sw_check_abort():
             sw_message("Aborted")
@@ -643,9 +670,8 @@ def supervised_train_tl(config_file):
             last_learning_rate = learning_rate
             if decay_lr:
                 last_learning_rate = scheduler.get_last_lr()[0]
-            log_print(logger,
-                      ["T-Flank", e, last_learning_rate, train_tf_err, train_rel_tf_err, val_tf_err, val_rel_tf_err,
-                       time.time() - t0])
+            log_tl_net(logger, "T-Flank", e, last_learning_rate, time.time() - t0,
+                       tf=(train_tf_err, train_rel_tf_err, val_tf_err, val_rel_tf_err))
             # plot
             epochs.append(e)
             plot_train_losses.append(train_tf_err)
@@ -656,6 +682,8 @@ def supervised_train_tl(config_file):
             train_plot.canvas.draw()
             train_plot.savefig(model_dir + C.TRAINING_PLOT_TF_FILE)
             t0 = time.time()
+        if decay_lr:
+            scheduler.step()
     # save
     torch.save(net.state_dict(), os.path.join(model_dir, C.FINAL_MODEL_TF_FILE))
     # jointly train the model
@@ -683,6 +711,8 @@ def supervised_train_tl(config_file):
     plot_train_losses = []
     plot_val_losses = []
     t0 = time.time()
+    if decay_lr:
+        scheduler = restart_scheduler(opt, decay_lr_params, learning_rate)
     for e in range(1, joint_epochs + 1):
         if sw_check_abort():
             sw_message("Aborted")
@@ -692,7 +722,9 @@ def supervised_train_tl(config_file):
 
         # train
         net.train()
+        ae_train_losses = []
         ae_train_rel_losses = []
+        tf_train_losses = []
         tf_train_rel_losses = []
         joint_train_losses = []
         pred_particles = []
@@ -720,7 +752,9 @@ def supervised_train_tl(config_file):
             loss.backward()
             opt.step()
             joint_train_losses.append(loss.item())
+            ae_train_losses.append(loss_ae.item())
             ae_train_rel_losses.append(ae_train_rel_loss.item())
+            tf_train_losses.append(loss_tf.item())
             tf_train_rel_losses.append(tf_train_rel_loss.item())
             pred_particles.extend(pred_pt.detach().cpu().numpy())
             true_particles.extend(mdl.detach().cpu().numpy())
@@ -732,7 +766,9 @@ def supervised_train_tl(config_file):
         val_names = []
         if ((e % eval_freq) == 0 or e == 1):
             net.eval()
+            ae_val_losses = []
             ae_val_rel_losses = []
+            tf_val_losses = []
             tf_val_rel_losses = []
             joint_val_losses = []
             for img, pca, mdl, names in val_loader:
@@ -748,7 +784,9 @@ def supervised_train_tl(config_file):
                 tf_val_rel_loss = losses.MSE(lat, lat_img) / losses.MSE(lat * 0, lat_img)
 
                 joint_val_losses.append(loss_ae.item() + alpha * loss_tf.item())
+                ae_val_losses.append(loss_ae.item())
                 ae_val_rel_losses.append(ae_val_rel_loss.item())
+                tf_val_losses.append(loss_tf.item())
                 tf_val_rel_losses.append(tf_val_rel_loss.item())
                 pred_particles.extend(pred_pt.detach().cpu().numpy())
                 true_particles.extend(mdl.detach().cpu().numpy())
@@ -756,17 +794,23 @@ def supervised_train_tl(config_file):
                                      model_dir + "examples/validation_")
 
             # log
+            train_ae_err = np.mean(ae_train_losses)
             train_rel_ae_err = np.mean(ae_train_rel_losses)
-            train_rel_tf_err = np.mean(tf_train_rel_losses)
+            val_ae_err = np.mean(ae_val_losses)
             val_rel_ae_err = np.mean(ae_val_rel_losses)
+            train_tf_err = np.mean(tf_train_losses)
+            train_rel_tf_err = np.mean(tf_train_rel_losses)
+            val_tf_err = np.mean(tf_val_losses)
             val_rel_tf_err = np.mean(tf_val_rel_losses)
             joint_train_losses = np.mean(joint_train_losses)
             joint_val_losses = np.mean(joint_val_losses)
             last_learning_rate = learning_rate
             if decay_lr:
                 last_learning_rate = scheduler.get_last_lr()[0]
-            log_print(logger, ["Joint", e, last_learning_rate, train_rel_ae_err, val_rel_ae_err, train_rel_tf_err,
-                               val_rel_tf_err, time.time() - t0])
+            log_tl_net(logger, "Joint", e, last_learning_rate, time.time() - t0,
+                       ae=(train_ae_err, train_rel_ae_err, val_ae_err, val_rel_ae_err),
+                       tf=(train_tf_err, train_rel_tf_err, val_tf_err, val_rel_tf_err),
+                       joint=(joint_train_losses, joint_val_losses))
             # plot
             epochs.append(e)
             plot_train_losses.append(joint_train_losses)

--- a/Python/shapeworks/setup.py
+++ b/Python/shapeworks/setup.py
@@ -11,5 +11,7 @@ setuptools.setup(
    version='1.0',
    description='Python module for Shapeworks.',
    packages=setuptools.find_packages(),
+   # datasets.json pins which archive each use case dataset downloads from
+   package_data={'shapeworks': ['datasets.json']},
    install_requires=['requests'], #external packages as dependencies
 )

--- a/Python/shapeworks/shapeworks/__init__.py
+++ b/Python/shapeworks/shapeworks/__init__.py
@@ -10,6 +10,6 @@ from .utils import num_subplots, positive_factors, save_images, get_file_with_ex
 from .data import get_file_list, sample_images, sample_meshes
 from .stats import compute_pvalues_for_group_difference,lda,dwd_loadings
 from .network_analysis import NetworkAnalysis
-from .portal import download_dataset
+from .datasets import download_dataset, list_datasets
 from .shape_scalars import run_mbpls
 from .torch_install import ensure_torch, is_torch_available

--- a/Python/shapeworks/shapeworks/datasets.json
+++ b/Python/shapeworks/shapeworks/datasets.json
@@ -1,0 +1,201 @@
+{
+  "base_url": "https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data/",
+  "datasets": {
+    "deep_ssm_femur": {
+      "file": "deep_ssm_femur-v1.zip",
+      "version": 1,
+      "sha256": "341d7d43866d52a43894cd3480b156fb069d5f55ec8f0f5134cfa7e32a731d0b",
+      "size": 4111489211,
+      "files": 131
+    },
+    "deep_ssm_femur_tiny_test": {
+      "file": "deep_ssm_femur_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "164c944b59c5c701d330c82c6007102a9db67b4e487d3ddba3fbeef2a2a1c99f",
+      "size": 601139594,
+      "files": 16
+    },
+    "ellipsoid": {
+      "file": "ellipsoid-v1.zip",
+      "version": 1,
+      "sha256": "2fca8034b4633eb44762ec3cdc44d77e8d0d3377682e35fa3f0f0311baffc5ce",
+      "size": 3732351,
+      "files": 61
+    },
+    "ellipsoid_cut": {
+      "file": "ellipsoid_cut-v1.zip",
+      "version": 1,
+      "sha256": "f8b756ab3c8dd8a930177462ebca738ba91bd8eaafb13aceba39e51ecd4e6c2a",
+      "size": 3265150,
+      "files": 76
+    },
+    "ellipsoid_cut_tiny_test": {
+      "file": "ellipsoid_cut_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "8c74ea70a1803bf28a6851d0b65f6f365edc1fed3c525e919b7a8f706f933892",
+      "size": 654138,
+      "files": 16
+    },
+    "ellipsoid_fd": {
+      "file": "ellipsoid_fd-v1.zip",
+      "version": 1,
+      "sha256": "6f59323ccc6cb112bfeffe108719c0dcee1d4fb78338ede3a961e09ac827db4e",
+      "size": 7751869,
+      "files": 97
+    },
+    "ellipsoid_fd_multiscale": {
+      "file": "ellipsoid_fd_multiscale-v1.zip",
+      "version": 1,
+      "sha256": "fe9a523faa97aa1c76226bb3124c1a49baa45755a59a35669d38c179bb92cda4",
+      "size": 7751891,
+      "files": 97
+    },
+    "ellipsoid_mesh": {
+      "file": "ellipsoid_mesh-v1.zip",
+      "version": 1,
+      "sha256": "eead381a3cbec3ca6a780371815383d8a0aebb7c1186bafc4c75a9c642559bf8",
+      "size": 712412,
+      "files": 61
+    },
+    "ellipsoid_mesh_tiny_test": {
+      "file": "ellipsoid_mesh_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "c566946278c1d7a4691ac8378ee7ac4f85ece673e9b3da695dc26aadd86cc124",
+      "size": 140467,
+      "files": 13
+    },
+    "ellipsoid_multiple_domain": {
+      "file": "ellipsoid_multiple_domain-v1.zip",
+      "version": 1,
+      "sha256": "68e13f3b5c0992d20d1ae8801fde6a67f58727c918116c3ae421c369f90afcbb",
+      "size": 61642,
+      "files": 31
+    },
+    "ellipsoid_multiple_domain_mesh": {
+      "file": "ellipsoid_multiple_domain_mesh-v1.zip",
+      "version": 1,
+      "sha256": "012514624218ca0f293ec86a068ddb9eb4765882e64d5d16e83663d3ee98c245",
+      "size": 1327283,
+      "files": 121
+    },
+    "ellipsoid_multiple_domain_mesh_tiny_test": {
+      "file": "ellipsoid_multiple_domain_mesh_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "7f252dba90090571ef2ce266cbf4b97ba4e80cf3bacae6607a9ca039a531969b",
+      "size": 528299,
+      "files": 49
+    },
+    "ellipsoid_multiple_domain_tiny_test": {
+      "file": "ellipsoid_multiple_domain_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "fbdec37cec763f898b1f66e725b94bc58a398b6c6f7f63f50407f09009ca960d",
+      "size": 9198,
+      "files": 7
+    },
+    "ellipsoid_tiny_test": {
+      "file": "ellipsoid_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "171981870ab45dd4d22efb13d3c3b250f7b7da84788d6275b6b1bcf8abdc54af",
+      "size": 703593,
+      "files": 13
+    },
+    "femur_cut": {
+      "file": "femur_cut-v1.zip",
+      "version": 1,
+      "sha256": "c4be1ae6b2d36d2be01959bb1289d79ff8e5fc1551e57a41721a098d5864f70f",
+      "size": 45206054,
+      "files": 246
+    },
+    "femur_cut_tiny_test": {
+      "file": "femur_cut_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "f43525b16b2ac12a8a6a867819bc54361305495c796608fbbc7b42c9df76a039",
+      "size": 2754929,
+      "files": 16
+    },
+    "hip_multiple_domain": {
+      "file": "hip_multiple_domain-v1.zip",
+      "version": 1,
+      "sha256": "a859cd5d6abdb5388cb690b7170210d7fb82871c69e2e5e130082d472807a590",
+      "size": 57278678,
+      "files": 161
+    },
+    "hip_multiple_domain_tiny_test": {
+      "file": "hip_multiple_domain_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "56851e87d325da066a7a2ae6f4b1f0e06e9dc17ac3a20bdb85abbeef098944ce",
+      "size": 21434562,
+      "files": 61
+    },
+    "incremental_supershapes": {
+      "file": "incremental_supershapes-v1.zip",
+      "version": 1,
+      "sha256": "18a5d808e1894a2e4f4fa6eee85dc5b5f095ca1a01cb99a11183c12b51dbd418",
+      "size": 1794926,
+      "files": 152
+    },
+    "incremental_supershapes_tiny_test": {
+      "file": "incremental_supershapes_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "412a2824e28f511e3aee44788871369671a69131a5828a0389dbc70a7ec02452",
+      "size": 109733,
+      "files": 10
+    },
+    "left_atrium": {
+      "file": "left_atrium-v1.zip",
+      "version": 1,
+      "sha256": "012d647344e6d4967bba1cb08b4c4d74513c5ed2017981cee8c36aa3105cb1de",
+      "size": 218722328,
+      "files": 201
+    },
+    "left_atrium_tiny_test": {
+      "file": "left_atrium_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "663120fee55b9376093fb5bca5ee6ab1e6aa3ce1e025be2626fd9f1668662f85",
+      "size": 11491951,
+      "files": 13
+    },
+    "lumps": {
+      "file": "lumps-v1.zip",
+      "version": 1,
+      "sha256": "9ea9d6e1a7aa79869d80ad5b0f03a830f39ffee0aaa74a885d71dc55f9b306d6",
+      "size": 4168646,
+      "files": 76
+    },
+    "lumps_tiny_test": {
+      "file": "lumps_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "a4d24405e66d53fc359de0367008763e3a2f58f463ce15d9f6638aee06ef6729",
+      "size": 500480,
+      "files": 10
+    },
+    "peanut_shared_boundary": {
+      "file": "peanut_shared_boundary-v1.zip",
+      "version": 1,
+      "sha256": "3303eccd8ad9411b53fee0b30eab2a80083b19baf08665c86c2b4f2400fa9a0b",
+      "size": 4973781,
+      "files": 212
+    },
+    "peanut_shared_boundary_tiny_test": {
+      "file": "peanut_shared_boundary_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "71bc77cc143f60cf54859b65ddea1da2e2c094057b84fd366df2b082fdab15bc",
+      "size": 681064,
+      "files": 29
+    },
+    "thin_cavity_bean": {
+      "file": "thin_cavity_bean-v1.zip",
+      "version": 1,
+      "sha256": "45dc471dae5c56d03ae7fb87c16ebcd8cb99788d8a8c22ad227adc33b2ac7e06",
+      "size": 7985366,
+      "files": 103
+    },
+    "thin_cavity_bean_tiny_test": {
+      "file": "thin_cavity_bean_tiny_test-v1.zip",
+      "version": 1,
+      "sha256": "1f30225744628f889c4130362f0776914f0d46a915cb8a592d47f244b9181dac",
+      "size": 800807,
+      "files": 3
+    }
+  }
+}

--- a/Python/shapeworks/shapeworks/datasets.py
+++ b/Python/shapeworks/shapeworks/datasets.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Download use case datasets over plain HTTPS.
+
+The use case data is published as one zip per dataset, fetched directly with no
+account, login, or client library, so the use cases keep working regardless of the
+state of the ShapeWorks Cloud portal.
+
+Which archive each dataset name resolves to is pinned in datasets.json, next to
+this file and checked into the source tree. Archives are versioned individually
+(<name>-v<version>.zip) and are never overwritten on the server, so a given release
+of ShapeWorks keeps downloading exactly the data it shipped against: republishing a
+dataset for a newer release cannot change what an older one gets. Updating a dataset
+means building a new version and pointing datasets.json at it.
+
+Pinning the checksums here rather than reading them from the server is also what
+makes verification worth doing, since a bad re-upload cannot rewrite the hash it is
+checked against.
+
+Set SW_DATA_URL to point at a different server or a local mirror when testing.
+Archives are built by Support/build_dataset_archives.py.
+"""
+import hashlib
+import json
+import os
+import ssl
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+
+INDEX_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "datasets.json")
+
+_CHUNK = 1024 * 256
+_RETRIES = 3
+_TIMEOUT = 60
+
+_index_cache = None
+
+
+def get_index():
+    """The pinned dataset table shipped alongside this module."""
+    global _index_cache
+    if _index_cache is None:
+        try:
+            with open(INDEX_FILE) as fh:
+                _index_cache = json.load(fh)
+        except OSError as e:
+            raise RuntimeError(f"Dataset index missing at {INDEX_FILE}: {e}")
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Malformed dataset index at {INDEX_FILE}: {e}")
+    return _index_cache
+
+
+def base_url():
+    """Server holding the dataset archives; override with $SW_DATA_URL."""
+    url = os.environ.get("SW_DATA_URL") or get_index().get("base_url", "")
+    return url if url.endswith("/") else url + "/"
+
+
+def _open(url):
+    """Open a URL, retrying transient failures."""
+    last = None
+    for attempt in range(_RETRIES):
+        try:
+            return urllib.request.urlopen(url, timeout=_TIMEOUT)
+        except (urllib.error.URLError, ssl.SSLError, TimeoutError) as e:
+            last = e
+            if attempt < _RETRIES - 1:
+                time.sleep(2 ** attempt)
+    raise RuntimeError(f"Could not reach {url}\n  {last}\n"
+                       f"Check your network connection, or set $SW_DATA_URL to a mirror.")
+
+
+def list_datasets():
+    """Names of every dataset this release knows how to download."""
+    return sorted(get_index().get("datasets", {}))
+
+
+def _progress(name, done, total):
+    if not sys.stdout.isatty():
+        return
+    if total:
+        pct = 100.0 * done / total
+        sys.stdout.write(f"\r  {name}: {pct:5.1f}%  "
+                         f"({done / 1e6:.1f} / {total / 1e6:.1f} MB)")
+    else:
+        sys.stdout.write(f"\r  {name}: {done / 1e6:.1f} MB")
+    sys.stdout.flush()
+
+
+def _download(url, destination, name, expected_size):
+    """Stream a URL to disk, returning its sha256."""
+    digest = hashlib.sha256()
+    downloaded = 0
+    with _open(url) as response:
+        total = expected_size or int(response.headers.get("Content-Length") or 0)
+        with open(destination, "wb") as out:
+            while True:
+                chunk = response.read(_CHUNK)
+                if not chunk:
+                    break
+                out.write(chunk)
+                digest.update(chunk)
+                downloaded += len(chunk)
+                _progress(name, downloaded, total)
+    if sys.stdout.isatty():
+        sys.stdout.write("\n")
+    if expected_size and downloaded != expected_size:
+        raise RuntimeError(
+            f"{name}: download truncated, got {downloaded} bytes, expected {expected_size}")
+    return digest.hexdigest()
+
+
+def _read_marker(path):
+    """Return what a previous download recorded, or None."""
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        # Pre-existing marker files were empty, so treat them as unknown content.
+        return None
+
+
+def download_dataset(datasetName, outputDirectory, force=False):
+    """Download a use case dataset and extract it into outputDirectory.
+
+    The archive is verified against the sha256 in the manifest before it is
+    extracted, so a partial or corrupted transfer fails loudly rather than leaving
+    a half-populated directory behind for the use case to silently run on.
+
+    The marker records the checksum that was installed, so pointing this release at
+    a newer version of a dataset makes the next run replace it instead of quietly
+    reusing whatever is already on disk.
+    """
+    marker = os.path.join("Output", datasetName + ".downloaded")
+    installed = _read_marker(marker) if os.path.exists(marker) else None
+
+    datasets = get_index().get("datasets", {})
+    if datasetName not in datasets:
+        raise RuntimeError(
+            f"Unknown dataset '{datasetName}'\n"
+            f"Available datasets:\n    " + "\n    ".join(sorted(datasets)))
+
+    entry = datasets[datasetName]
+
+    # Nothing here touches the network, so re-running a use case works offline.
+    if installed and not force and installed.get("sha256") == entry.get("sha256"):
+        print(f"Dataset {datasetName} already downloaded ({marker} exists)")
+        if os.environ.get("SW_PORTAL_DOWNLOAD_ONLY") == "1":
+            sys.exit(0)
+        return
+    if installed and installed.get("sha256") != entry.get("sha256"):
+        print(f"Dataset {datasetName} is pinned to {entry['file']}, downloading it")
+
+    url = urllib.parse.urljoin(base_url(), entry["file"])
+    os.makedirs(outputDirectory, exist_ok=True)
+    os.makedirs(os.path.dirname(marker) or ".", exist_ok=True)
+
+    print(f"Downloading {datasetName} from {url}")
+    handle, temporary = tempfile.mkstemp(suffix=".zip", prefix=datasetName + "-",
+                                         dir=outputDirectory)
+    os.close(handle)
+    try:
+        actual = _download(url, temporary, datasetName, entry.get("size"))
+        expected = entry.get("sha256")
+        if expected and actual != expected:
+            raise RuntimeError(
+                f"{datasetName}: checksum mismatch for {entry['file']}\n"
+                f"  expected {expected}\n  got      {actual}\n"
+                f"The copy on the server does not match what this release of "
+                f"ShapeWorks was built against. Published archives are immutable, "
+                f"so {entry['file']} was either overwritten or is corrupt.")
+
+        print(f"Extracting {datasetName} to {outputDirectory}")
+        with zipfile.ZipFile(temporary) as archive:
+            members = [m for m in archive.namelist() if not m.endswith("/")]
+            archive.extractall(outputDirectory)
+
+        expected_files = entry.get("files")
+        if expected_files is not None and len(members) != expected_files:
+            raise RuntimeError(
+                f"{datasetName}: archive holds {len(members)} files, "
+                f"datasets.json expects {expected_files}. The archive needs rebuilding.")
+    finally:
+        if os.path.exists(temporary):
+            os.remove(temporary)
+
+    with open(marker, "w") as fh:
+        json.dump({"dataset": datasetName, "sha256": entry.get("sha256"),
+                   "files": len(members)}, fh)
+        fh.write("\n")
+    print(f"Dataset {datasetName} downloaded to {outputDirectory} "
+          f"({len(members)} files)")
+
+    if os.environ.get("SW_PORTAL_DOWNLOAD_ONLY") == "1":
+        sys.exit(0)

--- a/Support/build_dataset_archives.py
+++ b/Support/build_dataset_archives.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Build the use case dataset archives served from sci.utah.edu.
+
+Turns a local export of the use case data into one zip per dataset name, and updates
+the pinned dataset table the shapeworks package downloads against. The zips are laid
+out so that extracting one into Output/<use case>/ produces exactly the directory
+structure the use case scripts glob for.
+
+Archives are versioned per dataset rather than as one big numbered directory. Each is
+published as <name>-v<version>.zip and is never overwritten on the server. Which
+archive a dataset name resolves to is pinned in the checked-in datasets.json, so an
+older release of ShapeWorks keeps downloading the data it shipped against no matter
+what is published later.
+
+To update a dataset: bump its `version` in DATASETS, rebuild just that one, upload the
+single new zip, and commit the regenerated datasets.json. Every other dataset keeps the
+file it already had, and the previous version stays on the server to roll back to.
+
+Usage:
+    python3 Support/build_dataset_archives.py [--source DIR] [--dest DIR]
+                                              [--index FILE] [--only NAME ...]
+                                              [--skip NAME ...] [--list] [--jobs N]
+                                              [--force]
+
+--dest holds the zips to upload; --index is the table to commit.
+"""
+import argparse
+import concurrent.futures
+import fnmatch
+import hashlib
+import json
+import os
+import sys
+import zipfile
+
+DEFAULT_SOURCE = os.path.expanduser("~/sci/datasets")
+DEFAULT_DEST = os.path.expanduser("~/sci/datasets-web")
+DEFAULT_INDEX = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                             "Python", "shapeworks", "shapeworks", "datasets.json")
+
+BASE_URL = "https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data/"
+
+# Fixed timestamp so rebuilding identical content produces an identical zip.
+FIXED_DATE = (1980, 1, 1, 0, 0, 0)
+
+# dataset name (as requested by the use cases) -> how to build it
+#   dir     : directory under --source holding the content
+#   version : bump when a dataset's content changes; publishes <name>-v<version>.zip
+#             beside the existing one instead of overwriting it, so only the dataset
+#             that actually changed is rebuilt and re-uploaded (default 1)
+#   prefix  : directory level to insert at the root of the zip (the export is
+#             missing a level the use case globs for)
+#   include : keep only files matching one of these globs
+#   subset  : (glob, n) keep only the first n files matching glob, plus every file
+#             that does not match it at all
+DATASETS = {
+    # --- tiny tests -------------------------------------------------------
+    "deep_ssm_femur_tiny_test": {"dir": "deep_ssm_femur_tiny_test"},
+    "ellipsoid_tiny_test": {"dir": "ellipsoid_tiny_test"},
+    "ellipsoid_cut_tiny_test": {"dir": "ellipsoid_cut_tiny_test"},
+    "ellipsoid_mesh_tiny_test": {"dir": "ellipsoid_mesh_tiny_test"},
+    "ellipsoid_multiple_domain_tiny_test": {"dir": "ellipsoid_multiple_domain_tiny_test"},
+    "ellipsoid_multiple_domain_mesh_tiny_test": {"dir": "ellipsoid_multiple_domain_mesh_tiny_test"},
+    "femur_cut_tiny_test": {"dir": "femur_cut_tiny_test"},
+    "hip_multiple_domain_tiny_test": {"dir": "hip_multiple_domain_tiny_test"},
+    "incremental_supershapes_tiny_test": {"dir": "incremental_supershapes_tiny_test"},
+    "left_atrium_tiny_test": {"dir": "left_atrium_tiny_test"},
+    "lumps_tiny_test": {"dir": "lumps_tiny_test"},
+    "peanut_shared_boundary_tiny_test": {"dir": "peanut_shared_boundary_tiny_test"},
+    # No tiny test was exported for thin_cavity_bean, so cut one from the full set.
+    "thin_cavity_bean_tiny_test": {"dir": "thin_cavity_bean",
+                                   "prefix": "thin_cavity_bean",
+                                   "include": ["meshes/*.ply"],
+                                   "subset": ("meshes/*.ply", 3)},
+
+    # --- full datasets ----------------------------------------------------
+    "deep_ssm_femur": {"dir": "deep_ssm_full"},
+    "ellipsoid": {"dir": "ellipsoid_multiscale"},
+    "ellipsoid_cut": {"dir": "ellipsoid_cut_multiscale"},
+    "ellipsoid_fd": {"dir": "ellipsoid_fd"},
+    "ellipsoid_fd_multiscale": {"dir": "ellipsoid_fd_multiscale"},
+    "ellipsoid_mesh": {"dir": "ellipsoid_mesh_multiscale"},
+    "ellipsoid_multiple_domain": {"dir": "ellipsoid_multiple_domain"},
+    "ellipsoid_multiple_domain_mesh": {"dir": "ellipsoid_multiple_domain_mesh_singlescale"},
+    "femur_cut": {"dir": "femur_cut_multiscale"},
+    "hip_multiple_domain": {"dir": "hip_multiple_domain_singlescale"},
+    "incremental_supershapes": {"dir": "incremental_supershapes"},
+    "left_atrium": {"dir": "left_atrium_multiscale"},
+    "lumps": {"dir": "lumps"},
+    "peanut_shared_boundary": {"dir": "peanut_shared_boundary_multiscale"},
+    # The export is missing the inner directory level the use case globs for.
+    "thin_cavity_bean": {"dir": "thin_cavity_bean", "prefix": "thin_cavity_bean"},
+}
+
+
+def collect(root, spec):
+    """Return [(absolute path, name inside the zip)] for one dataset."""
+    entries = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            if filename == ".DS_Store":
+                continue
+            full = os.path.join(dirpath, filename)
+            rel = os.path.relpath(full, root)
+            entries.append((full, rel))
+
+    include = spec.get("include")
+    if include:
+        entries = [e for e in entries
+                   if any(fnmatch.fnmatch(e[1], pat) for pat in include)]
+
+    subset = spec.get("subset")
+    if subset:
+        pattern, count = subset
+        matching = sorted(e for e in entries if fnmatch.fnmatch(e[1], pattern))
+        keep = set(matching[:count])
+        entries = [e for e in entries if e not in set(matching) or e in keep]
+
+    prefix = spec.get("prefix")
+    if prefix:
+        entries = [(full, os.path.join(prefix, rel)) for full, rel in entries]
+
+    return sorted(entries, key=lambda e: e[1])
+
+
+def archive_name(name, spec):
+    return f"{name}-v{spec.get('version', 1)}.zip"
+
+
+def build_one(name, spec, source, dest, existing=None, force=False):
+    filename = archive_name(name, spec)
+    out = os.path.join(dest, filename)
+
+    # An archive is immutable once published: same name means same bytes, so a
+    # rebuild of an unchanged dataset is a no-op rather than a fresh upload.
+    if not force and existing and existing.get("file") == filename \
+            and os.path.exists(out) and os.path.getsize(out) == existing.get("size"):
+        return name, existing, None
+
+    root = os.path.join(source, spec["dir"])
+    if not os.path.isdir(root):
+        return name, None, f"source directory missing: {root}"
+
+    entries = collect(root, spec)
+    if not entries:
+        return name, None, f"no files found under {root}"
+
+    tmp = out + ".partial"
+    with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        for full, arcname in entries:
+            info = zipfile.ZipInfo(arcname, date_time=FIXED_DATE)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            with open(full, "rb") as fh:
+                zf.writestr(info, fh.read())
+    os.replace(tmp, out)
+
+    digest = hashlib.sha256()
+    with open(out, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+
+    return name, {
+        "file": filename,
+        "version": spec.get("version", 1),
+        "sha256": digest.hexdigest(),
+        "size": os.path.getsize(out),
+        "files": len(entries),
+    }, None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--source", default=DEFAULT_SOURCE, help="local dataset export")
+    parser.add_argument("--dest", default=DEFAULT_DEST, help="staging directory to write")
+    parser.add_argument("--index", default=DEFAULT_INDEX,
+                        help="pinned dataset table to update and commit")
+    parser.add_argument("--only", nargs="+", metavar="NAME", help="build only these datasets")
+    parser.add_argument("--skip", nargs="+", metavar="NAME", default=[], help="skip these datasets")
+    parser.add_argument("--jobs", type=int, default=4, help="parallel zip workers")
+    parser.add_argument("--force", action="store_true",
+                        help="rebuild archives even if already staged at this version")
+    parser.add_argument("--list", action="store_true", help="list dataset names and exit")
+    args = parser.parse_args()
+
+    if args.list:
+        for name in sorted(DATASETS):
+            print(f"{name:44} v{DATASETS[name].get('version', 1)}")
+        return 0
+
+    names = sorted(args.only if args.only else DATASETS)
+    unknown = [n for n in names if n not in DATASETS]
+    if unknown:
+        parser.error("unknown dataset(s): " + ", ".join(unknown))
+    names = [n for n in names if n not in args.skip]
+
+    os.makedirs(args.dest, exist_ok=True)
+
+    # Merge into the pinned table so partial rebuilds leave other datasets alone.
+    datasets = {}
+    if os.path.exists(args.index):
+        with open(args.index) as fh:
+            datasets = json.load(fh).get("datasets", {})
+
+    failures = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        futures = {pool.submit(build_one, n, DATASETS[n], args.source, args.dest,
+                               datasets.get(n), args.force): n
+                   for n in names}
+        for future in concurrent.futures.as_completed(futures):
+            name, entry, error = future.result()
+            if error:
+                failures.append((name, error))
+                print(f"  FAIL  {name}: {error}", file=sys.stderr)
+                continue
+            action = "up to date" if datasets.get(name) == entry else "built"
+            datasets[name] = entry
+            print(f"  {action:11} {entry['file']:44} {entry['files']:>5} files  "
+                  f"{entry['size'] / 1e6:>9.1f} MB")
+
+    with open(args.index, "w") as fh:
+        json.dump({"base_url": BASE_URL,
+                   "datasets": dict(sorted(datasets.items()))}, fh, indent=2)
+        fh.write("\n")
+
+    total = sum(d["size"] for d in datasets.values())
+    print(f"\n{len(datasets)} datasets pinned, {total / 1e9:.2f} GB total")
+    print(f"archives staged in {args.dest}")
+    print(f"index written to  {args.index}  (commit this)")
+    if failures:
+        print(f"\n{len(failures)} failed:", file=sys.stderr)
+        for name, error in failures:
+            print(f"  {name}: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Support/check_dataset_server.py
+++ b/Support/check_dataset_server.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Check the data server actually serves what datasets.json pins.
+
+Issues one HEAD request per dataset and compares the size the server reports
+against the pinned size, so a missing, truncated, or half-uploaded archive is
+caught right after uploading rather than by a user running a use case.
+
+Pass --full to download each archive and verify its SHA-256 instead. That is the
+real check, but it transfers everything, so it is off by default.
+
+Usage:
+    python3 Support/check_dataset_server.py [--index FILE] [--url BASE] [--full]
+"""
+import argparse
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TIMEOUT = 60
+
+
+def head(url):
+    """Return (status, content-length) for a URL."""
+    request = urllib.request.Request(url, method="HEAD")
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT) as response:
+            return response.status, int(response.headers.get("Content-Length") or 0)
+    except urllib.error.HTTPError as e:
+        return e.code, 0
+    except (urllib.error.URLError, TimeoutError) as e:
+        print(f"    {e}", file=sys.stderr)
+        return 0, 0
+
+
+def sha256_of(url):
+    digest = hashlib.sha256()
+    with urllib.request.urlopen(url, timeout=TIMEOUT) as response:
+        for chunk in iter(lambda: response.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main():
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--index", default=os.path.join(
+        here, "Python", "shapeworks", "shapeworks", "datasets.json"),
+        help="pinned dataset table to check the server against")
+    parser.add_argument("--url", help="base URL to check (default: the pinned base_url)")
+    parser.add_argument("--full", action="store_true",
+                        help="download each archive and verify its checksum")
+    args = parser.parse_args()
+
+    with open(args.index) as fh:
+        index = json.load(fh)
+    base = args.url or index.get("base_url", "")
+    if not base.endswith("/"):
+        base += "/"
+    datasets = index.get("datasets", {})
+
+    print(f"checking {len(datasets)} datasets against {base}\n")
+    bad = 0
+    for name, entry in sorted(datasets.items()):
+        url = urllib.parse.urljoin(base, entry["file"])
+        status, length = head(url)
+        if status != 200:
+            print(f"  MISSING   {entry['file']:44} HTTP {status}")
+            bad += 1
+            continue
+        if length != entry["size"]:
+            print(f"  SIZE      {entry['file']:44} "
+                  f"server {length} != pinned {entry['size']}")
+            bad += 1
+            continue
+        if args.full:
+            actual = sha256_of(url)
+            if actual != entry["sha256"]:
+                print(f"  CHECKSUM  {entry['file']:44} {actual[:16]}... "
+                      f"!= {entry['sha256'][:16]}...")
+                bad += 1
+                continue
+            print(f"  ok        {entry['file']:44} checksum verified")
+        else:
+            print(f"  ok        {entry['file']:44} {length / 1e6:>9.1f} MB")
+
+    print()
+    if bad:
+        print(f"{bad} of {len(datasets)} datasets are wrong on the server", file=sys.stderr)
+        return 1
+    print(f"all {len(datasets)} datasets present and the right size"
+          + ("" if args.full else "; re-run with --full to verify checksums"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Support/deploy_docs.sh
+++ b/Support/deploy_docs.sh
@@ -13,6 +13,11 @@ if [ "$#" -ne 1 ]; then
 fi
 INSTALL_DIR=$1
 
+# Git ref the docs are built from.  Normally "master", which is always the
+# development version.  Run the workflow manually against a release tag (e.g.
+# v6.7.0) to rebuild the docs for a version that has already shipped.
+DOCS_REF=${DOCS_REF:-master}
+
 # Update auto-documentation
 PATH=$INSTALL_DIR/bin:$PATH
 
@@ -43,11 +48,12 @@ git remote rm origin
 git remote add origin "${remote_repo}"
 
 # get remote gh-pages branch
+git fetch origin gh-pages
 git checkout --track origin/gh-pages
 git pull --rebase
 
-# build docs from master
-git checkout master
+# build docs from the requested ref
+git checkout ${DOCS_REF}
 
 # clean out old api docs as mkdocs will just find whatever is there.
 rm -rf docs/api
@@ -57,9 +63,31 @@ mkdir docs/api
 python Python/RunShapeWorksAutoDoc.py --md_filename docs/tools/ShapeWorksCommands.md
 doxybook2 -i ${INSTALL_DIR}/Documentation/Doxygen/xml -o docs/api -c docs/doxygen/doxybook2.config.json
 
+# Derive the docs version (e.g. "6.8") from the source tree so this script does
+# not have to be edited every release.
+SW_MAJOR=$(sed -n 's/^SET(SHAPEWORKS_MAJOR_VERSION \([0-9][0-9]*\).*/\1/p' CMakeLists.txt)
+SW_MINOR=$(sed -n 's/^SET(SHAPEWORKS_MINOR_VERSION \([0-9][0-9]*\).*/\1/p' CMakeLists.txt)
+if [[ -z "${SW_MAJOR}" || -z "${SW_MINOR}" ]]; then
+    echo "Could not determine the ShapeWorks version from CMakeLists.txt"
+    exit 1
+fi
+DOCS_VERSION="${SW_MAJOR}.${SW_MINOR}"
+
+# master is the development version, so it is titled "<version> (dev)" and owns
+# the "dev" alias.  Anything else is a release rebuild and gets a plain title.
+# "latest" always points at the most recently released version; it is moved by
+# rebuilding that release's docs with DOCS_ALIAS=latest.
+if [ "${DOCS_REF}" = "master" ]; then
+    DOCS_TITLE=${DOCS_TITLE:-"${DOCS_VERSION} (dev)"}
+    DOCS_ALIAS=${DOCS_ALIAS:-dev}
+else
+    DOCS_TITLE=${DOCS_TITLE:-"${DOCS_VERSION}"}
+    DOCS_ALIAS=${DOCS_ALIAS:-}
+fi
+
 # use mike to mkdocs w/ version
-mike deploy --config-file ./mkdocs.yml --title "6.7 (dev)" 6.7 dev --branch gh-pages --update-aliases
-mike set-default latest
+mike deploy --config-file ./mkdocs.yml --title "${DOCS_TITLE}" --branch gh-pages --update-aliases "${DOCS_VERSION}" ${DOCS_ALIAS}
+mike set-default latest --branch gh-pages
 
 # update docs on github
 git push origin gh-pages

--- a/Support/verify_dataset_archives.py
+++ b/Support/verify_dataset_archives.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Verify the dataset archives satisfy the paths the use cases actually glob for.
+
+Parses each use case in Examples/Python with `ast`, walking the tiny_test and full
+branches separately, to recover the glob patterns Step 1 will run. Each pattern is
+then matched against the file list of the archive that use case downloads, so a
+dataset that is missing a directory level, or was published with the wrong layout,
+is caught before it reaches anyone.
+
+Reads the archives' indexes only, so it is cheap even for the multi-gigabyte sets.
+
+Usage:
+    python3 Support/verify_dataset_archives.py [--staging DIR] [--examples DIR]
+                                               [--index FILE]
+"""
+import argparse
+import ast
+import fnmatch
+import glob
+import json
+import os
+import sys
+import zipfile
+
+
+def _const_str(node, env):
+    """Best-effort evaluation of a string expression built from literals and names."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return env.get(node.id)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _const_str(node.left, env)
+        right = _const_str(node.right, env)
+        if left is not None and right is not None:
+            return left + right
+    if isinstance(node, ast.Subscript):
+        return _const_str(node.value, env)
+    if isinstance(node, ast.Call):
+        if getattr(node.func, "id", None) == "sorted" and node.args:
+            return _const_str(node.args[0], env)
+        # Paths are sometimes anchored with os.getcwd(); the leading directory is
+        # irrelevant here since patterns are matched relative to the archive root.
+        if ast.unparse(node.func) == "os.getcwd":
+            return ""
+    return None
+
+
+def _walk(body, env, found):
+    """Walk statements, forking the environment at each If so branches stay independent."""
+    for stmt in body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if isinstance(target, ast.Name):
+                    value = _const_str(stmt.value, env)
+                    if value is not None:
+                        env[target.id] = value
+        elif isinstance(stmt, ast.If):
+            _walk(stmt.body, dict(env), found)
+            _walk(stmt.orelse, dict(env), found)
+            continue
+        elif isinstance(stmt, (ast.For, ast.While, ast.With, ast.Try)):
+            _walk(stmt.body, env, found)
+            continue
+
+        for node in ast.walk(stmt):
+            if not isinstance(node, ast.Call):
+                continue
+            name = ast.unparse(node.func)
+            if name.endswith("download_dataset") and node.args:
+                dataset = _const_str(node.args[0], env)
+                if dataset:
+                    env["__dataset__"] = dataset
+                    env["__outdir__"] = _const_str(node.args[1], env) if len(node.args) > 1 else ""
+            elif name == "glob.glob" and node.args:
+                pattern = _const_str(node.args[0], env)
+                if pattern and env.get("__dataset__"):
+                    found.append((env["__dataset__"], pattern, env.get("__outdir__") or ""))
+
+
+def runnable_use_cases(examples):
+    """Use case names RunUseCase.py actually accepts, so scratch scripts are skipped."""
+    runner = os.path.join(examples, "RunUseCase.py")
+    tree = ast.parse(open(runner).read())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not ast.unparse(node.func).endswith("add_argument"):
+            continue
+        for kw in node.keywords:
+            if kw.arg == "choices" and isinstance(kw.value, (ast.List, ast.Tuple)):
+                names = [e.value for e in kw.value.elts
+                         if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+                if names:
+                    return set(names)
+    return set()
+
+
+def collect_patterns(examples):
+    """Return [(use case, dataset, pattern relative to the extraction root)]."""
+    runnable = runnable_use_cases(examples)
+    results = []
+    for path in sorted(glob.glob(os.path.join(examples, "*.py"))):
+        name = os.path.basename(path)
+        if runnable and name[:-3] not in runnable:
+            continue
+        try:
+            tree = ast.parse(open(path).read())
+        except SyntaxError:
+            continue
+        for fn in [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]:
+            if fn.name != "Run_Pipeline":
+                continue
+            found = []
+            _walk(fn.body, {}, found)
+            for dataset, pattern, outdir in found:
+                rest = pattern[len(outdir):] if outdir and pattern.startswith(outdir) else pattern
+                # The scripts concatenate path fragments, so doubled separators are
+                # common; the filesystem collapses them but fnmatch would not.
+                while "//" in rest:
+                    rest = rest.replace("//", "/")
+                results.append((name, dataset, rest.lstrip("/")))
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    parser.add_argument("--staging", default=os.path.expanduser("~/sci/datasets-web"),
+                        help="directory holding the built archives")
+    parser.add_argument("--index", default=os.path.join(
+        here, "Python", "shapeworks", "shapeworks", "datasets.json"),
+        help="pinned dataset table naming the archive for each dataset")
+    parser.add_argument("--examples", default=os.path.join(here, "Examples", "Python"),
+                        help="directory holding the use case scripts")
+    args = parser.parse_args()
+
+    patterns = collect_patterns(args.examples)
+    if not patterns:
+        print("no glob patterns recovered from the use cases", file=sys.stderr)
+        return 1
+
+    if not os.path.exists(args.index):
+        print(f"no dataset index at {args.index}; run build_dataset_archives.py first",
+              file=sys.stderr)
+        return 1
+    with open(args.index) as fh:
+        published = json.load(fh).get("datasets", {})
+
+    listings = {}
+    rows, broken = [], 0
+    for use_case, dataset, pattern in patterns:
+        if dataset not in listings:
+            entry = published.get(dataset)
+            archive = os.path.join(args.staging, entry["file"]) if entry else None
+            if not archive or not os.path.exists(archive):
+                listings[dataset] = None
+            else:
+                with zipfile.ZipFile(archive) as zf:
+                    listings[dataset] = [n for n in zf.namelist() if not n.endswith("/")]
+        names = listings[dataset]
+        if names is None:
+            rows.append((use_case, dataset, pattern, 0, "NO ARCHIVE"))
+            broken += 1
+            continue
+        hits = sum(1 for n in names if fnmatch.fnmatch(n, pattern))
+        status = "ok" if hits else "NO MATCH"
+        if not hits:
+            broken += 1
+        rows.append((use_case, dataset, pattern, hits, status))
+
+    dw = max(len(r[1]) for r in rows) + 2
+    pw = min(max(len(r[2]) for r in rows) + 2, 60)
+    print(f"{'USE CASE':34} {'DATASET':{dw}} {'PATTERN':{pw}} {'N':>4}  STATUS")
+    print("-" * (34 + dw + pw + 14))
+    for use_case, dataset, pattern, hits, status in rows:
+        print(f"{use_case:34} {dataset:{dw}} {pattern:{pw}} {hits:>4}  {status}")
+    print("-" * (34 + dw + pw + 14))
+    print(f"{len(rows)} patterns checked across {len(listings)} archives, {broken} broken")
+
+    unused = sorted(set(published) - set(listings))
+    if unused:
+        print(f"\npublished but not referenced by any use case: {', '.join(unused)}")
+    return 1 if broken else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -113,6 +113,19 @@ Deployment is taken care of automatically by GitHub Actions using the script `Su
 !!! danger "Do not edit gh-pages"
     Never manually edit files on the `gh-pages` branch because you will lose your work the next time the docs are deployed.
 
+### Versioned Documentation
+
+The site is versioned with [mike](https://github.com/jimporter/mike), which keeps one published
+version per minor release plus two aliases:
+
+- `dev` always points at the development version, i.e. whatever `CMakeLists.txt` says on `master`.
+  Every build of `master` publishes there and titles it `<version> (dev)` in the version dropdown.
+- `latest` points at the most recent *release*, and is what `https://sciinstitute.github.io/ShapeWorks/`
+  redirects to. It is moved by hand as part of the [release process](release-process.md).
+
+Because the version comes from `CMakeLists.txt`, bumping the version after a release is all that is
+needed to start publishing a new dev version; `Support/deploy_docs.sh` does not need to be edited.
+
 ## Contributing to Documentation
 
 !!! important

--- a/docs/dev/new-use-case.md
+++ b/docs/dev/new-use-case.md
@@ -21,7 +21,26 @@ To add a new use case to the codebase:
 
 To add the dataset associated with the new use case:
 
-- Upload the datset to ShapeWorks Cloud
+- Place the data in the local dataset export, laid out exactly as the use case globs for it
+- Add an entry for it to `DATASETS` in `Support/build_dataset_archives.py`
+- Run `python3 Support/build_dataset_archives.py --only <dataset-name>` to build the archive and update the pinned table
+- Run `python3 Support/verify_dataset_archives.py` to confirm the archive contains the paths the use case globs for
+- Upload the new `.zip` to the data server, and commit the regenerated `Python/shapeworks/shapeworks/datasets.json`
+
+The use case then downloads it by name via `sw.download_dataset(<dataset-name>, output_directory)`.
+
+## Changing an existing dataset
+
+Archives are versioned per dataset, not as one numbered directory, so only the dataset that changed is rebuilt and re-uploaded:
+
+- Bump that dataset's `version` in `DATASETS`
+- Rebuild it, upload the resulting `<dataset-name>-v<version>.zip`, and commit the regenerated `datasets.json`
+
+Every other dataset keeps the file it already had. Archives are immutable once published: nothing is ever overwritten in place, so the previous version stays on the server.
+
+Which archive a dataset name resolves to is decided by `datasets.json` in the source tree, not by anything on the server. That is what keeps older releases working — a release downloads exactly the data it shipped against, and publishing a new version for `master` cannot change what a release branch gets. Rolling back is a revert of that file. Users on the release you updated pick the new data up on their next run, because it compares the checksum it installed against the pinned one.
+
+Pinning the checksums in the source tree rather than fetching them alongside the data is also what makes the integrity check meaningful: a bad re-upload cannot rewrite the hash it is checked against.
 
 ## Use case documentation 
  

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -66,4 +66,14 @@ SW_MAJOR_VERSION=6.5
 
 * After the release, set the version to the next development version
 
+* Point the documentation's `latest` version at the new release
+
+The docs site publishes one version per minor release, taken from `CMakeLists.txt`.  Builds of
+`master` are always published as `<version> (dev)` under the `dev` alias, so bumping
+`CMakeLists.txt` to the next development version automatically starts a new dev version in the
+version dropdown.  The `latest` alias, which is what the site redirects to, has to be moved to the
+released version by hand: run the **Mac Arm64 Build** workflow manually with the release tag
+selected as the ref, `deploy_docs` checked, and `docs_alias` set to `latest`.  That rebuilds the
+release's docs from its tag and moves `latest` onto it.
+
 

--- a/docs/notebooks/getting-started-with-data-augmentation.ipynb
+++ b/docs/notebooks/getting-started-with-data-augmentation.ipynb
@@ -80,15 +80,36 @@
     "\n",
     "### Defining dataset location\n",
     "\n",
-    "You can download exemplar datasets from [ShapeWorks data portal](https://girder.shapeworks-cloud.org) after you login. For new users, you can [register](https://girder.shapeworks-cloud.org#?dialog=register) an account for free. Please do not use an important password.\n",
+    "The tutorial datasets are published on the ShapeWorks data server and are downloaded directly over HTTPS. No account, login, or registration is needed.\n",
     "\n",
-    "After you login, click `Collections` on the left panel and then `use-case-data-v2`. Select the dataset you would like to download by clicking on the checkbox on the left of the dataset name. See the video below.\n",
-    "After you download the dataset zip file, make sure you unzip/extract the contents in the appropriate location.\n",
+    "The cell below downloads [`femur-v0`](https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/femur-v0.zip) (4.3 GB) into `Examples/Python/Data/` and extracts it, unless it is already there. This notebook uses the groomed images and the shape model under that folder. Feel free to use your own dataset instead.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib.request\n",
+    "import zipfile\n",
     "\n",
-    "**This notebook assumes that you have downloaded `femur-v0` and you have placed the unzipped folder `femur-v0` in `Examples/Python/Data`.** Feel free to use your own dataset. \n",
+    "datasetName = 'femur-v0'\n",
+    "dataDir = '../../Data/'\n",
+    "url = 'https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/' + datasetName + '.zip'\n",
     "\n",
+    "if not os.path.isdir(dataDir + datasetName):\n",
+    "    os.makedirs(dataDir, exist_ok=True)\n",
+    "    archive = dataDir + datasetName + '.zip'\n",
+    "    print('Downloading ' + url)\n",
+    "    urllib.request.urlretrieve(url, archive)\n",
+    "    print('Extracting to ' + dataDir)\n",
+    "    with zipfile.ZipFile(archive) as zipHandle:\n",
+    "        zipHandle.extractall(dataDir)\n",
+    "    os.remove(archive)\n",
     "\n",
-    "<p><video src=\"https://sci.utah.edu/~shapeworks/doc-resources/mp4s/portal_data_download.mp4\" autoplay muted loop controls style=\"width:100%\"></p>"
+    "print('Dataset ready: ' + dataDir + datasetName)"
    ]
   },
   {

--- a/docs/notebooks/getting-started-with-exploring-segmentations.ipynb
+++ b/docs/notebooks/getting-started-with-exploring-segmentations.ipynb
@@ -42,15 +42,36 @@
     "\n",
     "### Defining dataset location\n",
     "\n",
-    "You can download exemplar datasets from [ShapeWorks data portal](https://girder.shapeworks-cloud.org) after you login. For new users, you can [register](https://girder.shapeworks-cloud.org#?dialog=register) an account for free. Please do not use an important password.\n",
+    "The tutorial datasets are published on the ShapeWorks data server and are downloaded directly over HTTPS. No account, login, or registration is needed.\n",
     "\n",
-    "After you login, click `Collections` on the left panel and then `use-case-data-v2`. Select the dataset you would like to download by clicking on the checkbox on the left of the dataset name. See the video below.\n",
-    "After you download the dataset zip file, make sure you unzip/extract the contents in the appropriate location.\n",
+    "The cell below downloads [`ellipsoid_1mode`](https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/ellipsoid_1mode.zip) (85 MB) into `Examples/Python/Data/` and extracts it, unless it is already there. This notebook uses the `segmentations` folder inside it. Feel free to use your own dataset instead.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib.request\n",
+    "import zipfile\n",
     "\n",
-    "**This notebook assumes that you have downloaded `ellipsoid_1mode` and you have placed the unzipped folder `ellipsoid_1mode` in `Examples/Python/Data`.** Feel free to use your own dataset.  \n",
+    "datasetName = 'ellipsoid_1mode'\n",
+    "dataDir = '../../Data/'\n",
+    "url = 'https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/' + datasetName + '.zip'\n",
     "\n",
+    "if not os.path.isdir(dataDir + datasetName):\n",
+    "    os.makedirs(dataDir, exist_ok=True)\n",
+    "    archive = dataDir + datasetName + '.zip'\n",
+    "    print('Downloading ' + url)\n",
+    "    urllib.request.urlretrieve(url, archive)\n",
+    "    print('Extracting to ' + dataDir)\n",
+    "    with zipfile.ZipFile(archive) as zipHandle:\n",
+    "        zipHandle.extractall(dataDir)\n",
+    "    os.remove(archive)\n",
     "\n",
-    "<p><video src=\"https://sci.utah.edu/~shapeworks/doc-resources/mp4s/portal_data_download.mp4\" autoplay muted loop controls style=\"width:100%\"></p>"
+    "print('Dataset ready: ' + dataDir + datasetName)"
    ]
   },
   {

--- a/docs/notebooks/getting-started-with-meshes.ipynb
+++ b/docs/notebooks/getting-started-with-meshes.ipynb
@@ -50,15 +50,36 @@
     "\n",
     "### Defining dataset location\n",
     "\n",
-    "You can download exemplar datasets from [ShapeWorks data portal](https://girder.shapeworks-cloud.org) after you login. For new users, you can [register](https://girder.shapeworks-cloud.org#?dialog=register) an account for free. Please do not use an important password.\n",
+    "The tutorial datasets are published on the ShapeWorks data server and are downloaded directly over HTTPS. No account, login, or registration is needed.\n",
     "\n",
-    "After you login, click `Collections` on the left panel and then `use-case-data-v2`. Select the dataset you would like to download by clicking on the checkbox on the left of the dataset name. See the video below.\n",
+    "The cell below downloads [`ellipsoid_1mode`](https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/ellipsoid_1mode.zip) (85 MB) into `Examples/Python/Data/` and extracts it, unless it is already there. This notebook uses the `meshes` folder inside it. Feel free to use your own dataset instead.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib.request\n",
+    "import zipfile\n",
     "\n",
-    "**This notebook assumes that you have downloaded `ellipsoid_1mode` and you have placed the unzipped folder`ellipsoid_1mode`in `Examples/Python/Data`.** Feel free to use your own dataset. \n",
+    "datasetName = 'ellipsoid_1mode'\n",
+    "dataDir = '../../Data/'\n",
+    "url = 'https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/' + datasetName + '.zip'\n",
     "\n",
+    "if not os.path.isdir(dataDir + datasetName):\n",
+    "    os.makedirs(dataDir, exist_ok=True)\n",
+    "    archive = dataDir + datasetName + '.zip'\n",
+    "    print('Downloading ' + url)\n",
+    "    urllib.request.urlretrieve(url, archive)\n",
+    "    print('Extracting to ' + dataDir)\n",
+    "    with zipfile.ZipFile(archive) as zipHandle:\n",
+    "        zipHandle.extractall(dataDir)\n",
+    "    os.remove(archive)\n",
     "\n",
-    "<p><video src=\"https://sci.utah.edu/~shapeworks/doc-resources/mp4s/portal_data_download.mp4\" autoplay muted loop controls style=\"width:100%\"></p>\n",
-    "\n"
+    "print('Dataset ready: ' + dataDir + datasetName)"
    ]
   },
   {

--- a/docs/notebooks/getting-started-with-segmentations.ipynb
+++ b/docs/notebooks/getting-started-with-segmentations.ipynb
@@ -43,15 +43,36 @@
     "\n",
     "### Defining dataset location\n",
     "\n",
-    "You can download exemplar datasets from [ShapeWorks data portal](https://girder.shapeworks-cloud.org) after you login. For new users, you can [register](https://girder.shapeworks-cloud.org#?dialog=register) an account for free. Please do not use an important password.\n",
+    "The tutorial datasets are published on the ShapeWorks data server and are downloaded directly over HTTPS. No account, login, or registration is needed.\n",
     "\n",
-    "After you login, click `Collections` on the left panel and then `use-case-data-v2`. Select the dataset you would like to download by clicking on the checkbox on the left of the dataset name. See the video below.\n",
-    "After you download the dataset zip file, make sure you unzip/extract the contents in the appropriate location.\n",
+    "The cell below downloads [`ellipsoid_1mode`](https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/ellipsoid_1mode.zip) (85 MB) into `Examples/Python/Data/` and extracts it, unless it is already there. This notebook uses the `segmentations` folder inside it. Feel free to use your own dataset instead.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import urllib.request\n",
+    "import zipfile\n",
     "\n",
-    "**This notebook assumes that you have downloaded `ellipsoid_1mode` and you have placed the unzipped folder `ellipsoid_1mode` in `Examples/Python/Data`.** Feel free to use your own dataset.  \n",
+    "datasetName = 'ellipsoid_1mode'\n",
+    "dataDir = '../../Data/'\n",
+    "url = 'https://www.sci.utah.edu/~shapeworks/data-sets/use-case-data-v2/' + datasetName + '.zip'\n",
     "\n",
+    "if not os.path.isdir(dataDir + datasetName):\n",
+    "    os.makedirs(dataDir, exist_ok=True)\n",
+    "    archive = dataDir + datasetName + '.zip'\n",
+    "    print('Downloading ' + url)\n",
+    "    urllib.request.urlretrieve(url, archive)\n",
+    "    print('Extracting to ' + dataDir)\n",
+    "    with zipfile.ZipFile(archive) as zipHandle:\n",
+    "        zipHandle.extractall(dataDir)\n",
+    "    os.remove(archive)\n",
     "\n",
-    "<p><video src=\"https://sci.utah.edu/~shapeworks/doc-resources/mp4s/portal_data_download.mp4\" autoplay muted loop controls style=\"width:100%\"></p>\n"
+    "print('Dataset ready: ' + dataDir + datasetName)"
    ]
   },
   {

--- a/docs/use-cases/deep-learning-based/deep-ssm-femur.md
+++ b/docs/use-cases/deep-learning-based/deep-ssm-femur.md
@@ -17,7 +17,7 @@ The use case pipeline includes creation of a training, validation, and testing s
 
 ### Step 1: Getting the original data
 
-The femur data is downloaded from the [ShapeWorks Data Portal](https://girder.shapeworks-cloud.org). The data includes the original unsegmented `.nrrd` images, corresponding `.ply` mesh files, and `.json` constraint files with cutting planes. Below is one example of an MRI (blue), mesh (white), and corrresponding cutting plane (green).
+The femur data is downloaded from the [ShapeWorks data server](https://www.sci.utah.edu/~shapeworks/data-sets/). The data includes the original unsegmented `.nrrd` images, corresponding `.ply` mesh files, and `.json` constraint files with cutting planes. Below is one example of an MRI (blue), mesh (white), and corrresponding cutting plane (green).
 ![Femur Data Example](https://sci.utah.edu/~shapeworks/doc-resources/pngs/deepssm_data.png)
 
 ### Step 2: Define the data split

--- a/docs/use-cases/use-cases.md
+++ b/docs/use-cases/use-cases.md
@@ -1,7 +1,7 @@
 # Getting Started with Use Cases
 
 ## What is a Use Case?
-Use cases are Python examples that can help users get familiar with ShapeWorks and the general shape modeling workflow. The full dataset associated with each use case (input and output) is available on [ShapeWorks Data Portal](https://girder.shapeworks-cloud.org/) and downloads automatically when the use case runs.
+Use cases are Python examples that can help users get familiar with ShapeWorks and the general shape modeling workflow. The full dataset associated with each use case (input and output) is published at [sci.utah.edu/~shapeworks/data-sets](https://www.sci.utah.edu/~shapeworks/data-sets/) and downloads automatically when the use case runs. No account or login is needed.
 
 Most use cases demomstrates the [Shape Modeling Workflow](../getting-started/workflow.md):
 
@@ -24,50 +24,33 @@ To see the names currently supported use cases and the complete list of optional
 ```
 $ swpython RunUseCase.py --help
 ```
-When a use case is run, the dataset required for the use case is automatically downloaded. This requires registering for a *free* ShapeWorks account by visiting the [ShapeWorks Data Portal](https://girder.shapeworks-cloud.org/).
+When a use case is run, the dataset it needs is downloaded automatically over HTTPS. No account, login, or credentials are required.
 
-!!! danger
-    Do not use the same password as for your bank account or email.
+Each archive is checked against a SHA-256 recorded in your ShapeWorks install before it is unpacked, so an interrupted or corrupted download fails with a clear error rather than leaving a partially populated directory for the use case to run on.
 
-After registering a free account, you can log in from within the script. 
-Note: You are only required to enter your credentials the first time you run a use case. 
-
-### Uploading a Dataset
-
-Uploading a dataset requires the following parameters:
-
-1. dataset_name - The name of the dataset and the same name must be used while running the usecase.
-
-2. licence_filename - File location which contains licence information of the dataset
-
-3. ack_filename - File location which contains acknowledge information of the dataset
-
-4. description - Description of the dataset
-
-5. project_file - File location which contains the project file of dataset using by the usecase which needs to be uploaded. (must be in swproj extension)
-
-6. overwrite - This is a boolean variable which controls any existing dataset with same name should be deleted or not. if True is passed it will delete the existing dataset. The default value is True.
-
-<!-- --overwrite - which controls any existing dataset with same name should be deleted or not. if --overwrite is specified it will delete the existing dataset. -->
-
-For example refer the following command
-```
-$ import shapeworks as sw
-$ sw.upload_dataset(dataset_name, licence_filename, acknowledgement_filename, description, project_file, overwrite)
-```
+Each release of ShapeWorks downloads the exact version of the data it was built against, so updating a dataset for a newer release does not change what your version gets. A dataset already on disk is reused without touching the network, so re-running a use case works offline.
 
 ### Downloading a Dataset
 
-Downloading a Dataset requires the following parameters:
+To fetch a dataset yourself, outside of a use case:
 
-1. datasetName - The name of the dataset which needs to be downloaded.
-
-2. outputDirectory - The location where the dataset should be downloaded.
-
-For example refer the following command
 ```
-$ python portal.py [dataset name] [output directory]
+$ import shapeworks as sw
+$ sw.download_dataset(dataset_name, output_directory)
 ```
+
+1. dataset_name - The name of the dataset to download.
+
+2. output_directory - The location the dataset should be extracted into.
+
+To see everything available:
+
+```
+$ import shapeworks as sw
+$ sw.list_datasets()
+```
+
+Set the `SW_DATA_URL` environment variable to fetch from a mirror or a local copy of the data instead of the default server.
 
 ### Use Case Data
 


### PR DESCRIPTION
The docs deploy hardcoded version `6.7` with the title `6.7 (dev)` and the `dev` alias, so every master build kept republishing into 6.7 even after 6.7 shipped and master moved on to `6.8.0-dev`. `latest` therefore pointed at a development build of an already-released version, and there was no 6.8 in the version dropdown. `Support/deploy_docs.sh` now reads the major/minor version out of `CMakeLists.txt`, so bumping the version is all that is needed to start a new dev version.

The deploy can also build from a ref other than master, so a released version's docs can be rebuilt from its tag and handed the `latest` alias: run the Mac Arm64 Build workflow manually with the tag selected, `deploy_docs` checked, and `docs_alias` set to `latest`. That step is now written down in the release process.

The published site was corrected separately on `gh-pages`: 6.7 is retitled and keeps `latest`, and 6.8 exists with the `dev` alias.