### PR TITLE
Bring the docs deploy script up to date on the release branch

### DIFF
--- a/Studio/Analysis/AnalysisTool.cpp
+++ b/Studio/Analysis/AnalysisTool.cpp
@@ -1097,7 +1097,10 @@ void AnalysisTool::update_regression_interface() {
       ui_->regression_hint_label->setText(
           "The selected column needs at least two subjects with differing numeric values.");
     }
-    ui_->regression_hint_label->show();
+    // a wrapped label's minimum is one line, too short for resize_tab_to_current()
+    auto* hint = ui_->regression_hint_label;
+    hint->setMinimumHeight(hint->heightForWidth(hint->width()));
+    hint->show();
     ui_->regression_min_label->setText("");
     ui_->regression_max_label->setText("");
     ui_->regressionLabel->setText("");

--- a/Support/deploy_docs.sh
+++ b/Support/deploy_docs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+set -e
+
 # Don't run this script if you are not a GitHub Action
 
 if [[ -z "${GITHUB_TOKEN}" ]]; then
@@ -26,13 +28,11 @@ echo "pip list:"
 pip list
 
 # check that 'shapeworks -h' is working
-shapeworks -h
-if [ $? -eq 0 ]; then
-    echo "shapeworks -h is working"
-else
+if ! shapeworks -h; then
     echo "shapeworks -h is not working"
     exit 1
 fi
+echo "shapeworks -h is working"
 
 # install doxybook2
 ${GITHUB_WORKSPACE}/Support/build_docs.sh $INSTALL_DIR
@@ -47,10 +47,11 @@ git reset --hard HEAD
 git remote rm origin
 git remote add origin "${remote_repo}"
 
-# get remote gh-pages branch
+# Make gh-pages available locally for mike, but do not check it out.  nbstripout
+# installs an *.ipynb clean filter into .git/info/attributes, which applies on
+# every branch, so checking out gh-pages leaves the notebooks it publishes dirty
+# and the working tree can never be switched back off of it.
 git fetch origin gh-pages
-git checkout --track origin/gh-pages
-git pull --rebase
 
 # build docs from the requested ref
 git checkout ${DOCS_REF}
@@ -74,20 +75,51 @@ fi
 DOCS_VERSION="${SW_MAJOR}.${SW_MINOR}"
 
 # master is the development version, so it is titled "<version> (dev)" and owns
-# the "dev" alias.  Anything else is a release rebuild and gets a plain title.
-# "latest" always points at the most recently released version; it is moved by
-# rebuilding that release's docs with DOCS_ALIAS=latest.
+# the "dev" alias.  Anything else is a release rebuild.  "latest" always points at
+# the most recently released version; it is moved by rebuilding that release's docs
+# with DOCS_ALIAS=latest, and that version is titled "<version> (latest)" so the
+# version selector says which one the site redirects to.
 if [ "${DOCS_REF}" = "master" ]; then
     DOCS_TITLE=${DOCS_TITLE:-"${DOCS_VERSION} (dev)"}
     DOCS_ALIAS=${DOCS_ALIAS:-dev}
+elif [ "${DOCS_ALIAS}" = "latest" ]; then
+    DOCS_TITLE=${DOCS_TITLE:-"${DOCS_VERSION} (latest)"}
 else
     DOCS_TITLE=${DOCS_TITLE:-"${DOCS_VERSION}"}
-    DOCS_ALIAS=${DOCS_ALIAS:-}
+fi
+
+# A master build must never publish over a version that has already shipped.  That
+# happens whenever master's version number has not been bumped past the release,
+# and it is how the 6.7 docs ended up serving 6.8 content.
+if [ "${DOCS_REF}" = "master" ] && mike list --branch gh-pages --json |
+        DOCS_VERSION="${DOCS_VERSION}" python -c '
+import json, os, sys
+released = [v for v in json.load(sys.stdin)
+            if v["version"] == os.environ["DOCS_VERSION"] and "latest" in v["aliases"]]
+sys.exit(0 if released else 1)'; then
+    echo "Refusing to publish master over ${DOCS_VERSION}, which is the released 'latest' version."
+    echo "Bump SHAPEWORKS_MAJOR_VERSION/SHAPEWORKS_MINOR_VERSION in CMakeLists.txt on master."
+    exit 1
 fi
 
 # use mike to mkdocs w/ version
 mike deploy --config-file ./mkdocs.yml --title "${DOCS_TITLE}" --branch gh-pages --update-aliases "${DOCS_VERSION}" ${DOCS_ALIAS}
 mike set-default latest --branch gh-pages
+
+# mike only titles the version it deploys, so the version that just lost the
+# "latest" alias would keep the "(latest)" suffix forever.  Strip it.
+if [ "${DOCS_ALIAS}" = "latest" ]; then
+    mike list --branch gh-pages --json |
+        DOCS_VERSION="${DOCS_VERSION}" python -c '
+import json, os, sys
+suffix = " (latest)"
+for v in json.load(sys.stdin):
+    if v["version"] != os.environ["DOCS_VERSION"] and v["title"].endswith(suffix):
+        print("%s\t%s" % (v["version"], v["title"][:-len(suffix)]))' |
+        while IFS=$'\t' read -r stale_version stale_title; do
+            mike retitle --branch gh-pages "${stale_version}" "${stale_title}"
+        done
+fi
 
 # update docs on github
 git push origin gh-pages

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -11,7 +11,6 @@
     * ShapeWorks now ships with a complete Python 3.12 environment built in — no conda setup required. Studio, the `shapeworks` CLI, and Python use cases all work directly out of the installer on macOS, Windows, and Linux.
     * New `swpython` and `swpip` wrappers run scripts against the bundled Python and install additional packages into a persistent per-user site-packages directory. Windows installs add a **ShapeWorks Prompt** Start Menu shortcut that puts these on `PATH`.
     * PyTorch installs on demand the first time DeepSSM runs (~3 GB, one-time) via `light-the-torch`, into a per-user directory that survives reinstalls.
-    * Source/developer builds are unchanged: `install_shapeworks.sh` / `.bat` still set up the conda environment used to build from source. (#2289, #2313)
 
   * **ShapeWorks Back-end**
     * Registration-based particle initialization as an alternative to particle splitting: particles are spread over a single reference shape and carried onto every other shape by deformable registration (rigid → affine → SyN over distance transforms), so each shape starts optimization already holding a full set of corresponding particles (#2374)
@@ -35,9 +34,6 @@
     * File → Export → Export All Meshes writes the reconstructed mesh for every subject in the project (#2281)
     * The glyph-size slider and auto-sizing now scale to the shape's largest dimension instead of a fixed world-unit range, so very small or very large shapes get usable glyph sizes (#2459)
     * Cutting-plane table edits to center and normal now take effect (#2567)
-
-  * **Documentation**
-    * New [optimization scaling study](../workflow/optimize-scaling.md) documenting runtime against particle count and cohort size, with a reproducible test harness (#2572)
 
 ### Fixes
   * Fix DeepSSM jobs reporting success after failing: a job that died during training logged "Training complete", chained into testing, and exited zero. Failures now stop the run and exit non-zero, and the CLI no longer hangs waiting on a failed job (#2621)


### PR DESCRIPTION
The 6.8 docs published on the site are the hand-made snapshot from `d177336f33`, taken before the release notes were expanded — they still show only the Bundled Python section and no release image. Publishing the real ones has to happen from this branch so the API reference and `ShapeWorksCommands.md` come from 6.8 binaries.

Takes master's `deploy_docs.sh`: it no longer checks out `gh-pages` (which nbstripout leaves permanently dirty), and it titles the version holding the `latest` alias `<version> (latest)`. Once merged, run **Mac Arm64 Build** on this branch with `deploy_docs` checked and `docs_alias` blank.