### PR TITLE
Allow the 6.7 docs to be rebuilt from this branch

### DIFF
--- a/.github/workflows/build-mac-arm64.yml
+++ b/.github/workflows/build-mac-arm64.yml
@@ -8,6 +8,18 @@ on:
     tags:
     - '*'
   pull_request:
+  workflow_dispatch:
+    inputs:
+      deploy_docs:
+        description: 'Deploy the docs for the selected ref (use with a release tag to rebuild a released version)'
+        type: boolean
+        required: false
+        default: false
+      docs_alias:
+        description: 'mike alias to move to this version (e.g. latest).  Leave blank for the default.'
+        type: string
+        required: false
+        default: ''
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -127,10 +139,12 @@ jobs:
              ${{runner.workspace}}/ShapeWorks/artifacts/*.pkg
 
     - name: Deploy Docs
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' || inputs.deploy_docs
       shell: bash -l {0}
       run: conda activate shapeworks && source ./devenv.sh ./build/bin && ./Support/deploy_docs.sh ${GITHUB_WORKSPACE}/build
       env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCS_REF: ${{ github.ref_name }}
+          DOCS_ALIAS: ${{ inputs.docs_alias }}
       

--- a/Support/deploy_docs.sh
+++ b/Support/deploy_docs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -x
 
+set -e
+
 # Don't run this script if you are not a GitHub Action
 
 if [[ -z "${GITHUB_TOKEN}" ]]; then
@@ -13,6 +15,11 @@ if [ "$#" -ne 1 ]; then
 fi
 INSTALL_DIR=$1
 
+# Git ref the docs are built from.  Normally "master", which is always the
+# development version.  Run the workflow manually against a release tag (e.g.
+# v6.7.0) to rebuild the docs for a version that has already shipped.
+DOCS_REF=${DOCS_REF:-master}
+
 # Update auto-documentation
 PATH=$INSTALL_DIR/bin:$PATH
 
@@ -21,13 +28,11 @@ echo "pip list:"
 pip list
 
 # check that 'shapeworks -h' is working
-shapeworks -h
-if [ $? -eq 0 ]; then
-    echo "shapeworks -h is working"
-else
+if ! shapeworks -h; then
     echo "shapeworks -h is not working"
     exit 1
 fi
+echo "shapeworks -h is working"
 
 # install doxybook2
 ${GITHUB_WORKSPACE}/Support/build_docs.sh $INSTALL_DIR
@@ -42,12 +47,14 @@ git reset --hard HEAD
 git remote rm origin
 git remote add origin "${remote_repo}"
 
-# get remote gh-pages branch
-git checkout --track origin/gh-pages
-git pull --rebase
+# Make gh-pages available locally for mike, but do not check it out.  nbstripout
+# installs an *.ipynb clean filter into .git/info/attributes, which applies on
+# every branch, so checking out gh-pages leaves the notebooks it publishes dirty
+# and the working tree can never be switched back off of it.
+git fetch origin gh-pages
 
-# build docs from master
-git checkout master
+# build docs from the requested ref
+git checkout ${DOCS_REF}
 
 # clean out old api docs as mkdocs will just find whatever is there.
 rm -rf docs/api
@@ -57,9 +64,62 @@ mkdir docs/api
 python Python/RunShapeWorksAutoDoc.py --md_filename docs/tools/ShapeWorksCommands.md
 doxybook2 -i ${INSTALL_DIR}/Documentation/Doxygen/xml -o docs/api -c docs/doxygen/doxybook2.config.json
 
+# Derive the docs version (e.g. "6.8") from the source tree so this script does
+# not have to be edited every release.
+SW_MAJOR=$(sed -n 's/^SET(SHAPEWORKS_MAJOR_VERSION \([0-9][0-9]*\).*/\1/p' CMakeLists.txt)
+SW_MINOR=$(sed -n 's/^SET(SHAPEWORKS_MINOR_VERSION \([0-9][0-9]*\).*/\1/p' CMakeLists.txt)
+if [[ -z "${SW_MAJOR}" || -z "${SW_MINOR}" ]]; then
+    echo "Could not determine the ShapeWorks version from CMakeLists.txt"
+    exit 1
+fi
+DOCS_VERSION="${SW_MAJOR}.${SW_MINOR}"
+
+# master is the development version, so it is titled "<version> (dev)" and owns
+# the "dev" alias.  Anything else is a release rebuild.  "latest" always points at
+# the most recently released version; it is moved by rebuilding that release's docs
+# with DOCS_ALIAS=latest, and that version is titled "<version> (latest)" so the
+# version selector says which one the site redirects to.
+if [ "${DOCS_REF}" = "master" ]; then
+    DOCS_TITLE=${DOCS_TITLE:-"${DOCS_VERSION} (dev)"}
+    DOCS_ALIAS=${DOCS_ALIAS:-dev}
+elif [ "${DOCS_ALIAS}" = "latest" ]; then
+    DOCS_TITLE=${DOCS_TITLE:-"${DOCS_VERSION} (latest)"}
+else
+    DOCS_TITLE=${DOCS_TITLE:-"${DOCS_VERSION}"}
+fi
+
+# A master build must never publish over a version that has already shipped.  That
+# happens whenever master's version number has not been bumped past the release,
+# and it is how the 6.7 docs ended up serving 6.8 content.
+if [ "${DOCS_REF}" = "master" ] && mike list --branch gh-pages --json |
+        DOCS_VERSION="${DOCS_VERSION}" python -c '
+import json, os, sys
+released = [v for v in json.load(sys.stdin)
+            if v["version"] == os.environ["DOCS_VERSION"] and "latest" in v["aliases"]]
+sys.exit(0 if released else 1)'; then
+    echo "Refusing to publish master over ${DOCS_VERSION}, which is the released 'latest' version."
+    echo "Bump SHAPEWORKS_MAJOR_VERSION/SHAPEWORKS_MINOR_VERSION in CMakeLists.txt on master."
+    exit 1
+fi
+
 # use mike to mkdocs w/ version
-mike deploy --config-file ./mkdocs.yml --title "6.7 (dev)" 6.7 dev --branch gh-pages --update-aliases
-mike set-default latest
+mike deploy --config-file ./mkdocs.yml --title "${DOCS_TITLE}" --branch gh-pages --update-aliases "${DOCS_VERSION}" ${DOCS_ALIAS}
+mike set-default latest --branch gh-pages
+
+# mike only titles the version it deploys, so the version that just lost the
+# "latest" alias would keep the "(latest)" suffix forever.  Strip it.
+if [ "${DOCS_ALIAS}" = "latest" ]; then
+    mike list --branch gh-pages --json |
+        DOCS_VERSION="${DOCS_VERSION}" python -c '
+import json, os, sys
+suffix = " (latest)"
+for v in json.load(sys.stdin):
+    if v["version"] != os.environ["DOCS_VERSION"] and v["title"].endswith(suffix):
+        print("%s\t%s" % (v["version"], v["title"][:-len(suffix)]))' |
+        while IFS=$'\t' read -r stale_version stale_title; do
+            mike retitle --branch gh-pages "${stale_version}" "${stale_title}"
+        done
+fi
 
 # update docs on github
 git push origin gh-pages


### PR DESCRIPTION
The 6.7 docs on the site are a build of `master` taken after the 6.8 release notes and bundled-Python install instructions had been merged there, so 6.7 serves 6.8 content — 26 files differ from the `v6.7.0` tag, including `users/install.md` and the platform READMEs. Rebuilding them has to happen from this branch, since the API reference and `ShapeWorksCommands.md` are generated by running the binaries the workflow builds.

The `v6.7.0` tag cannot be used for this: it has no `workflow_dispatch` trigger, and its `deploy_docs.sh` hardcodes `git checkout master`, so dispatching there would republish master into 6.7 again. This adds the dispatch inputs the deploy step needs and takes master's `deploy_docs.sh`, which builds from the dispatched ref. Once merged, run **Mac Arm64 Build** on this branch with `deploy_docs` checked and `docs_alias` set to `latest`.